### PR TITLE
[feature] Add future schema grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,13 +186,14 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 #### properties
 
-|     NAME      |  TYPE  |                                                                  DESCRIPTION                                                                  | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
-|---------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|---------|
-| database_name | string | The name of the database containing the schema on which to grant privileges.                                                                  | false    | true      | false    | <nil>   |
-| privilege     | string | The privilege to grant on the schema.  Note that if "OWNERSHIP" is specified, ensure that the role that terraform is using is granted access. | true     | false     | false    | "USAGE" |
-| roles         | set    | Grants privilege to these roles.                                                                                                              | true     | false     | false    | <nil>   |
-| schema_name   | string | The name of the schema on which to grant privileges.                                                                                          | false    | true      | false    | <nil>   |
-| shares        | set    | Grants privilege to these shares.                                                                                                             | true     | false     | false    | <nil>   |
+|     NAME      |  TYPE  |                                                                             DESCRIPTION                                                                             | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
+|---------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|---------|
+| database_name | string | The name of the database containing the current or future schema on which to grant privileges.                                                                      | false    | true      | false    | <nil>   |
+| on_future     | bool   | When this is set to true, apply this grant on all future schemas in the given database.  The schema_name and shares fields must be unset in order to use on_future. | true     | false     | false    | false   |
+| privilege     | string | The privilege to grant on the current or future schema.  Note that if "OWNERSHIP" is specified, ensure that the role that terraform is using is granted access.     | true     | false     | false    | "USAGE" |
+| roles         | set    | Grants privilege to these roles.                                                                                                                                    | true     | false     | false    | <nil>   |
+| schema_name   | string | The name of the schema on which to grant privileges (only valid if on_future is unset).                                                                             | true     | false     | false    | <nil>   |
+| shares        | set    | Grants privilege to these shares (only valid if on_future is unset).                                                                                                | true     | false     | false    | <nil>   |
 
 ### snowflake_share
 

--- a/pkg/resources/schema_grant.go
+++ b/pkg/resources/schema_grant.go
@@ -76,7 +76,7 @@ var schemaGrantSchema = map[string]*schema.Schema{
 	},
 }
 
-// ViewGrant returns a pointer to the resource representing a view grant
+// SchemaGrant returns a pointer to the resource representing a schema grant
 func SchemaGrant() *schema.Resource {
 	return &schema.Resource{
 		Create: CreateSchemaGrant,

--- a/pkg/resources/schema_grant.go
+++ b/pkg/resources/schema_grant.go
@@ -124,6 +124,7 @@ func CreateSchemaGrant(data *schema.ResourceData, meta interface{}) error {
 		Privilege:    priv,
 	}
 	if !onFuture {
+		grantID.SchemaName = schemaName
 		grantID.ObjectName = schemaName
 	}
 

--- a/pkg/resources/schema_grant_acceptance_test.go
+++ b/pkg/resources/schema_grant_acceptance_test.go
@@ -22,9 +22,19 @@ func TestAccSchemaGrant(t *testing.T) {
 		Providers: providers(),
 		Steps: []resource.TestStep{
 			{
-				Config: schemaGrantConfig(sName, roleName, shareName),
+				Config: schemaGrantConfig(sName, roleName, shareName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "schema_name", sName),
+					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "on_future", "false"),
+					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "privilege", "USAGE"),
+				),
+			},
+			// FUTURE
+			{
+				Config: schemaGrantConfig(sName, roleName, shareName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "schema_name", ""),
+					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "on_future", "true"),
 					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "privilege", "USAGE"),
 				),
 			},
@@ -38,8 +48,15 @@ func TestAccSchemaGrant(t *testing.T) {
 	})
 }
 
-func schemaGrantConfig(n, role, share string) string {
-	return fmt.Sprintf(`
+func schemaGrantConfig(n, role, share string, future bool) string {
+  schema_name_config := `schema_name   = snowflake_schema.test.name
+  shares        = [snowflake_share.test.name]`
+
+  if future {
+    schema_name_config = "on_future     = true"
+  }
+
+  return fmt.Sprintf(`
 resource "snowflake_database" "test" {
   name = "%v"
 }
@@ -65,12 +82,11 @@ resource "snowflake_database_grant" "test" {
 }
 
 resource "snowflake_schema_grant" "test" {
-  schema_name   = snowflake_schema.test.name
   database_name = snowflake_schema.test.database
+  %v
   roles         = [snowflake_role.test.name]
-  shares        = [snowflake_share.test.name]
 
   depends_on = [snowflake_database_grant.test]
 }
-`, n, n, role, share)
+`, n, n, role, share, schema_name_config)
 }

--- a/pkg/resources/schema_grant_test.go
+++ b/pkg/resources/schema_grant_test.go
@@ -69,3 +69,39 @@ func expectReadSchemaGrant(mock sqlmock.Sqlmock, test_priv string) {
 	)
 	mock.ExpectQuery(`^SHOW GRANTS ON SCHEMA "test-db"."test-schema"$`).WillReturnRows(rows)
 }
+
+func TestFutureSchemaGrantCreate(t *testing.T) {
+	a := assert.New(t)
+
+	in := map[string]interface{}{
+		"on_future":     true,
+		"database_name": "test-db",
+		"privilege":     "SELECT",
+		"roles":         []interface{}{"test-role-1", "test-role-2"},
+	}
+	d := schema.TestResourceDataRaw(t, resources.SchemaGrant().Schema, in)
+	a.NotNil(d)
+
+	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`^GRANT SELECT ON FUTURE SCHEMAS IN DATABASE "test-db" TO ROLE "test-role-1"$`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(
+			`^GRANT SELECT ON FUTURE SCHEMAS IN DATABASE "test-db" TO ROLE "test-role-2"$`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+		expectReadFutureSchemaGrant(mock)
+		err := resources.CreateSchemaGrant(d, db)
+		a.NoError(err)
+	})
+}
+
+func expectReadFutureSchemaGrant(mock sqlmock.Sqlmock) {
+	rows := sqlmock.NewRows([]string{
+		"created_on", "privilege", "grant_on", "name", "grant_to", "grantee_name", "grant_option",
+	}).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), "SELECT", "SCHEMA", "test-db.<SCHEMA>", "ROLE", "test-role-1", false,
+	).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), "SELECT", "SCHEMA", "test-db.<SCHEMA>", "ROLE", "test-role-2", false,
+	)
+	mock.ExpectQuery(`^SHOW FUTURE GRANTS IN DATABASE "test-db"$`).WillReturnRows(rows)
+}

--- a/pkg/snowflake/future_grant_test.go
+++ b/pkg/snowflake/future_grant_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFutureSchemaGrant(t *testing.T) {
+	a := assert.New(t)
+	fsg := snowflake.FutureSchemaGrant("test_db")
+	a.Equal(fsg.Name(), "test_db")
+
+	s := fsg.Show()
+	a.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
+
+	s = fsg.Role("bob").Grant("USAGE")
+	a.Equal(`GRANT USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" TO ROLE "bob"`, s)
+
+	s = fsg.Role("bob").Revoke("USAGE")
+	a.Equal(`REVOKE USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" FROM ROLE "bob"`, s)
+}
+
 func TestFutureTableGrant(t *testing.T) {
 	a := assert.New(t)
 	fvg := snowflake.FutureTableGrant("test_db", "PUBLIC")


### PR DESCRIPTION
I didn't see a way to add grants for future schemas.

Followed the approach of the functionality for future tables and #78 