### PR TITLE
[breaking] make snowflake_role_grants exclusive, remove `name`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DIRTY=$(shell if `git diff-index --quiet HEAD --`; then echo false; else echo tr
 # TODO add release flag
 LDFLAGS=-ldflags "-w -s -X github.com/chanzuckerberg/terraform-provider-snowflake/util.GitSha=${SHA} -X github.com/chanzuckerberg/terraform-provider-snowflake/util.Version=${VERSION} -X github.com/chanzuckerberg/terraform-provider-snowflake/util.Dirty=${DIRTY}"
 
-all: test install
+all: test docs install
 .PHONY: all
 
 setup: ## setup development dependencies

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ You can see a number of examples [here](examples).
 
 |   NAME    |  TYPE  |              DESCRIPTION              | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
 |-----------|--------|---------------------------------------|----------|-----------|----------|---------|
-| name      | string |                                       | false    | true      | false    | <nil>   |
 | role_name | string | The name of the role we are granting. | false    | true      | false    | <nil>   |
 | roles     | set    | Grants role to this specified role.   | true     | false     | false    | <nil>   |
 | users     | set    | Grants role to this specified user.   | true     | false     | false    | <nil>   |

--- a/pkg/resources/helpers_test.go
+++ b/pkg/resources/helpers_test.go
@@ -46,6 +46,7 @@ func roleGrants(t *testing.T, id string, params map[string]interface{}) *schema.
 	a := assert.New(t)
 	d := schema.TestResourceDataRaw(t, resources.RoleGrants().Schema, params)
 	a.NotNil(d)
+	d.SetId(id)
 	return d
 }
 func providers() map[string]terraform.ResourceProvider {

--- a/pkg/resources/role_grants.go
+++ b/pkg/resources/role_grants.go
@@ -18,10 +18,6 @@ func RoleGrants() *schema.Resource {
 		Update: UpdateRoleGrants,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
 			"role_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -44,16 +40,15 @@ func RoleGrants() *schema.Resource {
 				Description: "Grants role to this specified user.",
 			},
 		},
-		// TODO
-		// Importer: &schema.ResourceImporter{
-		// 	State: schema.ImportStatePassthrough,
-		// },
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 
 func CreateRoleGrants(data *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
-	name := data.Get("name").(string)
 	roleName := data.Get("role_name").(string)
 	roles := expandStringList(data.Get("roles").(*schema.Set).List())
 	users := expandStringList(data.Get("users").(*schema.Set).List())
@@ -75,7 +70,7 @@ func CreateRoleGrants(data *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
-	data.SetId(name)
+	data.SetId(roleName)
 	return ReadRoleGrants(data, meta)
 }
 
@@ -103,7 +98,7 @@ type grant struct {
 
 func ReadRoleGrants(data *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
-	roleName := data.Get("role_name").(string)
+	roleName := data.Id()
 
 	roles := make([]string, 0)
 	users := make([]string, 0)
@@ -124,6 +119,7 @@ func ReadRoleGrants(data *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	data.Set("role_name", roleName)
 	data.Set("roles", roles)
 	data.Set("users", users)
 

--- a/pkg/resources/role_grants_acceptance_test.go
+++ b/pkg/resources/role_grants_acceptance_test.go
@@ -98,7 +98,7 @@ func TestAccGrantRole(t *testing.T) {
 	basicChecks := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("snowflake_role.r", "name", role1),
 		resource.TestCheckResourceAttr("snowflake_role.r2", "name", role2),
-		resource.TestCheckResourceAttr("snowflake_role_grants.w", "name", role1),
+		resource.TestCheckResourceAttr("snowflake_role_grants.w", "role_name", role1),
 	)
 
 	baselineStep := resource.TestStep{
@@ -149,12 +149,12 @@ func TestAccGrantRole(t *testing.T) {
 					},
 				),
 			},
-			// 			// IMPORT
-			// 			{
-			// 				ResourceName:            "snowflake_role_grants.w",
-			// 				ImportState:             true,
-			// 				ImportStateVerify:       true,
-			// 			},
+			// IMPORT
+			{
+				ResourceName:      "snowflake_role_grants.w",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -185,7 +185,6 @@ func rgConfig(role1, role2, role3, user1, user2 string) string {
 %s
 
 resource "snowflake_role_grants" "w" {
-	name = "${snowflake_role.r.name}"
 	role_name = "${snowflake_role.r.name}"
 	roles = ["${snowflake_role.r2.name}", "${snowflake_role.r3.name}"]
 	users = ["${snowflake_user.u.name}", "${snowflake_user.u2.name}"]
@@ -200,7 +199,6 @@ func rgConfig2(role1, role2, role3, user1, user2 string) string {
 %s
 
 resource "snowflake_role_grants" "w" {
-	name = "${snowflake_role.r.name}"
 	role_name = "${snowflake_role.r.name}"
 	roles = ["${snowflake_role.r2.name}"]
 	users = ["${snowflake_user.u.name}", "${snowflake_user.u2.name}"]
@@ -215,7 +213,6 @@ func rgConfig3(role1, role2, role3, user1, user2 string) string {
 %s
 
 resource "snowflake_role_grants" "w" {
-	name = "${snowflake_role.r.name}"
 	role_name = "${snowflake_role.r.name}"
 	roles = ["${snowflake_role.r2.name}", "${snowflake_role.r3.name}"]
 	users = ["${snowflake_user.u.name}"]
@@ -229,7 +226,6 @@ func rgConfig4(role1, role2, role3, user1, user2 string) string {
 
 %s
 	resource "snowflake_role_grants" "w" {
-	name = "${snowflake_role.r.name}"
 	role_name = "${snowflake_role.r.name}"
 	roles = ["${snowflake_role.r3.name}", "${snowflake_role.r2.name}"]
 	users = ["${snowflake_user.u2.name}", "${snowflake_user.u.name}"]

--- a/pkg/resources/role_grants_test.go
+++ b/pkg/resources/role_grants_test.go
@@ -20,7 +20,6 @@ func TestRoleGrantsCreate(t *testing.T) {
 	a := assert.New(t)
 
 	d := roleGrants(t, "good_name", map[string]interface{}{
-		"name":      "fake name",
 		"role_name": "good_name",
 		"roles":     []string{"role1", "role2"},
 		"users":     []string{"user1", "user2"},
@@ -56,7 +55,6 @@ func TestRoleGrantsRead(t *testing.T) {
 	a := assert.New(t)
 
 	d := roleGrants(t, "good_name", map[string]interface{}{
-		"name":      "fake name",
 		"role_name": "good_name",
 		"roles":     []string{"role1", "role2"},
 		"users":     []string{"user1", "user2"},
@@ -75,7 +73,6 @@ func TestRoleGrantsDelete(t *testing.T) {
 	a := assert.New(t)
 
 	d := roleGrants(t, "drop_it", map[string]interface{}{
-		"name":      "drop_it",
 		"role_name": "drop_it",
 		"roles":     []string{"role1", "role2"},
 		"users":     []string{"user1", "user2"},


### PR DESCRIPTION
This enables import of this resource (tested here and manually).

Side effect is that this resource assumes it exclusively manages all role grants for this role.