### PR TITLE
db.go: use log.Println instead of fmt.Println

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"regexp"
 
 	"github.com/ExpansiveWorlds/instrumentedsql"
@@ -15,7 +16,7 @@ func init() {
 
 	logger := instrumentedsql.LoggerFunc(func(ctx context.Context, msg string, keyvals ...interface{}) {
 		s := fmt.Sprintf("[DEBUG] %s %v\n", msg, keyvals)
-		fmt.Println(re.ReplaceAllString(s, " "))
+		log.Println(re.ReplaceAllString(s, " "))
 	})
 
 	sql.Register("snowflake-instrumented", instrumentedsql.WrapDriver(&gosnowflake.SnowflakeDriver{}, instrumentedsql.WithLogger(logger)))


### PR DESCRIPTION
This causes logging from the gosnowflake driver to actually successfully
bubble up to the master terraform process console log.

As a major side benefit, this was the fix for large terraform plans
hanging forever after refreshing a couple dozen schema_grant resources.
For more information see #69.

Fixes #69.