### PR TITLE
schema_grant to support more than just USAGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,18 @@ install:
 script:
   - make
 
-jobs:
+matrix:
   include:
-    - stage: check
+    - name: unit/acceptance tests
       script:
         - make test-acceptance
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     # Disable snyk until https://github.com/snyk/snyk/issues/354 is resolved
-    # - stage: check
+    # - name: snyk
     #   script:
     #     - snyk monitor --org=czi
     #     - snyk test
-    - stage: check
+    - name: docs check
       script:
         - make check-docs

--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,6 @@ require (
 	github.com/snowflakedb/gosnowflake v1.2.0
 	github.com/stretchr/testify v1.4.0
 )
+
+// TODO: when https://github.com/hashicorp/terraform/issues/22664 gets resolved, remove this line:
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBr
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+git.apache.org/thrift.git v0.12.0 h1:CMxsZlAmxKs+VAZMlDDL0wXciMblJcutQbEe3A9CYUM=
 github.com/Azure/azure-sdk-for-go v21.3.0+incompatible h1:YFvAka2WKAl2xnJkYV1e1b7E2z88AgFszDzWU18ejMY=
 github.com/Azure/azure-sdk-for-go v21.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.15.4+incompatible h1:q+DRrRdbCnkY7f2WxQBx58TwCGkEdMAK/hkZ10g0Pzk=
@@ -45,6 +46,7 @@ github.com/aliyun/aliyun-tablestore-go-sdk v4.1.2+incompatible/go.mod h1:LDQHRZy
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antchfx/xpath v0.0.0-20190129040759-c8489ed3251e/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0/go.mod h1:LzD22aAzDP8/dyiCKFp31He4m2GPjl0AFyzDtZzUu9M=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apparentlymart/go-cidr v1.0.0 h1:lGDvXx8Lv9QHjrAVP7jyzleG4F9+FkRhJcEsDFxeb8w=
 github.com/apparentlymart/go-cidr v1.0.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
@@ -270,6 +272,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/resources/schema_grant.go
+++ b/pkg/resources/schema_grant.go
@@ -9,7 +9,23 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
 )
 
-var validSchemaPrivileges = []string{"USAGE"}
+// Intentionally exclude the "ALL" alias because it is not a real privilege and
+// might not interact well with this provider.
+var validSchemaPrivileges = []string{
+	"MODIFY",
+	"MONITOR",
+	"USAGE",
+	"CREATE TABLE",
+	"CREATE VIEW",
+	"CREATE FILE FORMAT",
+	"CREATE STAGE",
+	"CREATE PIPE",
+	"CREATE STREAM",
+	"CREATE TASK",
+	"CREATE SEQUENCE",
+	"CREATE FUNCTION",
+	"CREATE PROCEDURE",
+}
 
 var schemaGrantSchema = map[string]*schema.Schema{
 	"schema_name": &schema.Schema{
@@ -29,7 +45,7 @@ var schemaGrantSchema = map[string]*schema.Schema{
 		Optional:     true,
 		Description:  "The privilege to grant on the schema.",
 		Default:      "USAGE",
-		ValidateFunc: validation.StringInSlice(validViewPrivileges, true),
+		ValidateFunc: validation.StringInSlice(validSchemaPrivileges, true),
 		ForceNew:     true,
 	},
 	"roles": &schema.Schema{

--- a/pkg/resources/schema_grant_test.go
+++ b/pkg/resources/schema_grant_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -25,30 +26,48 @@ func TestSchemaGrant(t *testing.T) {
 func TestSchemaGrantCreate(t *testing.T) {
 	a := assert.New(t)
 
-	in := map[string]interface{}{
-		"schema_name":   "test-schema",
-		"database_name": "test-db",
-		"privilege":     "USAGE",
-		"roles":         []interface{}{"test-role-1", "test-role-2"},
-		"shares":        []interface{}{"test-share-1", "test-share-2"},
-	}
-	d := schema.TestResourceDataRaw(t, resources.SchemaGrant().Schema, in)
-	a.NotNil(d)
+	for _, test_priv := range []string{"USAGE", "MODIFY"} {
+		in := map[string]interface{}{
+			"schema_name":   "test-schema",
+			"database_name": "test-db",
+			"privilege":     test_priv,
+			"roles":         []interface{}{"test-role-1", "test-role-2"},
+			"shares":        []interface{}{"test-share-1", "test-share-2"},
+		}
+		d := schema.TestResourceDataRaw(t, resources.SchemaGrant().Schema, in)
+		a.NotNil(d)
 
-	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`^GRANT USAGE ON SCHEMA "test-db"."test-schema" TO ROLE "test-role-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`^GRANT USAGE ON SCHEMA "test-db"."test-schema" TO ROLE "test-role-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`^GRANT USAGE ON SCHEMA "test-db"."test-schema" TO SHARE "test-share-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`^GRANT USAGE ON SCHEMA "test-db"."test-schema" TO SHARE "test-share-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
-		expectReadSchemaGrant(mock)
-		err := resources.CreateSchemaGrant(d, db)
-		a.NoError(err)
-	})
+		WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+			mock.ExpectExec(
+				fmt.Sprintf(`^GRANT %s ON SCHEMA "test-db"."test-schema" TO ROLE "test-role-1"$`, test_priv),
+			).WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectExec(
+				fmt.Sprintf(`^GRANT %s ON SCHEMA "test-db"."test-schema" TO ROLE "test-role-2"$`, test_priv),
+			).WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectExec(
+				fmt.Sprintf(`^GRANT %s ON SCHEMA "test-db"."test-schema" TO SHARE "test-share-1"$`, test_priv),
+			).WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectExec(
+				fmt.Sprintf(`^GRANT %s ON SCHEMA "test-db"."test-schema" TO SHARE "test-share-2"$`, test_priv),
+			).WillReturnResult(sqlmock.NewResult(1, 1))
+			expectReadSchemaGrant(mock, test_priv)
+			err := resources.CreateSchemaGrant(d, db)
+			a.NoError(err)
+		})
+	}
 }
 
-func expectReadSchemaGrant(mock sqlmock.Sqlmock) {
+func expectReadSchemaGrant(mock sqlmock.Sqlmock, test_priv string) {
 	rows := sqlmock.NewRows([]string{
 		"created_on", "privilege", "granted_on", "name", "granted_to", "grantee_name", "grant_option", "granted_by",
-	}).AddRow(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), "USAGE", "SCHEMA", "test-schema", "ROLE", "test-role-1", false, "bob").AddRow(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), "SELECT", "VIEW", "test-view", "ROLE", "test-role-2", false, "bob").AddRow(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), "SELECT", "VIEW", "test-view", "SHARE", "test-share-1", false, "bob").AddRow(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), "SELECT", "VIEW", "test-view", "SHARE", "test-share-2", false, "bob")
+	}).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), test_priv, "SCHEMA", "test-schema", "ROLE", "test-role-1", false, "bob",
+	).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), test_priv, "SCHEMA", "test-schema", "ROLE", "test-role-2", false, "bob",
+	).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), test_priv, "SCHEMA", "test-schema", "SHARE", "test-share-1", false, "bob",
+	).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), test_priv, "SCHEMA", "test-schema", "SHARE", "test-share-2", false, "bob",
+	)
 	mock.ExpectQuery(`^SHOW GRANTS ON SCHEMA "test-db"."test-schema"$`).WillReturnRows(rows)
 }


### PR DESCRIPTION
Define correct list of valid schema grant privileges and actually use it.  Also update unit tests to ensure something other than USAGE works correctly.

Addresses #68.