### PR TITLE
Add AWS SNS topic to pipe resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 |         NAME         |  TYPE  |                                                   DESCRIPTION                                                   | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
 |----------------------|--------|-----------------------------------------------------------------------------------------------------------------|----------|-----------|----------|---------|
 | auto_ingest          | bool   | Specifies a auto_ingest param for the pipe.                                                                     | true     | false     | false    | false   |
+| aws_sns_topic        | string | Specifies the sns topic that will be associated with the pipes sqs queue.                                       | true     | false     | false    | <nil>   |
 | comment              | string | Specifies a comment for the pipe.                                                                               | true     | false     | false    | <nil>   |
 | copy_statement       | string | Specifies the copy statement for the pipe.                                                                      | false    | true      | false    | <nil>   |
 | database             | string | The database in which to create the pipe.                                                                       | false    | true      | false    | <nil>   |

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -236,7 +236,7 @@ func ReadPipe(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	err = data.Set("aws_sns_topic", pipeShow.awsSnsTopic)
+	err = data.Set("aws_sns_topic", data.Get("aws_sns_topic"))
 	if err != nil {
 		return err
 	}
@@ -334,7 +334,6 @@ type showPipeResult struct {
 	owner               string
 	notificationChannel string
 	comment             string
-	awsSnsTopic					string
 }
 
 func showPipe(db *sql.DB, query string) (showPipeResult, error) {
@@ -349,7 +348,6 @@ func showPipe(db *sql.DB, query string) (showPipeResult, error) {
 		&r.owner,
 		&r.notificationChannel,
 		&r.comment,
-		&r.awsSnsTopic,
 	)
 	if err != nil {
 		return r, err

--- a/pkg/resources/pipe_test.go
+++ b/pkg/resources/pipe_test.go
@@ -27,13 +27,14 @@ func TestPipeCreate(t *testing.T) {
 		"database": "test_db",
 		"schema":   "test_schema",
 		"comment":  "great comment",
+		"aws_sns_topic": "some topic",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Pipe().Schema, in)
 	a.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE PIPE "test_db"."test_schema"."test_pipe" COMMENT = 'great comment'$`,
+			`^CREATE PIPE "test_db"."test_schema"."test_pipe" AWS_SNS_TOPIC = 'some topic' COMMENT = 'great comment'$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		expectReadPipe(mock)
@@ -44,7 +45,7 @@ func TestPipeCreate(t *testing.T) {
 
 func expectReadPipe(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "database_name", "schema_name", "definition", "owner", "notification_channel", "comment"},
-	).AddRow("2019-12-23 17:20:50.088 +0000", "test_pipe", "test_db", "test_schema", "test definition", "N", "test", "great comment")
+		"created_on", "name", "database_name", "schema_name", "definition", "owner", "notification_channel", "comment", "aws_sns_topic"},
+	).AddRow("2019-12-23 17:20:50.088 +0000", "test_pipe", "test_db", "test_schema", "test definition", "N", "test", "great comment", "some topic")
 	mock.ExpectQuery(`^SHOW PIPES LIKE 'test_pipe' IN DATABASE "test_db"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/pipe_test.go
+++ b/pkg/resources/pipe_test.go
@@ -45,7 +45,7 @@ func TestPipeCreate(t *testing.T) {
 
 func expectReadPipe(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "database_name", "schema_name", "definition", "owner", "notification_channel", "comment", "aws_sns_topic"},
-	).AddRow("2019-12-23 17:20:50.088 +0000", "test_pipe", "test_db", "test_schema", "test definition", "N", "test", "great comment", "some topic")
+		"created_on", "name", "database_name", "schema_name", "definition", "owner", "notification_channel", "comment"},
+	).AddRow("2019-12-23 17:20:50.088 +0000", "test_pipe", "test_db", "test_schema", "test definition", "N", "test", "great comment")
 	mock.ExpectQuery(`^SHOW PIPES LIKE 'test_pipe' IN DATABASE "test_db"$`).WillReturnRows(rows)
 }

--- a/pkg/snowflake/pipe.go
+++ b/pkg/snowflake/pipe.go
@@ -13,6 +13,7 @@ type PipeBuilder struct {
 	autoIngest    bool
 	comment       string
 	copyStatement string
+	awsSnsTopic   string
 }
 
 // QualifiedName prepends the db and schema if set and escapes everything nicely
@@ -39,6 +40,12 @@ func (pb *PipeBuilder) QualifiedName() string {
 // Transient adds the auto_ingest flag to the PipeBuilder
 func (pb *PipeBuilder) WithAutoIngest() *PipeBuilder {
 	pb.autoIngest = true
+	return pb
+}
+
+// WithAwsSnsTopic adds a aws sns topic to the PipeBuilder
+func (pb *PipeBuilder) WithAwsSnsTopic(a string) *PipeBuilder {
+	pb.awsSnsTopic = a
 	return pb
 }
 
@@ -81,7 +88,9 @@ func (pb *PipeBuilder) Create() string {
 	if pb.autoIngest {
 		q.WriteString(` AUTO_INGEST = TRUE`)
 	}
-
+	if pb.awsSnsTopic != "" {
+		q.WriteString(fmt.Sprintf(` AWS_SNS_TOPIC = '%v'`, pb.awsSnsTopic))
+	}
 	if pb.comment != "" {
 		q.WriteString(fmt.Sprintf(` COMMENT = '%v'`, EscapeString(pb.comment)))
 	}

--- a/pkg/snowflake/pipe_test.go
+++ b/pkg/snowflake/pipe_test.go
@@ -16,11 +16,14 @@ func TestPipeCreate(t *testing.T) {
 	s.WithAutoIngest()
 	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE`)
 
+	s.WithAwsSnsTopic("test-topic")
+	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE AWS_SNS_TOPIC = 'test-topic'`)
+
 	s.WithComment("Yeehaw")
-	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw'`)
+	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE AWS_SNS_TOPIC = 'test-topic' COMMENT = 'Yeehaw'`)
 
 	s.WithCopyStatement("test copy statement ")
-	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw' AS test copy statement `)
+	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE AWS_SNS_TOPIC = 'test-topic' COMMENT = 'Yeehaw' AS test copy statement `)
 }
 
 func TestPipeChangeComment(t *testing.T) {


### PR DESCRIPTION
Currently when creating a pipe you cant specify an SNS topic to associate a pipes SQS queue with. This pr add that option.