### PR TITLE
[feature] Add `WITH GRANT OPTION`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 #### properties
 
-|     NAME      |  TYPE  |                      DESCRIPTION                       | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
-|---------------|--------|--------------------------------------------------------|----------|-----------|----------|---------|
-| database_name | string | The name of the database on which to grant privileges. | false    | true      | false    | <nil>   |
-| privilege     | string | The privilege to grant on the database.                | true     | false     | false    | "USAGE" |
-| roles         | set    | Grants privilege to these roles.                       | true     | false     | false    | <nil>   |
-| shares        | set    | Grants privilege to these shares.                      | true     | false     | false    | <nil>   |
+|       NAME        |  TYPE  |                      DESCRIPTION                       | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
+|-------------------|--------|--------------------------------------------------------|----------|-----------|----------|---------|
+| database_name     | string | The name of the database on which to grant privileges. | false    | true      | false    | <nil>   |
+| privilege         | string | The privilege to grant on the database.                | true     | false     | false    | "USAGE" |
+| roles             | set    | Grants privilege to these roles.                       | true     | false     | false    | <nil>   |
+| shares            | set    | Grants privilege to these shares.                      | true     | false     | false    | <nil>   |
+| with_grant_option | bool   | The privilege to grant this privilege to other roles.  | true     | false     | false    | false   |
 
 ### snowflake_managed_account
 
@@ -186,13 +187,14 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 #### properties
 
-|     NAME      |  TYPE  |                                                                  DESCRIPTION                                                                  | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
-|---------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|---------|
-| database_name | string | The name of the database containing the schema on which to grant privileges.                                                                  | false    | true      | false    | <nil>   |
-| privilege     | string | The privilege to grant on the schema.  Note that if "OWNERSHIP" is specified, ensure that the role that terraform is using is granted access. | true     | false     | false    | "USAGE" |
-| roles         | set    | Grants privilege to these roles.                                                                                                              | true     | false     | false    | <nil>   |
-| schema_name   | string | The name of the schema on which to grant privileges.                                                                                          | false    | true      | false    | <nil>   |
-| shares        | set    | Grants privilege to these shares.                                                                                                             | true     | false     | false    | <nil>   |
+|       NAME        |  TYPE  |                                                                  DESCRIPTION                                                                  | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
+|-------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|---------|
+| database_name     | string | The name of the database containing the schema on which to grant privileges.                                                                  | false    | true      | false    | <nil>   |
+| privilege         | string | The privilege to grant on the schema.  Note that if "OWNERSHIP" is specified, ensure that the role that terraform is using is granted access. | true     | false     | false    | "USAGE" |
+| roles             | set    | Grants privilege to these roles.                                                                                                              | true     | false     | false    | <nil>   |
+| schema_name       | string | The name of the schema on which to grant privileges.                                                                                          | false    | true      | false    | <nil>   |
+| shares            | set    | Grants privilege to these shares.                                                                                                             | true     | false     | false    | <nil>   |
+| with_grant_option | bool   | The privilege to grant this privilege to other roles.                                                                                         | true     | false     | false    | false   |
 
 ### snowflake_share
 
@@ -233,14 +235,15 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 #### properties
 
-|     NAME      |  TYPE  |                                     DESCRIPTION                                     | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
-|---------------|--------|-------------------------------------------------------------------------------------|----------|-----------|----------|---------|
-| database_name | string | The name of the database containing the current stage on which to grant privileges. | false    | true      | false    | <nil>   |
-| privilege     | string | The privilege to grant on the stage.                                                | true     | false     | false    | "USAGE" |
-| roles         | set    | Grants privilege to these roles.                                                    | true     | false     | false    | <nil>   |
-| schema_name   | string | The name of the schema containing the current stage on which to grant privileges.   | false    | true      | false    | <nil>   |
-| shares        | set    | Grants privilege to these shares.                                                   | true     | false     | false    | <nil>   |
-| stage_name    | string | The name of the stage on which to grant privileges.                                 | false    | true      | false    | <nil>   |
+|       NAME        |  TYPE  |                                     DESCRIPTION                                     | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
+|-------------------|--------|-------------------------------------------------------------------------------------|----------|-----------|----------|---------|
+| database_name     | string | The name of the database containing the current stage on which to grant privileges. | false    | true      | false    | <nil>   |
+| privilege         | string | The privilege to grant on the stage.                                                | true     | false     | false    | "USAGE" |
+| roles             | set    | Grants privilege to these roles.                                                    | true     | false     | false    | <nil>   |
+| schema_name       | string | The name of the schema containing the current stage on which to grant privileges.   | false    | true      | false    | <nil>   |
+| shares            | set    | Grants privilege to these shares.                                                   | true     | false     | false    | <nil>   |
+| stage_name        | string | The name of the stage on which to grant privileges.                                 | false    | true      | false    | <nil>   |
+| with_grant_option | bool   | The privilege to grant this privilege to other roles.                               | true     | false     | false    | false   |
 
 ### snowflake_storage_integration
 
