### PR TITLE
[fix] resource_monitor credit quota as float64, not int

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ provider "snowflake" {
 ```
 
 ### Keypair Authentication Environment Variables
-You should generate the public and private keys and set up environment variables. 
+You should generate the public and private keys and set up environment variables.
 
 ```shell
 cd ~/.ssh
@@ -119,7 +119,7 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 |            NAME            |  TYPE  |                                                                   DESCRIPTION                                                                   | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
 |----------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|---------|
-| credit_quota               | int    | The number of credits allocated monthly to the resource monitor.                                                                                | true     | false     | true     | <nil>   |
+| credit_quota               | float  | The amount of credits allocated monthly to the resource monitor.                                                                                | true     | false     | true     | <nil>   |
 | end_timestamp              | string | The date and time when the resource monitor suspends the assigned warehouses.                                                                   | true     | false     | false    | <nil>   |
 | frequency                  | string | The frequency interval at which the credit usage resets to 0. If you set a frequency for a resource monitor, you must also set START_TIMESTAMP. | true     | false     | true     | <nil>   |
 | name                       | string | Identifier for the resource monitor; must be unique for your account.                                                                           | false    | true      | false    | <nil>   |

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 |            NAME            |  TYPE  |                                                                   DESCRIPTION                                                                   | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
 |----------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|---------|
-| credit_quota               | float  | The amount of credits allocated monthly to the resource monitor.                                                                                | true     | false     | true     | <nil>   |
+| credit_quota               | float  | The amount of credits allocated monthly to the resource monitor. Round up to 2 decimal places.                                                  | true     | false     | true     | <nil>   |
 | end_timestamp              | string | The date and time when the resource monitor suspends the assigned warehouses.                                                                   | true     | false     | false    | <nil>   |
 | frequency                  | string | The frequency interval at which the credit usage resets to 0. If you set a frequency for a resource monitor, you must also set START_TIMESTAMP. | true     | false     | true     | <nil>   |
 | name                       | string | Identifier for the resource monitor; must be unique for your account.                                                                           | false    | true      | false    | <nil>   |

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 |            NAME            |  TYPE  |                                                                   DESCRIPTION                                                                   | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
 |----------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|---------|
-| credit_quota               | float  | The amount of credits allocated monthly to the resource monitor. Round up to 2 decimal places.                                                  | true     | false     | true     | <nil>   |
+| credit_quota               | float  | The amount of credits allocated monthly to the resource monitor, round up to 2 decimal places.                                                  | true     | false     | true     | <nil>   |
 | end_timestamp              | string | The date and time when the resource monitor suspends the assigned warehouses.                                                                   | true     | false     | false    | <nil>   |
 | frequency                  | string | The frequency interval at which the credit usage resets to 0. If you set a frequency for a resource monitor, you must also set START_TIMESTAMP. | true     | false     | true     | <nil>   |
 | name                       | string | Identifier for the resource monitor; must be unique for your account.                                                                           | false    | true      | false    | <nil>   |

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -181,7 +181,7 @@ func ReadResourceMonitor(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// Credit quota is the only integer
+	// Credit quota is a float
 	if rm.CreditQuota.Valid {
 		err = data.Set("credit_quota", rm.CreditQuota.Float64)
 	} else {

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -44,7 +44,7 @@ var resourceMonitorSchema = map[string]*schema.Schema{
 		Type:        schema.TypeFloat,
 		Optional:    true,
 		Computed:    true,
-		Description: "The amount of credits allocated monthly to the resource monitor.",
+		Description: "The amount of credits allocated monthly to the resource monitor, round up to 2 decimal places.",
 		ForceNew:    true,
 	},
 	"frequency": &schema.Schema{

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -15,20 +15,20 @@ import (
 )
 
 type resourceMonitor struct {
-	Name                 sql.NullString `db:"name"`
-	CreditQuota          sql.NullInt64  `db:"credit_quota"`
-	UsedCredits          sql.NullString `db:"used_credits"`
-	RemainingCredits     sql.NullString `db:"remaining_credits"`
-	Level                sql.NullString `db:"level"`
-	Frequency            sql.NullString `db:"frequency"`
-	StartTime            sql.NullString `db:"start_time"`
-	EndTime              sql.NullString `db:"end_time"`
-	NotifyAt             sql.NullString `db:"notify_at"`
-	SuspendAt            sql.NullString `db:"suspend_at"`
-	SuspendImmediatelyAt sql.NullString `db:"suspend_immediately_at"`
-	CreatedOn            sql.NullString `db:"created_on"`
-	Owner                sql.NullString `db:"owner"`
-	Comment              sql.NullString `db:"comment"`
+	Name                 sql.NullString  `db:"name"`
+	CreditQuota          sql.NullFloat64 `db:"credit_quota"`
+	UsedCredits          sql.NullString  `db:"used_credits"`
+	RemainingCredits     sql.NullString  `db:"remaining_credits"`
+	Level                sql.NullString  `db:"level"`
+	Frequency            sql.NullString  `db:"frequency"`
+	StartTime            sql.NullString  `db:"start_time"`
+	EndTime              sql.NullString  `db:"end_time"`
+	NotifyAt             sql.NullString  `db:"notify_at"`
+	SuspendAt            sql.NullString  `db:"suspend_at"`
+	SuspendImmediatelyAt sql.NullString  `db:"suspend_immediately_at"`
+	CreatedOn            sql.NullString  `db:"created_on"`
+	Owner                sql.NullString  `db:"owner"`
+	Comment              sql.NullString  `db:"comment"`
 }
 
 var validFrequencies = []string{"MONTHLY", "DAILY", "WEEKLY", "YEARLY", "NEVER"}
@@ -41,10 +41,10 @@ var resourceMonitorSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	},
 	"credit_quota": &schema.Schema{
-		Type:        schema.TypeInt,
+		Type:        schema.TypeFloat,
 		Optional:    true,
 		Computed:    true,
-		Description: "The number of credits allocated monthly to the resource monitor.",
+		Description: "The amount of credits allocated monthly to the resource monitor.",
 		ForceNew:    true,
 	},
 	"frequency": &schema.Schema{
@@ -115,7 +115,7 @@ func CreateResourceMonitor(data *schema.ResourceData, meta interface{}) error {
 	cb := snowflake.ResourceMonitor(name).Create()
 	// Set optionals
 	if v, ok := data.GetOk("credit_quota"); ok {
-		cb.SetInt("credit_quota", v.(int))
+		cb.SetFloat("credit_quota", v.(float64))
 	}
 	if v, ok := data.GetOk("frequency"); ok {
 		cb.SetString("frequency", v.(string))
@@ -183,9 +183,9 @@ func ReadResourceMonitor(data *schema.ResourceData, meta interface{}) error {
 
 	// Credit quota is the only integer
 	if rm.CreditQuota.Valid {
-		err = data.Set("credit_quota", rm.CreditQuota.Int64)
+		err = data.Set("credit_quota", rm.CreditQuota.Float64)
 	} else {
-		err = data.Set("credit_quota", 0) // not sure if this is the right approach
+		err = data.Set("credit_quota", 0.0) // not sure if this is the right approach
 	}
 	if err != nil {
 		return err

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -25,7 +25,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	in := map[string]interface{}{
 		"name":                       "good_name",
-		"credit_quota":               100,
+		"credit_quota":               100.00,
 		"notify_triggers":            []interface{}{75, 88},
 		"suspend_triggers":           []interface{}{99},
 		"suspend_immediate_triggers": []interface{}{105},
@@ -36,7 +36,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100 TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
+			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100.00 TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		expectReadResourceMonitor(mock)
@@ -51,7 +51,7 @@ func expectReadResourceMonitor(mock sqlmock.Sqlmock) {
 		"frequency", "start_time", "end_time", "notify_at", "suspend_at",
 		"suspend_immediately_at", "created_on", "owner", "comment",
 	}).AddRow(
-		"good_name", 100, 0, 100, "", "MONTHLY", "2001-01-01 00:00:00.000 -0700",
+		"good_name", 100.00, 0, 100, "", "MONTHLY", "2001-01-01 00:00:00.000 -0700",
 		"", "75%,88%", "99%", "105%", "2001-01-01 00:00:00.000 -0700", "ACCOUNTADMIN", "")
 	mock.ExpectQuery(`^SHOW RESOURCE MONITORS LIKE 'good_name'$`).WillReturnRows(rows)
 }

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -36,7 +36,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100.00 TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
+			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100.000000 TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		expectReadResourceMonitor(mock)

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -36,7 +36,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100.000000 TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
+			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100.00 TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		expectReadResourceMonitor(mock)

--- a/pkg/snowflake/generic.go
+++ b/pkg/snowflake/generic.go
@@ -88,7 +88,7 @@ func (ab *AlterPropertiesBuilder) Statement() string {
 	}
 
 	for k, v := range ab.floatProperties {
-		sb.WriteString(fmt.Sprintf(" %s=%f", strings.ToUpper(k), v))
+		sb.WriteString(fmt.Sprintf(" %s=%.2f", strings.ToUpper(k), v))
 	}
 
 	return sb.String()
@@ -171,7 +171,7 @@ func (b *CreateBuilder) Statement() string {
 	sort.Strings(sortedFloatProperties)
 
 	for _, k := range sortedFloatProperties {
-		sb.WriteString(fmt.Sprintf(" %s=%f", strings.ToUpper(k), b.floatProperties[k]))
+		sb.WriteString(fmt.Sprintf(" %s=%.2f", strings.ToUpper(k), b.floatProperties[k]))
 	}
 
 	return sb.String()

--- a/pkg/snowflake/generic.go
+++ b/pkg/snowflake/generic.go
@@ -41,6 +41,7 @@ type AlterPropertiesBuilder struct {
 	stringProperties map[string]string
 	boolProperties   map[string]bool
 	intProperties    map[string]int
+	floatProperties  map[string]float64
 }
 
 func (b *Builder) Alter() *AlterPropertiesBuilder {
@@ -50,6 +51,7 @@ func (b *Builder) Alter() *AlterPropertiesBuilder {
 		stringProperties: make(map[string]string),
 		boolProperties:   make(map[string]bool),
 		intProperties:    make(map[string]int),
+		floatProperties:  make(map[string]float64),
 	}
 }
 
@@ -63,6 +65,10 @@ func (ab *AlterPropertiesBuilder) SetBool(key string, value bool) {
 
 func (ab *AlterPropertiesBuilder) SetInt(key string, value int) {
 	ab.intProperties[key] = value
+}
+
+func (ab *AlterPropertiesBuilder) SetFloat(key string, value float64) {
+	ab.floatProperties[key] = value
 }
 
 func (ab *AlterPropertiesBuilder) Statement() string {
@@ -81,6 +87,10 @@ func (ab *AlterPropertiesBuilder) Statement() string {
 		sb.WriteString(fmt.Sprintf(" %s=%d", strings.ToUpper(k), v))
 	}
 
+	for k, v := range ab.floatProperties {
+		sb.WriteString(fmt.Sprintf(" %s=%f", strings.ToUpper(k), v))
+	}
+
 	return sb.String()
 }
 
@@ -90,6 +100,7 @@ type CreateBuilder struct {
 	stringProperties map[string]string
 	boolProperties   map[string]bool
 	intProperties    map[string]int
+	floatProperties  map[string]float64
 }
 
 func (b *Builder) Create() *CreateBuilder {
@@ -99,6 +110,7 @@ func (b *Builder) Create() *CreateBuilder {
 		stringProperties: make(map[string]string),
 		boolProperties:   make(map[string]bool),
 		intProperties:    make(map[string]int),
+		floatProperties:  make(map[string]float64),
 	}
 }
 
@@ -112,6 +124,10 @@ func (b *CreateBuilder) SetBool(key string, value bool) {
 
 func (b *CreateBuilder) SetInt(key string, value int) {
 	b.intProperties[key] = value
+}
+
+func (b *CreateBuilder) SetFloat(key string, value float64) {
+	b.floatProperties[key] = value
 }
 
 func (b *CreateBuilder) Statement() string {
@@ -146,6 +162,16 @@ func (b *CreateBuilder) Statement() string {
 
 	for _, k := range sortedIntProperties {
 		sb.WriteString(fmt.Sprintf(" %s=%d", strings.ToUpper(k), b.intProperties[k]))
+	}
+
+	sortedFloatProperties := make([]string, 0)
+	for k := range b.floatProperties {
+		sortedFloatProperties = append(sortedFloatProperties, k)
+	}
+	sort.Strings(sortedFloatProperties)
+
+	for _, k := range sortedFloatProperties {
+		sb.WriteString(fmt.Sprintf(" %s=%f", strings.ToUpper(k), b.floatProperties[k]))
 	}
 
 	return sb.String()

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -62,6 +62,7 @@ func (rb *ResourceMonitorBuilder) Create() *ResourceMonitorCreateBuilder {
 			stringProperties: make(map[string]string),
 			boolProperties:   make(map[string]bool),
 			intProperties:    make(map[string]int),
+			floatProperties:  make(map[string]float64),
 		},
 		make([]trigger, 0),
 	}
@@ -96,6 +97,10 @@ func (rcb *ResourceMonitorCreateBuilder) Statement() string {
 
 	for k, v := range rcb.intProperties {
 		sb.WriteString(fmt.Sprintf(` %v=%d`, strings.ToUpper(k), v))
+	}
+
+	for k, v := range rcb.floatProperties {
+		sb.WriteString(fmt.Sprintf(` %v=%f`, strings.ToUpper(k), v))
 	}
 
 	if len(rcb.triggers) > 0 {

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -100,7 +100,7 @@ func (rcb *ResourceMonitorCreateBuilder) Statement() string {
 	}
 
 	for k, v := range rcb.floatProperties {
-		sb.WriteString(fmt.Sprintf(` %v=%f`, strings.ToUpper(k), v))
+		sb.WriteString(fmt.Sprintf(` %v=%.2f`, strings.ToUpper(k), v))
 	}
 
 	if len(rcb.triggers) > 0 {

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -22,14 +22,14 @@ func TestResourceMonitor(t *testing.T) {
 	a.Equal(`DROP RESOURCE MONITOR "resource_monitor"`, q)
 
 	ab := rm.Alter()
-	ab.SetInt("credit_quota", 66)
+	ab.SetFloat("credit_quota", 66.6)
 	q = ab.Statement()
-	a.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66`, q)
+	a.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66.6`, q)
 
 	cb := snowflake.ResourceMonitor("resource_monitor").Create()
 	cb.NotifyAt(80).NotifyAt(90).SuspendAt(95).SuspendImmediatelyAt(100)
 	cb.SetString("frequency", "YEARLY")
-	cb.SetInt("credit_quota", 666)
+	cb.SetFloat("credit_quota", 666.66)
 	q = cb.Statement()
-	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.66 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 }

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -29,7 +29,13 @@ func TestResourceMonitor(t *testing.T) {
 	cb := snowflake.ResourceMonitor("resource_monitor").Create()
 	cb.NotifyAt(80).NotifyAt(90).SuspendAt(95).SuspendImmediatelyAt(100)
 	cb.SetString("frequency", "YEARLY")
+
 	cb.SetFloat("credit_quota", 666.66666666)
 	q = cb.Statement()
 	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.666667 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+
+	// Check if credit quota can be parsed correctly to float if given an integer
+	cb.SetFloat("credit_quota", 666)
+	q = cb.Statement()
+	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.000000 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 }

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -24,7 +24,7 @@ func TestResourceMonitor(t *testing.T) {
 	ab := rm.Alter()
 	ab.SetFloat("credit_quota", 66.6)
 	q = ab.Statement()
-	a.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66.600000`, q)
+	a.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66.60`, q)
 
 	cb := snowflake.ResourceMonitor("resource_monitor").Create()
 	cb.NotifyAt(80).NotifyAt(90).SuspendAt(95).SuspendImmediatelyAt(100)
@@ -32,10 +32,10 @@ func TestResourceMonitor(t *testing.T) {
 
 	cb.SetFloat("credit_quota", 666.66666666)
 	q = cb.Statement()
-	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.666667 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.67 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 
 	// Check if credit quota can be parsed correctly to float if given an integer
 	cb.SetFloat("credit_quota", 666)
 	q = cb.Statement()
-	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.000000 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.00 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 }

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -24,12 +24,12 @@ func TestResourceMonitor(t *testing.T) {
 	ab := rm.Alter()
 	ab.SetFloat("credit_quota", 66.6)
 	q = ab.Statement()
-	a.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66.6`, q)
+	a.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66.600000`, q)
 
 	cb := snowflake.ResourceMonitor("resource_monitor").Create()
 	cb.NotifyAt(80).NotifyAt(90).SuspendAt(95).SuspendImmediatelyAt(100)
 	cb.SetString("frequency", "YEARLY")
-	cb.SetFloat("credit_quota", 666.66)
+	cb.SetFloat("credit_quota", 666.66666666)
 	q = cb.Statement()
-	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.66 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.666667 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 }


### PR DESCRIPTION
Issue: https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/109

Note that if a float has more than 6 trailing numbers after the decimal point, `%f` rounds it up to have exactly 6. If fewer than 6 trailing numbers are provided, it appends zeros, for example, `66.00` becomes `66.000000`, which I think is fine?