### PR TITLE
Add support for "ALL" privilege in snowflake_table_grant resource

### DIFF
--- a/pkg/resources/table_grant.go
+++ b/pkg/resources/table_grant.go
@@ -9,6 +9,7 @@ import (
 )
 
 var validTablePrivileges = newPrivilegeSet(
+	privilegeAll,
 	privilegeSelect,
 	privilegeInsert,
 	privilegeUpdate,


### PR DESCRIPTION
All Snowflake resources [support](https://docs.snowflake.net/manuals/user-guide/security-access-control-privileges.html) the `GRANT ALL` privilege, but the `snowflake_table_grant` resource doesn't:

```
Error: expected privilege to be one of [DELETE TRUNCATE REFERENCES SELECT INSERT UPDATE], got ALL
```