@@ -271,15 +274,16 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 #### properties
 
-|     NAME      |  TYPE  |                                                                           DESCRIPTION                                                                           | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT  |
-|---------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|----------|
-| database_name | string | The name of the database containing the current or future tables on which to grant privileges.                                                                  | false    | true      | false    | <nil>    |
-| on_future     | bool   | When this is set to true, apply this grant on all future tables in the given schema.  The table_name and shares fields must be unset in order to use on_future. | true     | false     | false    | false    |
-| privilege     | string | The privilege to grant on the current or future table.                                                                                                          | true     | false     | false    | "SELECT" |
-| roles         | set    | Grants privilege to these roles.                                                                                                                                | true     | false     | false    | <nil>    |
-| schema_name   | string | The name of the schema containing the current or future tables on which to grant privileges.                                                                    | true     | false     | false    | "PUBLIC" |
-| shares        | set    | Grants privilege to these shares (only valid if on_future is unset).                                                                                            | true     | false     | false    | <nil>    |
-| table_name    | string | The name of the table on which to grant privileges immediately (only valid if on_future is unset).                                                              | true     | false     | false    | <nil>    |
+|       NAME        |  TYPE  |                                                                           DESCRIPTION                                                                           | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT  |
+|-------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|----------|
+| database_name     | string | The name of the database containing the current or future tables on which to grant privileges.                                                                  | false    | true      | false    | <nil>    |
+| on_future         | bool   | When this is set to true, apply this grant on all future tables in the given schema.  The table_name and shares fields must be unset in order to use on_future. | true     | false     | false    | false    |
+| privilege         | string | The privilege to grant on the current or future table.                                                                                                          | true     | false     | false    | "SELECT" |
+| roles             | set    | Grants privilege to these roles.                                                                                                                                | true     | false     | false    | <nil>    |
+| schema_name       | string | The name of the schema containing the current or future tables on which to grant privileges.                                                                    | true     | false     | false    | "PUBLIC" |
+| shares            | set    | Grants privilege to these shares (only valid if on_future is unset).                                                                                            | true     | false     | false    | <nil>    |
+| table_name        | string | The name of the table on which to grant privileges immediately (only valid if on_future is unset).                                                              | true     | false     | false    | <nil>    |
+| with_grant_option | bool   | The privilege to grant this privilege to other roles.                                                                                                           | true     | false     | false    | false    |
 
 ### snowflake_user
 
@@ -323,15 +327,16 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 #### properties
 
-|     NAME      |  TYPE  |                                                                          DESCRIPTION                                                                          | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT  |
-|---------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|----------|
-| database_name | string | The name of the database containing the current or future views on which to grant privileges.                                                                 | false    | true      | false    | <nil>    |
-| on_future     | bool   | When this is set to true, apply this grant on all future views in the given schema.  The view_name and shares fields must be unset in order to use on_future. | true     | false     | false    | false    |
-| privilege     | string | The privilege to grant on the current or future view.                                                                                                         | true     | false     | false    | "SELECT" |
-| roles         | set    | Grants privilege to these roles.                                                                                                                              | true     | false     | false    | <nil>    |
-| schema_name   | string | The name of the schema containing the current or future views on which to grant privileges.                                                                   | true     | false     | false    | "PUBLIC" |
-| shares        | set    | Grants privilege to these shares (only valid if on_future is unset).                                                                                          | true     | false     | false    | <nil>    |
-| view_name     | string | The name of the view on which to grant privileges immediately (only valid if on_future is unset).                                                             | true     | false     | false    | <nil>    |
+|       NAME        |  TYPE  |                                                                          DESCRIPTION                                                                          | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT  |
+|-------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|----------|----------|
+| database_name     | string | The name of the database containing the current or future views on which to grant privileges.                                                                 | false    | true      | false    | <nil>    |
+| on_future         | bool   | When this is set to true, apply this grant on all future views in the given schema.  The view_name and shares fields must be unset in order to use on_future. | true     | false     | false    | false    |
+| privilege         | string | The privilege to grant on the current or future view.                                                                                                         | true     | false     | false    | "SELECT" |
+| roles             | set    | Grants privilege to these roles.                                                                                                                              | true     | false     | false    | <nil>    |
+| schema_name       | string | The name of the schema containing the current or future views on which to grant privileges.                                                                   | true     | false     | false    | "PUBLIC" |
+| shares            | set    | Grants privilege to these shares (only valid if on_future is unset).                                                                                          | true     | false     | false    | <nil>    |
+| view_name         | string | The name of the view on which to grant privileges immediately (only valid if on_future is unset).                                                             | true     | false     | false    | <nil>    |
+| with_grant_option | bool   | The privilege to grant this privilege to other roles.                                                                                                         | true     | false     | false    | false    |
 
 ### snowflake_warehouse
 
