### PR TITLE
[fix] schema managed access option

### DIFF
--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -223,7 +223,7 @@ func ReadSchema(data *schema.ResourceData, meta interface{}) error {
 				if err != nil {
 					return err
 				}
-			case "MANAGED":
+			case "MANAGED ACCESS":
 				err = data.Set("is_managed", true)
 				if err != nil {
 					return err

--- a/pkg/resources/schema_test.go
+++ b/pkg/resources/schema_test.go
@@ -46,6 +46,6 @@ func TestSchemaCreate(t *testing.T) {
 func expectReadSchema(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
 		"created_on", "name", "is_default", "is_current", "database_name", "owner", "comment", "options", "retention_time"},
-	).AddRow("2019-05-19 16:55:36.530 -0700", "good_name", "N", "Y", "test_db", "admin", "great comment", "TRANSIENT, MANAGED", 1)
+	).AddRow("2019-05-19 16:55:36.530 -0700", "good_name", "N", "Y", "test_db", "admin", "great comment", "TRANSIENT, MANAGED ACCESS", 1)
 	mock.ExpectQuery(`^SHOW SCHEMAS LIKE 'good_name' IN DATABASE "test_db"$`).WillReturnRows(rows)
 }


### PR DESCRIPTION
Terraform state refresh was always setting the managed access option to the default, false.