### PR TITLE
set go_import_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 go:
   - '1.12'
+
+go_import_path: github.com/chanzuckerberg/terraform-provider-snowflake
+
 install:
   - npm install -g snyk
   - make setup


### PR DESCRIPTION
This should enable forks to build successfully on travis-ci.

See https://github.com/chanzuckerberg/terraform-provider-snowflake/pull/39