@@ -362,11 +367,12 @@ These resources do not enforce exclusive attachment of a grant, it is the user's
 
 #### properties
 
-|      NAME      |  TYPE  |                       DESCRIPTION                       | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
-|----------------|--------|---------------------------------------------------------|----------|-----------|----------|---------|
-| privilege      | string | The privilege to grant on the warehouse.                | true     | false     | false    | "USAGE" |
-| roles          | set    | Grants privilege to these roles.                        | true     | false     | false    | <nil>   |
-| warehouse_name | string | The name of the warehouse on which to grant privileges. | false    | true      | false    | <nil>   |
+|       NAME        |  TYPE  |                       DESCRIPTION                       | OPTIONAL | REQUIRED  | COMPUTED | DEFAULT |
+|-------------------|--------|---------------------------------------------------------|----------|-----------|----------|---------|
+| privilege         | string | The privilege to grant on the warehouse.                | true     | false     | false    | "USAGE" |
+| roles             | set    | Grants privilege to these roles.                        | true     | false     | false    | <nil>   |
+| warehouse_name    | string | The name of the warehouse on which to grant privileges. | false    | true      | false    | <nil>   |
+| with_grant_option | bool   | The privilege to grant this privilege to other roles.   | true     | false     | false    | false   |
 <!-- END -->
 
 ## Development

--- a/pkg/resources/database_grant.go
+++ b/pkg/resources/database_grant.go
@@ -46,6 +46,13 @@ var databaseGrantSchema = map[string]*schema.Schema{
 		Description: "Grants privilege to these shares.",
 		ForceNew:    true,
 	},
+	"with_grant_option": &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "The privilege to grant this privilege to other roles.",
+		Default:     false,
+		ForceNew:    true,
+	},
 }
 
 // DatabaseGrant returns a pointer to the resource representing a database grant
