### PR TITLE
add Exists function to user object

### DIFF
--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -108,8 +108,9 @@ func User() *schema.Resource {
 	return &schema.Resource{
 		Create: CreateUser,
 		Read:   ReadUser,
-		Delete: DeleteUser,
 		Update: UpdateUser,
+		Delete: DeleteUser,
+		Exists: UserExists,
 
 		Schema: userSchema,
 		Importer: &schema.ResourceImporter{
@@ -122,6 +123,22 @@ func User() *schema.Resource {
 
 func CreateUser(data *schema.ResourceData, meta interface{}) error {
 	return CreateResource("user", userProperties, userSchema, snowflake.User, ReadUser)(data, meta)
+}
+
+func UserExists(data *schema.ResourceData, meta interface{}) (bool, error) {
+	db := meta.(*sql.DB)
+	id := data.Id()
+
+	stmt := snowflake.User(id).Show()
+	rows, err := db.Query(stmt)
+	if err != nil {
+		return false, err
+	}
+
+	if rows.Next() {
+		return true, nil
+	}
+	return false, nil
 }
 
 func ReadUser(data *schema.ResourceData, meta interface{}) error {

--- a/pkg/resources/user_test.go
+++ b/pkg/resources/user_test.go
@@ -73,6 +73,20 @@ func TestUserRead(t *testing.T) {
 	})
 }
 
+func TestUserExists(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	d := user(t, "good_name", map[string]interface{}{"name": "good_name"})
+
+	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		expectReadUser(mock)
+		b, err := resources.UserExists(d, db)
+		a.NoError(err)
+		a.True(b)
+	})
+}
+
 func TestUserDelete(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)


### PR DESCRIPTION
Without this it will just try to read a user and in the case where a user has been deleted, but is in the state file we will get an error. There may be a graceful way to handle that in the Read function, but this seems like a cleaner way to do it.