### PR TITLE
[fix] Fix cannot convert NULL to string when creating stage (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,10 +359,16 @@ We also run all tests in our [Travis-CI account](https://travis-ci.com/chanzucke
 
 Our CI jobs run the full acceptence test suite, which involves creating and destroying resources in a live snowflake account. Travis-CI is configured with environment variables to authenticate to our test snowflake account. For security reasons, those variables are not available to forks of this repo.
 
-If you are making a PR from a forked repo, you can set up Travis to build it by setting these environement variables:
+If you are making a PR from a forked repo, you can create a new Snowflake trial account and set up Travis to build it by setting these environement variables:
 
 * `SNOWFLAKE_ACCOUNT` - The account name
 * `SNOWFLAKE_USER` - A snowflake user for running tests.
 * `SNOWFLAKE_PASSWORD` - Password for that user.
 * `SNOWFLAKE_ROLE` - Needs to be ACCOUNTADMIN or similar.
 * `SNOWFLAKE_REGION` - Default is us-west-2, set this if your snowflake account is in a different region.
+
+If you are using the Standard Snowflake plan, it's recommended you also set up the following environment variables to skip tests for features not enabled for it:
+
+* `SKIP_DATABASE_TESTS` - to skip tests with retention time larger than 1 day
+* `SKIP_WAREHOUSE_TESTS` - to skip tests with multi warehouses
+

--- a/pkg/resources/database_acceptance_test.go
+++ b/pkg/resources/database_acceptance_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -9,6 +10,10 @@ import (
 )
 
 func TestAccDatabase(t *testing.T) {
+	if _, ok := os.LookupEnv("SKIP_DATABASE_TESTS"); ok {
+		t.Skip("Skipping TestAccDatabase")
+	}
+
 	prefix := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	prefix2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -400,18 +400,18 @@ func StageExists(data *schema.ResourceData, meta interface{}) (bool, error) {
 }
 
 type showStageResult struct {
-	createdOn        string
-	name             string
-	databaseName     string
-	schemaName       string
-	url              string
-	hasCredentials   string
-	hasEncryptionKey string
-	owner            string
-	comment          string
-	region           string
-	stageType        string
-	cloud            string
+	createdOn        *string
+	name             *string
+	databaseName     *string
+	schemaName       *string
+	url              *string
+	hasCredentials   *string
+	hasEncryptionKey *string
+	owner            *string
+	comment          *string
+	region           *string
+	stageType        *string
+	cloud            *string
 }
 
 func showStage(db *sql.DB, query string) (showStageResult, error) {

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -400,18 +400,20 @@ func StageExists(data *schema.ResourceData, meta interface{}) (bool, error) {
 }
 
 type showStageResult struct {
-	createdOn        *string
-	name             *string
-	databaseName     *string
-	schemaName       *string
-	url              *string
-	hasCredentials   *string
-	hasEncryptionKey *string
-	owner            *string
-	comment          *string
-	region           *string
-	stageType        *string
-	cloud            *string
+	createdOn           *string
+	name                *string
+	databaseName        *string
+	schemaName          *string
+	url                 *string
+	hasCredentials      *string
+	hasEncryptionKey    *string
+	owner               *string
+	comment             *string
+	region              *string
+	stageType           *string
+	cloud               *string
+	notificationChannel *string
+	storageIntegration  *string
 }
 
 func showStage(db *sql.DB, query string) (showStageResult, error) {
@@ -430,6 +432,8 @@ func showStage(db *sql.DB, query string) (showStageResult, error) {
 		&r.region,
 		&r.stageType,
 		&r.cloud,
+		&r.notificationChannel,
+		&r.storageIntegration,
 	)
 	if err != nil {
 		return r, err

--- a/pkg/resources/stage_acceptance_test.go
+++ b/pkg/resources/stage_acceptance_test.go
@@ -1,0 +1,50 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccStage(t *testing.T) {
+	accName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		Providers: providers(),
+		Steps: []resource.TestStep{
+			{
+				Config: stageConfig(accName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_stage.test", "name", accName),
+					resource.TestCheckResourceAttr("snowflake_stage.test", "database", accName),
+					resource.TestCheckResourceAttr("snowflake_stage.test", "schema", accName),
+					resource.TestCheckResourceAttr("snowflake_stage.test", "comment", "Terraform acceptance test"),
+				),
+			},
+		},
+	})
+}
+
+func stageConfig(n string) string {
+	return fmt.Sprintf(`
+resource "snowflake_database" "test" {
+	name = "%v"
+	comment = "Terraform acceptance test"
+}
+
+resource "snowflake_schema" "test" {
+	name = "%v"
+	database = snowflake_database.test.name
+	comment = "Terraform acceptance test"
+}
+
+resource "snowflake_stage" "test" {
+	name = "%v"
+	database = snowflake_database.test.name
+	schema = snowflake_schema.test.name
+	comment = "Terraform acceptance test"
+}
+`, n, n, n)
+}

--- a/pkg/resources/stage_test.go
+++ b/pkg/resources/stage_test.go
@@ -54,7 +54,7 @@ func expectReadStage(mock sqlmock.Sqlmock) {
 
 func expectReadStageShow(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "database_name", "schema_name", "url", "has_credentials", "has_encryption_key", "owner", "comment", "region", "type", "cloud"},
-	).AddRow("2019-12-23 17:20:50.088 +0000", "test_stage", "test_db", "test_schema", "s3://load/test/", "N", "Y", "test", "great comment", "us-east-1", "EXTERNAL", "AWS")
+		"created_on", "name", "database_name", "schema_name", "url", "has_credentials", "has_encryption_key", "owner", "comment", "region", "type", "cloud", "notification_channel", "storage_integration"},
+	).AddRow("2019-12-23 17:20:50.088 +0000", "test_stage", "test_db", "test_schema", "s3://load/test/", "N", "Y", "test", "great comment", "us-east-1", "EXTERNAL", "AWS", "NULL", "NULL")
 	mock.ExpectQuery(`^SHOW STAGES LIKE 'test_stage' IN DATABASE "test_db"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/warehouse_acceptance_test.go
+++ b/pkg/resources/warehouse_acceptance_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -9,6 +10,10 @@ import (
 )
 
 func TestAccWarehouse(t *testing.T) {
+	if _, ok := os.LookupEnv("SKIP_WAREHOUSE_TESTS"); ok {
+		t.Skip("Skipping TestAccWarehouse")
+	}
+
 	prefix := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	prefix2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 


### PR DESCRIPTION
When I try to create an internal stage, Terraform breaks with an error
trying to convert a NULL value to a string, which is not possible in Go.

When you run SHOW STAGES in internal stages, the "region" and "cloud"
fields are NULL. This pull request fixes that by using *string pointers
in the SHOW STAGE struct.