@@ -67,6 +74,7 @@ func CreateDatabaseGrant(data *schema.ResourceData, meta interface{}) error {
 	dbName := data.Get("database_name").(string)
 	builder := snowflake.DatabaseGrant(dbName)
 	priv := data.Get("privilege").(string)
+	grantOption := data.Get("with_grant_option").(bool)
 
 	err := createGenericGrant(data, meta, builder)
 	if err != nil {
@@ -76,6 +84,7 @@ func CreateDatabaseGrant(data *schema.ResourceData, meta interface{}) error {
 	grant := &grantID{
 		ResourceName: dbName,
 		Privilege:    priv,
+		GrantOption:  grantOption,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {
@@ -97,6 +106,10 @@ func ReadDatabaseGrant(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	err = data.Set("privilege", grantID.Privilege)
+	if err != nil {
+		return err
+	}
+	err = data.Set("with_grant_option", grantID.GrantOption)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/database_grant_acceptance_test.go
+++ b/pkg/resources/database_grant_acceptance_test.go
@@ -51,6 +51,7 @@ func TestAccDatabaseGrant(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_database_grant.test", "roles.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_database_grant.test", "shares.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_database_grant.test", "shares.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_database_grant.test", "with_grant_option", false),
 					testRolesAndShares("snowflake_database_grant.test", []string{roleName}, []string{shareName}),
 				),
 			},

--- a/pkg/resources/database_grant_test.go
+++ b/pkg/resources/database_grant_test.go
@@ -48,11 +48,12 @@ func TestDatabaseGrantCreate(t *testing.T) {
 func TestDatabaseGrantRead(t *testing.T) {
 	a := assert.New(t)
 
-	d := databaseGrant(t, "test-database|||IMPORTED PRIVILIGES", map[string]interface{}{
-		"database_name": "test-database",
-		"privilege":     "IMPORTED PRIVILIGES",
-		"roles":         []interface{}{"test-role-1", "test-role-2"},
-		"shares":        []interface{}{"test-share-1", "test-share-2"},
+	d := databaseGrant(t, "test-database|||IMPORTED PRIVILIGES|", map[string]interface{}{
+		"database_name":     "test-database",
+		"privilege":         "IMPORTED PRIVILIGES",
+		"roles":             []interface{}{"test-role-1", "test-role-2"},
+		"shares":            []interface{}{"test-share-1", "test-share-2"},
+		"with_grant_option": false,
 	})
 
 	a.NotNil(d)

--- a/pkg/resources/privileges.go
+++ b/pkg/resources/privileges.go
@@ -39,12 +39,12 @@ const (
 	privilegeCreateTemporaryTable   privilege = "CREATE TEMPORARY TABLE"
 )
 
-type privilegeSet map[privilege]struct{}
+type privilegeSet map[privilege]bool
 
 func newPrivilegeSet(privileges ...privilege) privilegeSet {
 	ps := privilegeSet{}
 	for _, priv := range privileges {
-		ps[priv] = struct{}{}
+		ps[priv] = false
 	}
 	return ps
 }
@@ -57,8 +57,20 @@ func (ps privilegeSet) toList() []string {
 	return privs
 }
 
+func (ps privilegeSet) addGrantedString(s string, grant bool) {
+	ps[privilege(s)] = grant
+}
+
+func (ps privilegeSet) hasGrantedString(s string, grantOption bool) bool {
+	if option, ok := ps[privilege(s)]; ok {
+	  return option == grantOption
+	}
+
+	return false
+}
+
 func (ps privilegeSet) addString(s string) {
-	ps[privilege(s)] = struct{}{}
+	ps.addGrantedString(s, false)
 }
 
 func (ps privilegeSet) hasString(s string) bool {

--- a/pkg/resources/schema_grant.go
+++ b/pkg/resources/schema_grant.go
@@ -65,6 +65,13 @@ var schemaGrantSchema = map[string]*schema.Schema{
 		Description: "Grants privilege to these shares.",
 		ForceNew:    true,
 	},
+	"with_grant_option": &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "The privilege to grant this privilege to other roles.",
+		Default:     false,
+		ForceNew:    true,
+	},
 }
 
 // ViewGrant returns a pointer to the resource representing a view grant
@@ -86,6 +93,7 @@ func CreateSchemaGrant(data *schema.ResourceData, meta interface{}) error {
 	schema := data.Get("schema_name").(string)
 	db := data.Get("database_name").(string)
 	priv := data.Get("privilege").(string)
+	grantOption := data.Get("with_grant_option").(bool)
 	builder := snowflake.SchemaGrant(db, schema)
 
 	err := createGenericGrant(data, meta, builder)
@@ -97,6 +105,7 @@ func CreateSchemaGrant(data *schema.ResourceData, meta interface{}) error {
 		ResourceName: db,
 		SchemaName:   schema,
 		Privilege:    priv,
+		GrantOption:  grantOption,
 	}
 	dataIDInput, err := grantID.String()
 	if err != nil {
@@ -122,6 +131,10 @@ func ReadSchemaGrant(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	err = data.Set("privilege", grantID.Privilege)
+	if err != nil {
+		return err
+	}
+	err = data.Set("with_grant_option", grantID.GrantOption)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/schema_grant_acceptance_test.go
+++ b/pkg/resources/schema_grant_acceptance_test.go
@@ -26,6 +26,7 @@ func TestAccSchemaGrant(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "schema_name", sName),
 					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "privilege", "USAGE"),
+					resource.TestCheckResourceAttr("snowflake_schema_grant.test", "with_grant_option", false),
 				),
 			},
 			// IMPORT

--- a/pkg/resources/schema_grant_test.go
+++ b/pkg/resources/schema_grant_test.go
@@ -26,11 +26,12 @@ func TestSchemaGrantCreate(t *testing.T) {
 
 	for _, test_priv := range []string{"USAGE", "MODIFY"} {
 		in := map[string]interface{}{
-			"schema_name":   "test-schema",
-			"database_name": "test-db",
-			"privilege":     test_priv,
-			"roles":         []interface{}{"test-role-1", "test-role-2"},
-			"shares":        []interface{}{"test-share-1", "test-share-2"},
+			"schema_name":       "test-schema",
+			"database_name":     "test-db",
+			"privilege":         test_priv,
+			"roles":             []interface{}{"test-role-1", "test-role-2"},
+			"shares":            []interface{}{"test-share-1", "test-share-2"},
+			"with_grant_option": false,
 		}
 		d := schema.TestResourceDataRaw(t, resources.SchemaGrant().Schema, in)
 		a.NotNil(d)

--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -99,7 +99,7 @@ func setAccounts(data *schema.ResourceData, meta interface{}) error {
 
 		// 2. Create temporary DB grant to the share
 		tempDBGrant := snowflake.DatabaseGrant(tempName)
-		err = DBExec(db, tempDBGrant.Share(name).Grant("USAGE"))
+		err = DBExec(db, tempDBGrant.Share(name).Grant("USAGE", false))
 		if err != nil {
 			return errors.Wrapf(err, "error creating temporary DB grant %v", tempName)
 		}

--- a/pkg/resources/stage_grant.go
+++ b/pkg/resources/stage_grant.go
@@ -57,6 +57,13 @@ var stageGrantSchema = map[string]*schema.Schema{
 		Description: "Grants privilege to these shares.",
 		ForceNew:    true,
 	},
+	"with_grant_option": &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "The privilege to grant this privilege to other roles.",
+		Default:     false,
+		ForceNew:    true,
+	},
 }
 
 // StageGrant returns a pointer to the resource representing a stage grant
@@ -84,6 +91,7 @@ func CreateStageGrant(data *schema.ResourceData, meta interface{}) error {
 	schemaName := data.Get("schema_name").(string)
 	dbName := data.Get("database_name").(string)
 	priv := data.Get("privilege").(string)
+	grantOption := data.Get("with_grant_option").(bool)
 
 	var builder snowflake.GrantBuilder
 	builder = snowflake.StageGrant(dbName, schemaName, stageName)
@@ -98,6 +106,7 @@ func CreateStageGrant(data *schema.ResourceData, meta interface{}) error {
 		SchemaName:   schemaName,
 		ObjectName:   stageName,
 		Privilege:    priv,
+		GrantOption:  grantOption,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {
@@ -132,6 +141,10 @@ func ReadStageGrant(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	err = data.Set("privilege", priv)
+	if err != nil {
+		return err
+	}
+	err = data.Set("with_grant_option", grantID.GrantOption)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/stage_grant_test.go
+++ b/pkg/resources/stage_grant_test.go
@@ -26,12 +26,13 @@ func TestStageGrantCreate(t *testing.T) {
 
 	for _, test_priv := range []string{"USAGE", "READ"} {
 		in := map[string]interface{}{
-			"stage_name":    "test-stage",
-			"schema_name":   "test-schema",
-			"database_name": "test-db",
-			"privilege":     test_priv,
-			"roles":         []interface{}{"test-role-1", "test-role-2"},
-			"shares":        []interface{}{"test-share-1", "test-share-2"},
+			"stage_name":        "test-stage",
+			"schema_name":       "test-schema",
+			"database_name":     "test-db",
+			"privilege":         test_priv,
+			"roles":             []interface{}{"test-role-1", "test-role-2"},
+			"shares":            []interface{}{"test-share-1", "test-share-2"},
+			"with_grant_option": false,
 		}
 		d := schema.TestResourceDataRaw(t, resources.StageGrant().Schema, in)
 		a.NotNil(d)

--- a/pkg/resources/table_grant.go
+++ b/pkg/resources/table_grant.go
@@ -67,6 +67,13 @@ var tableGrantSchema = map[string]*schema.Schema{
 		ForceNew:      true,
 		ConflictsWith: []string{"table_name", "shares"},
 	},
+	"with_grant_option": &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "The privilege to grant this privilege to other roles.",
+		Default:     false,
+		ForceNew:    true,
+	},
 }
 
 // TableGrant returns a pointer to the resource representing a Table grant
@@ -95,6 +102,7 @@ func CreateTableGrant(data *schema.ResourceData, meta interface{}) error {
 	dbName := data.Get("database_name").(string)
 	priv := data.Get("privilege").(string)
 	onFuture := data.Get("on_future").(bool)
+	grantOption := data.Get("with_grant_option").(bool)
 
 	if (tableName == "") && !onFuture {
 		return errors.New("table_name must be set unless on_future is true.")
@@ -117,6 +125,7 @@ func CreateTableGrant(data *schema.ResourceData, meta interface{}) error {
 		ResourceName: dbName,
 		SchemaName:   schemaName,
 		Privilege:    priv,
+		GrantOption:  grantOption,
 	}
 	if !onFuture {
 		grantID.ObjectName = tableName
@@ -141,6 +150,8 @@ func ReadTableGrant(data *schema.ResourceData, meta interface{}) error {
 	schemaName := grantID.SchemaName
 	tableName := grantID.ObjectName
 	priv := grantID.Privilege
+	grantOption := grantID.GrantOption
+
 	err = data.Set("database_name", dbName)
 	if err != nil {
 		return err
@@ -162,6 +173,10 @@ func ReadTableGrant(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	err = data.Set("privilege", priv)
+	if err != nil {
+		return err
+	}
+	err = data.Set("with_grant_option", grantOption)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/table_grant_test.go
+++ b/pkg/resources/table_grant_test.go
@@ -26,12 +26,13 @@ func TestTableGrantCreate(t *testing.T) {
 	a := assert.New(t)
 
 	in := map[string]interface{}{
-		"table_name":    "test-table",
-		"schema_name":   "PUBLIC",
-		"database_name": "test-db",
-		"privilege":     "SELECT",
-		"roles":         []interface{}{"test-role-1", "test-role-2"},
-		"shares":        []interface{}{"test-share-1", "test-share-2"},
+		"table_name":        "test-table",
+		"schema_name":       "PUBLIC",
+		"database_name":     "test-db",
+		"privilege":         "SELECT",
+		"roles":             []interface{}{"test-role-1", "test-role-2"},
+		"shares":            []interface{}{"test-share-1", "test-share-2"},
+		"with_grant_option": false,
 	}
 	d := schema.TestResourceDataRaw(t, resources.TableGrant().Schema, in)
 	a.NotNil(d)

--- a/pkg/resources/view_grant.go
+++ b/pkg/resources/view_grant.go
@@ -62,6 +62,13 @@ var viewGrantSchema = map[string]*schema.Schema{
 		ForceNew:      true,
 		ConflictsWith: []string{"view_name", "shares"},
 	},
+	"with_grant_option": &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "The privilege to grant this privilege to other roles.",
+		Default:     false,
+		ForceNew:    true,
+	},
 }
 
 // ViewGrant returns a pointer to the resource representing a view grant
@@ -90,6 +97,7 @@ func CreateViewGrant(data *schema.ResourceData, meta interface{}) error {
 	dbName := data.Get("database_name").(string)
 	priv := data.Get("privilege").(string)
 	futureViews := data.Get("on_future").(bool)
+	grantOption := data.Get("with_grant_option").(bool)
 
 	if (viewName == "") && !futureViews {
 		return errors.New("view_name must be set unless on_future is true.")
@@ -115,6 +123,7 @@ func CreateViewGrant(data *schema.ResourceData, meta interface{}) error {
 		SchemaName:   schemaName,
 		ObjectName:   viewName,
 		Privilege:    priv,
+		GrantOption:  grantOption,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {
@@ -135,6 +144,7 @@ func ReadViewGrant(data *schema.ResourceData, meta interface{}) error {
 	schemaName := grantID.SchemaName
 	viewName := grantID.ObjectName
 	priv := grantID.Privilege
+	grantOption := grantID.GrantOption
 
 	err = data.Set("database_name", dbName)
 	if err != nil {
@@ -157,6 +167,10 @@ func ReadViewGrant(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	err = data.Set("privilege", priv)
+	if err != nil {
+		return err
+	}
+	err = data.Set("with_grant_option", grantOption)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/view_grant_acceptance_test.go
+++ b/pkg/resources/view_grant_acceptance_test.go
@@ -68,6 +68,7 @@ func TestAccFutureViewGrantChange(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_view_grant.test", "view_name", viewName),
 					resource.TestCheckResourceAttr("snowflake_view_grant.test", "on_future", "false"),
 					resource.TestCheckResourceAttr("snowflake_view_grant.test", "privilege", "SELECT"),
+					resource.TestCheckResourceAttr("snowflake_view_grant.test", "with_grant_option", false),
 				),
 			},
 			// CHANGE FROM CURRENT TO FUTURE VIEWS
@@ -77,6 +78,7 @@ func TestAccFutureViewGrantChange(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_view_grant.test", "view_name", ""),
 					resource.TestCheckResourceAttr("snowflake_view_grant.test", "on_future", "true"),
 					resource.TestCheckResourceAttr("snowflake_view_grant.test", "privilege", "SELECT"),
+					resource.TestCheckResourceAttr("snowflake_view_grant.test", "with_grant_option", false),
 				),
 			},
 			// IMPORT

--- a/pkg/resources/view_grant_test.go
+++ b/pkg/resources/view_grant_test.go
@@ -24,12 +24,13 @@ func TestViewGrantCreate(t *testing.T) {
 	a := assert.New(t)
 
 	in := map[string]interface{}{
-		"view_name":     "test-view",
-		"schema_name":   "PUBLIC",
-		"database_name": "test-db",
-		"privilege":     "SELECT",
-		"roles":         []interface{}{"test-role-1", "test-role-2"},
-		"shares":        []interface{}{"test-share-1", "test-share-2"},
+		"view_name":         "test-view",
+		"schema_name":       "PUBLIC",
+		"database_name":     "test-db",
+		"privilege":         "SELECT",
+		"roles":             []interface{}{"test-role-1", "test-role-2"},
+		"shares":            []interface{}{"test-share-1", "test-share-2"},
+		"with_grant_option": false,
 	}
 	d := schema.TestResourceDataRaw(t, resources.ViewGrant().Schema, in)
 	a.NotNil(d)
@@ -64,11 +65,12 @@ func TestFutureViewGrantCreate(t *testing.T) {
 	a := assert.New(t)
 
 	in := map[string]interface{}{
-		"on_future":     true,
-		"schema_name":   "PUBLIC",
-		"database_name": "test-db",
-		"privilege":     "SELECT",
-		"roles":         []interface{}{"test-role-1", "test-role-2"},
+		"on_future":         true,
+		"schema_name":       "PUBLIC",
+		"database_name":     "test-db",
+		"privilege":         "SELECT",
+		"roles":             []interface{}{"test-role-1", "test-role-2"},
+		"with_grant_option": false,
 	}
 	d := schema.TestResourceDataRaw(t, resources.ViewGrant().Schema, in)
 	a.NotNil(d)

--- a/pkg/resources/warehouse_grant.go
+++ b/pkg/resources/warehouse_grant.go
@@ -36,6 +36,13 @@ var warehouseGrantSchema = map[string]*schema.Schema{
 		Description: "Grants privilege to these roles.",
 		ForceNew:    true,
 	},
+	"with_grant_option": &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "The privilege to grant this privilege to other roles.",
+		Default:     false,
+		ForceNew:    true,
+	},
 }
 
 // WarehouseGrant returns a pointer to the resource representing a warehouse grant
@@ -57,6 +64,7 @@ func WarehouseGrant() *schema.Resource {
 func CreateWarehouseGrant(data *schema.ResourceData, meta interface{}) error {
 	w := data.Get("warehouse_name").(string)
 	priv := data.Get("privilege").(string)
+	grantOption := data.Get("with_grant_option").(bool)
 	builder := snowflake.WarehouseGrant(w)
 
 	err := createGenericGrant(data, meta, builder)
@@ -67,6 +75,7 @@ func CreateWarehouseGrant(data *schema.ResourceData, meta interface{}) error {
 	grant := &grantID{
 		ResourceName: w,
 		Privilege:    priv,
+		GrantOption:  grantOption,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {
@@ -85,12 +94,17 @@ func ReadWarehouseGrant(data *schema.ResourceData, meta interface{}) error {
 	}
 	w := grantID.ResourceName
 	priv := grantID.Privilege
+	grantOption := grantID.GrantOption
 
 	err = data.Set("warehouse_name", w)
 	if err != nil {
 		return err
 	}
 	err = data.Set("privilege", priv)
+	if err != nil {
+		return err
+	}
+	err = data.Set("with_grant_option", grantOption)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/warehouse_grant_acceptance_test.go
+++ b/pkg/resources/warehouse_grant_acceptance_test.go
@@ -24,6 +24,7 @@ func TestAccWarehouseGrant(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_warehouse_grant.test", "warehouse_name", wName),
 					resource.TestCheckResourceAttr("snowflake_warehouse_grant.test", "privilege", "USAGE"),
+					resource.TestCheckResourceAttr("snowflake_warehouse_grant.test", "with_grant_option", false),
 				),
 			},
 			// // IMPORT

--- a/pkg/resources/warehouse_grant_test.go
+++ b/pkg/resources/warehouse_grant_test.go
@@ -26,9 +26,10 @@ func TestWarehouseGrantCreate(t *testing.T) {
 	a := assert.New(t)
 
 	in := map[string]interface{}{
-		"warehouse_name": "test-warehouse",
-		"privilege":      "USAGE",
-		"roles":          []interface{}{"test-role-1", "test-role-2"},
+		"warehouse_name":    "test-warehouse",
+		"privilege":         "USAGE",
+		"roles":             []interface{}{"test-role-1", "test-role-2"},
+		"with_grant_option": false,
 	}
 	d := schema.TestResourceDataRaw(t, resources.WarehouseGrant().Schema, in)
 	a.NotNil(d)

--- a/pkg/snowflake/future_grant.go
+++ b/pkg/snowflake/future_grant.go
@@ -69,9 +69,12 @@ func (gb *FutureGrantBuilder) Share(n string) GrantExecutable {
 }
 
 // Grant returns the SQL that will grant future privileges on the grant to the grantee
-func (fge *FutureGrantExecutable) Grant(p string) string {
-	return fmt.Sprintf(`GRANT %v ON FUTURE %vS IN SCHEMA %v TO ROLE "%v"`,
-		p, fge.futureGrantType, fge.grantName, fge.granteeName)
+func (fge *FutureGrantExecutable) Grant(p string, grantOption bool) string {
+	template := `GRANT %v ON FUTURE %vS IN SCHEMA %v TO ROLE "%v"`
+	if grantOption {
+		template = `GRANT %v ON FUTURE %vS IN SCHEMA %v TO ROLE "%v" WITH GRANT OPTION`
+	}
+	return fmt.Sprintf(template, p, fge.futureGrantType, fge.grantName, fge.granteeName)
 }
 
 // Revoke returns the SQL that will revoke future privileges on the grant from the grantee

--- a/pkg/snowflake/future_grant_test.go
+++ b/pkg/snowflake/future_grant_test.go
@@ -15,7 +15,7 @@ func TestFutureTableGrant(t *testing.T) {
 	s := fvg.Show()
 	a.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
 
-	s = fvg.Role("bob").Grant("USAGE")
+	s = fvg.Role("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
 	s = fvg.Role("bob").Revoke("USAGE")
@@ -30,7 +30,7 @@ func TestFutureViewGrant(t *testing.T) {
 	s := fvg.Show()
 	a.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
 
-	s = fvg.Role("bob").Grant("USAGE")
+	s = fvg.Role("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
 	s = fvg.Role("bob").Revoke("USAGE")

--- a/pkg/snowflake/grant.go
+++ b/pkg/snowflake/grant.go
@@ -16,7 +16,7 @@ const (
 )
 
 type GrantExecutable interface {
-	Grant(p string) string
+	Grant(p string, grantOption bool) string
 	Revoke(p string) string
 	Show() string
 }
@@ -137,12 +137,16 @@ func (gb *CurrentGrantBuilder) Share(n string) GrantExecutable {
 }
 
 // Grant returns the SQL that will grant privileges on the grant to the grantee
-func (ge *CurrentGrantExecutable) Grant(p string) string {
+func (ge *CurrentGrantExecutable) Grant(p string, grantOption bool) string {
 	var template string
 	if p == `OWNERSHIP` {
 		template = `GRANT %v ON %v %v TO %v "%v" COPY CURRENT GRANTS`
 	} else {
-		template = `GRANT %v ON %v %v TO %v "%v"`
+		if grantOption {
+			template = `GRANT %v ON %v %v TO %v "%v" WITH GRANT OPTION`
+		} else {
+			template = `GRANT %v ON %v %v TO %v "%v"`
+		}
 	}
 	return fmt.Sprintf(template,
 		p, ge.grantType, ge.grantName, ge.granteeType, ge.granteeName)

--- a/pkg/snowflake/grant_test.go
+++ b/pkg/snowflake/grant_test.go
@@ -15,17 +15,23 @@ func TestDatabaseGrant(t *testing.T) {
 	s := dg.Show()
 	a.Equal(`SHOW GRANTS ON DATABASE "testDB"`, s)
 
-	s = dg.Role("bob").Grant("USAGE")
+	s = dg.Role("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON DATABASE "testDB" TO ROLE "bob"`, s)
+
+	s = dg.Role("bob").Grant("USAGE", true)
+	a.Equal(`GRANT USAGE ON DATABASE "testDB" TO ROLE "bob" WITH GRANT OPTION`, s)
 
 	s = dg.Role("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON DATABASE "testDB" FROM ROLE "bob"`, s)
 
-	s = dg.Role("bob").Grant("OWNERSHIP")
+	s = dg.Role("bob").Grant("OWNERSHIP", false)
 	a.Equal(`GRANT OWNERSHIP ON DATABASE "testDB" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = dg.Share("bob").Grant("USAGE")
+	s = dg.Share("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON DATABASE "testDB" TO SHARE "bob"`, s)
+
+	s = dg.Share("bob").Grant("USAGE", true)
+	a.Equal(`GRANT USAGE ON DATABASE "testDB" TO SHARE "bob" WITH GRANT OPTION`, s)
 
 	s = dg.Share("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON DATABASE "testDB" FROM SHARE "bob"`, s)
@@ -39,19 +45,19 @@ func TestSchemaGrant(t *testing.T) {
 	s := sg.Show()
 	a.Equal(`SHOW GRANTS ON SCHEMA "test_db"."testSchema"`, s)
 
-	s = sg.Role("bob").Grant("USAGE")
+	s = sg.Role("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON SCHEMA "test_db"."testSchema" TO ROLE "bob"`, s)
 
 	s = sg.Role("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM ROLE "bob"`, s)
 
-	s = sg.Share("bob").Grant("USAGE")
+	s = sg.Share("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON SCHEMA "test_db"."testSchema" TO SHARE "bob"`, s)
 
 	s = sg.Share("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM SHARE "bob"`, s)
 
-	s = sg.Role("bob").Grant("OWNERSHIP")
+	s = sg.Role("bob").Grant("OWNERSHIP", false)
 	a.Equal(`GRANT OWNERSHIP ON SCHEMA "test_db"."testSchema" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 }
 
@@ -63,19 +69,22 @@ func TestViewGrant(t *testing.T) {
 	s := vg.Show()
 	a.Equal(`SHOW GRANTS ON VIEW "test_db"."PUBLIC"."testView"`, s)
 
-	s = vg.Role("bob").Grant("USAGE")
+	s = vg.Role("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob"`, s)
 
 	s = vg.Role("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM ROLE "bob"`, s)
 
-	s = vg.Share("bob").Grant("USAGE")
+	s = vg.Share("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON VIEW "test_db"."PUBLIC"."testView" TO SHARE "bob"`, s)
 
 	s = vg.Share("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM SHARE "bob"`, s)
 
-	s = vg.Role("bob").Grant("OWNERSHIP")
+	s = vg.Role("bob").Grant("OWNERSHIP", false)
+	a.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = vg.Role("bob").Grant("OWNERSHIP", true)
 	a.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 }
 
@@ -87,13 +96,13 @@ func TestWarehouseGrant(t *testing.T) {
 	s := wg.Show()
 	a.Equal(`SHOW GRANTS ON WAREHOUSE "test_warehouse"`, s)
 
-	s = wg.Role("bob").Grant("USAGE")
+	s = wg.Role("bob").Grant("USAGE", false)
 	a.Equal(`GRANT USAGE ON WAREHOUSE "test_warehouse" TO ROLE "bob"`, s)
 
 	s = wg.Role("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON WAREHOUSE "test_warehouse" FROM ROLE "bob"`, s)
 
-	s = wg.Role("bob").Grant("OWNERSHIP")
+	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	a.Equal(`GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 }


### PR DESCRIPTION
Add `with_grant_option` bool to most grant resources.

* Used `GRANT` as the `GrantOption` value in `grantID`s so that these values still hold some readability.