### PR TITLE
Fix a small connection leak

### DIFF
--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -264,11 +264,13 @@ func SchemaExists(data *schema.ResourceData, meta interface{}) (bool, error) {
 		return false, err
 	}
 
+	exists := false
 	if rows.Next() {
-		return true, nil
+		exists = true
 	}
 
-	return false, nil
+	rows.Close()
+	return exists, nil
 }
 
 // splitSchemaID takes the <database_name>|<schema_name> ID and returns the


### PR DESCRIPTION
This fixes a connection leak which causes open connections to accumulate
for each schema that gets refreshed.  This probably doesn't manifest as
a user-facing bug, but it certainly can't hurt to merge a fix.

For an explanation on how I discovered and tested this, see the
following github issue comment:

https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/69#issuecomment-528959865