### PR TITLE
switch testify/assert to testify/require

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ setup: ## setup development dependencies
 	curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh
 .PHONY: setup
 
-lint: ## run the fast go linters
+lint: fmt ## run the fast go linters
 	./bin/reviewdog -conf .reviewdog.yml  -diff "git diff master"
 .PHONY: lint
 
@@ -23,7 +23,7 @@ lint-ci: ## run the fast go linters
 	./bin/reviewdog -conf .reviewdog.yml  -reporter=github-pr-review
 .PHONY: lint-ci
 
-lint-all: ## run the fast go linters
+lint-all: fmt ## run the fast go linters
 	# doesn't seem to be a way to get reviewdog to not filter by diff
 	./bin/golangci-lint run
 .PHONY: lint-all
@@ -54,11 +54,11 @@ coverage: ## run the go coverage tool, reading file coverage.out
 	go tool cover -html=coverage.txt
 .PHONY: coverage
 
-test: deps ## run the tests
+test: fmt deps ## run the tests
 	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 .PHONY: test
 
-test-acceptance: deps ## runs all tests, including the acceptance tests which create and destroys real resources
+test-acceptance: fmt deps ## runs all tests, including the acceptance tests which create and destroys real resources
 	SKIP_WAREHOUSE_GRANT_TESTS=1 SKIP_SHARE_TESTS=1 SKIP_MANAGED_ACCOUNT_TEST=1 TF_ACC=1 go test -v -coverprofile=coverage.txt -covermode=atomic $(TESTARGS) ./...
 .PHONY: test-acceptance
 
@@ -101,3 +101,7 @@ check-mod:
 	go mod tidy
 	git diff --exit-code -- go.mod go.sum
 .PHONY: check-mod
+
+fmt:
+	goimports -w -d $$(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./dist/*")
+.PHONY: fmt

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -6,17 +6,17 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	_ "github.com/snowflakedb/gosnowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProvider(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	err := provider.Provider().InternalValidate()
 	a.NoError(err)
 }
 
 // func TestConfigureProvider(t *testing.T) {
-// 	// a := assert.New(t)
+// 	// a := require.New(t)
 // }
 
 func TestDSN(t *testing.T) {
@@ -49,7 +49,7 @@ func TestDSN(t *testing.T) {
 }
 
 func resourceData(t *testing.T, account, username, password, region, role string) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"account":  account,

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestProvider(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	err := provider.Provider().InternalValidate()
-	a.NoError(err)
+	r.NoError(err)
 }
 
 // func TestConfigureProvider(t *testing.T) {
-// 	// a := require.New(t)
+// 	// r := require.New(t)
 // }
 
 func TestDSN(t *testing.T) {
@@ -49,7 +49,7 @@ func TestDSN(t *testing.T) {
 }
 
 func resourceData(t *testing.T, account, username, password, region, role string) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"account":  account,
@@ -60,6 +60,6 @@ func resourceData(t *testing.T, account, username, password, region, role string
 	}
 
 	d := schema.TestResourceDataRaw(t, provider.Provider().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 	return d
 }

--- a/pkg/resources/account_grant_test.go
+++ b/pkg/resources/account_grant_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -23,7 +22,7 @@ func TestAccountGrant(t *testing.T) {
 }
 
 func TestAccountGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"privilege": "CREATE DATABASE",
@@ -42,7 +41,7 @@ func TestAccountGrantCreate(t *testing.T) {
 }
 
 func TestAccountGrantRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := accountGrant(t, "ACCOUNT|||MANAGE GRANTS", map[string]interface{}{
 		"privilege": "MANAGE GRANTS",

--- a/pkg/resources/account_grant_test.go
+++ b/pkg/resources/account_grant_test.go
@@ -22,38 +22,38 @@ func TestAccountGrant(t *testing.T) {
 }
 
 func TestAccountGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"privilege": "CREATE DATABASE",
 		"roles":     []interface{}{"test-role-1", "test-role-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.AccountGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^GRANT CREATE DATABASE ON ACCOUNT TO ROLE "test-role-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^GRANT CREATE DATABASE ON ACCOUNT TO ROLE "test-role-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadAccountGrant(mock)
 		err := resources.CreateAccountGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestAccountGrantRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := accountGrant(t, "ACCOUNT|||MANAGE GRANTS", map[string]interface{}{
 		"privilege": "MANAGE GRANTS",
 		"roles":     []interface{}{"test-role-1", "test-role-2"},
 	})
 
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadAccountGrant(mock)
 		err := resources.ReadAccountGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/database_grant_test.go
+++ b/pkg/resources/database_grant_test.go
@@ -22,7 +22,7 @@ func TestDatabaseGrant(t *testing.T) {
 }
 
 func TestDatabaseGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"database_name": "test-database",
@@ -31,7 +31,7 @@ func TestDatabaseGrantCreate(t *testing.T) {
 		"shares":        []interface{}{"test-share-1", "test-share-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.DatabaseGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^GRANT USAGE ON DATABASE "test-database" TO ROLE "test-role-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -40,12 +40,12 @@ func TestDatabaseGrantCreate(t *testing.T) {
 		mock.ExpectExec(`^GRANT USAGE ON DATABASE "test-database" TO SHARE "test-share-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadDatabaseGrant(mock)
 		err := resources.CreateDatabaseGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestDatabaseGrantRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := databaseGrant(t, "test-database|||IMPORTED PRIVILIGES", map[string]interface{}{
 		"database_name": "test-database",
@@ -54,12 +54,12 @@ func TestDatabaseGrantRead(t *testing.T) {
 		"shares":        []interface{}{"test-share-1", "test-share-2"},
 	})
 
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadDatabaseGrant(mock)
 		err := resources.ReadDatabaseGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/database_grant_test.go
+++ b/pkg/resources/database_grant_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -23,7 +22,7 @@ func TestDatabaseGrant(t *testing.T) {
 }
 
 func TestDatabaseGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"database_name": "test-database",
@@ -46,7 +45,7 @@ func TestDatabaseGrantCreate(t *testing.T) {
 }
 
 func TestDatabaseGrantRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := databaseGrant(t, "test-database|||IMPORTED PRIVILIGES", map[string]interface{}{
 		"database_name": "test-database",

--- a/pkg/resources/database_test.go
+++ b/pkg/resources/database_test.go
@@ -19,20 +19,20 @@ func TestDatabase(t *testing.T) {
 }
 
 func TestDatabaseCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":    "good_name",
 		"comment": "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE DATABASE "good_name" COMMENT='great comment`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -42,34 +42,34 @@ func expectRead(mock sqlmock.Sqlmock) {
 }
 
 func TestDatabaseRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := database(t, "good_name", map[string]interface{}{"name": "good_name"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectRead(mock)
 		err := resources.ReadDatabase(d, db)
-		a.NoError(err)
-		a.Equal("good_name", d.Get("name").(string))
-		a.Equal("mock comment", d.Get("comment").(string))
-		a.Equal(1, d.Get("data_retention_time_in_days").(int))
+		r.NoError(err)
+		r.Equal("good_name", d.Get("name").(string))
+		r.Equal("mock comment", d.Get("comment").(string))
+		r.Equal(1, d.Get("data_retention_time_in_days").(int))
 	})
 }
 
 func TestDatabaseDelete(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := database(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP DATABASE "drop_it"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteDatabase(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestDatabaseCreateFromShare(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name": "good_name",
@@ -79,30 +79,30 @@ func TestDatabaseCreateFromShare(t *testing.T) {
 		},
 	}
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE DATABASE "good_name" FROM SHARE "abc123"."my_share"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestDatabaseCreateFromDatabase(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":          "good_name",
 		"from_database": "abc123",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE DATABASE "good_name" CLONE "abc123"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }

--- a/pkg/resources/database_test.go
+++ b/pkg/resources/database_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestDatabase(t *testing.T) {
 }
 
 func TestDatabaseCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":    "good_name",
@@ -43,7 +42,7 @@ func expectRead(mock sqlmock.Sqlmock) {
 }
 
 func TestDatabaseRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := database(t, "good_name", map[string]interface{}{"name": "good_name"})
 
@@ -58,7 +57,7 @@ func TestDatabaseRead(t *testing.T) {
 }
 
 func TestDatabaseDelete(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := database(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 
@@ -70,7 +69,7 @@ func TestDatabaseDelete(t *testing.T) {
 }
 
 func TestDatabaseCreateFromShare(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name": "good_name",
@@ -91,7 +90,7 @@ func TestDatabaseCreateFromShare(t *testing.T) {
 }
 
 func TestDatabaseCreateFromDatabase(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":          "good_name",

--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -285,10 +285,10 @@ func readGenericCurrentGrants(db *sql.DB, builder snowflake.GrantBuilder) ([]*gr
 			return nil, err
 		}
 		if currentGrant.GrantedBy == "" {
-		  // If GrantedBy is empty string, terraform can't
-		  // manage the grant because the grant is a default
-		  // grant seeded by Snowflake.
-		  continue
+			// If GrantedBy is empty string, terraform can't
+			// manage the grant because the grant is a default
+			// grant seeded by Snowflake.
+			continue
 		}
 
 		grant := &grant{

--- a/pkg/resources/helpers_test.go
+++ b/pkg/resources/helpers_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func database(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -19,7 +19,7 @@ func database(t *testing.T, id string, params map[string]interface{}) *schema.Re
 }
 
 func databaseGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.DatabaseGrant().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -27,7 +27,7 @@ func databaseGrant(t *testing.T, id string, params map[string]interface{}) *sche
 }
 
 func resourceMonitorGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ResourceMonitorGrant().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -35,7 +35,7 @@ func resourceMonitorGrant(t *testing.T, id string, params map[string]interface{}
 }
 
 func integrationGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.IntegrationGrant().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -43,7 +43,7 @@ func integrationGrant(t *testing.T, id string, params map[string]interface{}) *s
 }
 
 func accountGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.AccountGrant().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -58,7 +58,7 @@ func providers() map[string]terraform.ResourceProvider {
 }
 
 func role(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Role().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -66,7 +66,7 @@ func role(t *testing.T, id string, params map[string]interface{}) *schema.Resour
 }
 
 func roleGrants(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.RoleGrants().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -74,7 +74,7 @@ func roleGrants(t *testing.T, id string, params map[string]interface{}) *schema.
 }
 
 func storageIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.StorageIntegration().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -82,7 +82,7 @@ func storageIntegration(t *testing.T, id string, params map[string]interface{}) 
 }
 
 func user(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.User().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)
@@ -90,7 +90,7 @@ func user(t *testing.T, id string, params map[string]interface{}) *schema.Resour
 }
 
 func warehouse(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := assert.New(t)
+	a := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Warehouse().Schema, params)
 	a.NotNil(d)
 	d.SetId(id)

--- a/pkg/resources/helpers_test.go
+++ b/pkg/resources/helpers_test.go
@@ -11,41 +11,41 @@ import (
 )
 
 func database(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
 
 func databaseGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.DatabaseGrant().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
 
 func resourceMonitorGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ResourceMonitorGrant().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
 
 func integrationGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.IntegrationGrant().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
 
 func accountGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.AccountGrant().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
@@ -58,41 +58,41 @@ func providers() map[string]terraform.ResourceProvider {
 }
 
 func role(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Role().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
 
 func roleGrants(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.RoleGrants().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
 
 func storageIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.StorageIntegration().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
 
 func user(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.User().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
 
 func warehouse(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
-	a := require.New(t)
+	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Warehouse().Schema, params)
-	a.NotNil(d)
+	r.NotNil(d)
 	d.SetId(id)
 	return d
 }

--- a/pkg/resources/integration_grant_test.go
+++ b/pkg/resources/integration_grant_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -23,7 +22,7 @@ func TestIntegrationGrant(t *testing.T) {
 }
 
 func TestIntegrationGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"integration_name": "test-integration",
@@ -43,7 +42,7 @@ func TestIntegrationGrantCreate(t *testing.T) {
 }
 
 func TestIntegrationGrantRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := integrationGrant(t, "test-integration|||IMPORTED PRIVILIGES", map[string]interface{}{
 		"integration_name": "test-integration",

--- a/pkg/resources/integration_grant_test.go
+++ b/pkg/resources/integration_grant_test.go
@@ -22,7 +22,7 @@ func TestIntegrationGrant(t *testing.T) {
 }
 
 func TestIntegrationGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"integration_name": "test-integration",
@@ -30,19 +30,19 @@ func TestIntegrationGrantCreate(t *testing.T) {
 		"roles":            []interface{}{"test-role-1", "test-role-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.IntegrationGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^GRANT USAGE ON INTEGRATION "test-integration" TO ROLE "test-role-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^GRANT USAGE ON INTEGRATION "test-integration" TO ROLE "test-role-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadIntegrationGrant(mock)
 		err := resources.CreateIntegrationGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestIntegrationGrantRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := integrationGrant(t, "test-integration|||IMPORTED PRIVILIGES", map[string]interface{}{
 		"integration_name": "test-integration",
@@ -50,12 +50,12 @@ func TestIntegrationGrantRead(t *testing.T) {
 		"roles":            []interface{}{"test-role-1", "test-role-2"},
 	})
 
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadIntegrationGrant(mock)
 		err := resources.ReadIntegrationGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/managed_account_test.go
+++ b/pkg/resources/managed_account_test.go
@@ -20,7 +20,7 @@ func TestManagedAccount(t *testing.T) {
 }
 
 func TestManagedAccountCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":           "test-account",
@@ -29,13 +29,13 @@ func TestManagedAccountCreate(t *testing.T) {
 		"comment":        "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.ManagedAccount().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^CREATE MANAGED ACCOUNT "test-account" ADMIN_NAME='bob' ADMIN_PASSWORD='abc123ABC' COMMENT='great comment' TYPE='READER'$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadManagedAccount(mock)
 		err := resources.CreateManagedAccount(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/managed_account_test.go
+++ b/pkg/resources/managed_account_test.go
@@ -6,7 +6,6 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/provider"
@@ -21,7 +20,7 @@ func TestManagedAccount(t *testing.T) {
 }
 
 func TestManagedAccountCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":           "test-account",

--- a/pkg/resources/pipe_test.go
+++ b/pkg/resources/pipe_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestPipe(t *testing.T) {
 }
 
 func TestPipeCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":     "test_pipe",

--- a/pkg/resources/pipe_test.go
+++ b/pkg/resources/pipe_test.go
@@ -19,7 +19,7 @@ func TestPipe(t *testing.T) {
 }
 
 func TestPipeCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":     "test_pipe",
@@ -28,7 +28,7 @@ func TestPipeCreate(t *testing.T) {
 		"comment":  "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Pipe().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -37,7 +37,7 @@ func TestPipeCreate(t *testing.T) {
 
 		expectReadPipe(mock)
 		err := resources.CreatePipe(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/resource_monitor_grant_test.go
+++ b/pkg/resources/resource_monitor_grant_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -23,7 +22,7 @@ func TestResourceMonitorGrant(t *testing.T) {
 }
 
 func TestResourceMonitorGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"monitor_name": "test-monitor",
@@ -43,7 +42,7 @@ func TestResourceMonitorGrantCreate(t *testing.T) {
 }
 
 func TestResourceMonitorGrantRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := resourceMonitorGrant(t, "test-monitor|||MONITOR", map[string]interface{}{
 		"monitor_name": "test-monitor",

--- a/pkg/resources/resource_monitor_grant_test.go
+++ b/pkg/resources/resource_monitor_grant_test.go
@@ -22,7 +22,7 @@ func TestResourceMonitorGrant(t *testing.T) {
 }
 
 func TestResourceMonitorGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"monitor_name": "test-monitor",
@@ -30,19 +30,19 @@ func TestResourceMonitorGrantCreate(t *testing.T) {
 		"roles":        []interface{}{"test-role-1", "test-role-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.ResourceMonitorGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^GRANT MONITOR ON RESOURCE MONITOR "test-monitor" TO ROLE "test-role-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^GRANT MONITOR ON RESOURCE MONITOR "test-monitor" TO ROLE "test-role-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadResourceMonitorGrant(mock)
 		err := resources.CreateResourceMonitorGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestResourceMonitorGrantRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := resourceMonitorGrant(t, "test-monitor|||MONITOR", map[string]interface{}{
 		"monitor_name": "test-monitor",
@@ -50,12 +50,12 @@ func TestResourceMonitorGrantRead(t *testing.T) {
 		"roles":        []interface{}{"test-role-1", "test-role-2"},
 	})
 
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadResourceMonitorGrant(mock)
 		err := resources.ReadResourceMonitorGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -6,7 +6,6 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/provider"
@@ -21,7 +20,7 @@ func TestResourceMonitor(t *testing.T) {
 }
 
 func TestResourceMonitorCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":                       "good_name",
@@ -57,7 +56,7 @@ func expectReadResourceMonitor(mock sqlmock.Sqlmock) {
 }
 
 func TestResourceMonitorDelete(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name": "good_name",
@@ -75,7 +74,7 @@ func TestResourceMonitorDelete(t *testing.T) {
 }
 
 func TestResourceMonitorExists(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name": "good_name",

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -20,7 +20,7 @@ func TestResourceMonitor(t *testing.T) {
 }
 
 func TestResourceMonitorCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":                       "good_name",
@@ -31,7 +31,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 	}
 
 	d := schema.TestResourceDataRaw(t, resources.ResourceMonitor().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -40,7 +40,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 		expectReadResourceMonitor(mock)
 		err := resources.CreateResourceMonitor(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -56,7 +56,7 @@ func expectReadResourceMonitor(mock sqlmock.Sqlmock) {
 }
 
 func TestResourceMonitorDelete(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name": "good_name",
@@ -69,12 +69,12 @@ func TestResourceMonitorDelete(t *testing.T) {
 		mock.ExpectExec(`^DROP RESOURCE MONITOR "good_name"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		err := resources.DeleteResourceMonitor(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestResourceMonitorExists(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name": "good_name",
@@ -87,7 +87,7 @@ func TestResourceMonitorExists(t *testing.T) {
 		expectReadResourceMonitor(mock)
 
 		ok, err := resources.ResourceMonitorExists(d, db)
-		a.NoError(err)
-		a.True(ok)
+		r.NoError(err)
+		r.True(ok)
 	})
 }

--- a/pkg/resources/role_grants_internal_test.go
+++ b/pkg/resources/role_grants_internal_test.go
@@ -6,11 +6,11 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_grantToRole(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`GRANT ROLE "foo" TO ROLE "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -20,7 +20,7 @@ func Test_grantToRole(t *testing.T) {
 }
 
 func Test_grantToUser(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`GRANT ROLE "foo" TO USER "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -30,7 +30,7 @@ func Test_grantToUser(t *testing.T) {
 }
 
 func Test_readGrants(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rows := sqlmock.NewRows([]string{"created_on", "role", "granted_to", "grantee_name", "granted_by"}).AddRow("_", "foo", "ROLE", "bam", "")
@@ -45,7 +45,7 @@ func Test_readGrants(t *testing.T) {
 }
 
 func Test_revokeRoleFromRole(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`REVOKE ROLE "foo" FROM ROLE "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := revokeRoleFromRole(db, "foo", "bar")
@@ -55,7 +55,7 @@ func Test_revokeRoleFromRole(t *testing.T) {
 
 }
 func Test_revokeRoleFromUser(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`REVOKE ROLE "foo" FROM USER "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := revokeRoleFromUser(db, "foo", "bar")

--- a/pkg/resources/role_grants_internal_test.go
+++ b/pkg/resources/role_grants_internal_test.go
@@ -10,56 +10,56 @@ import (
 )
 
 func Test_grantToRole(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`GRANT ROLE "foo" TO ROLE "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := grantRoleToRole(db, "foo", "bar")
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func Test_grantToUser(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`GRANT ROLE "foo" TO USER "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := grantRoleToUser(db, "foo", "bar")
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func Test_readGrants(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		rows := sqlmock.NewRows([]string{"created_on", "role", "granted_to", "grantee_name", "granted_by"}).AddRow("_", "foo", "ROLE", "bam", "")
 		mock.ExpectQuery(`SHOW GRANTS OF ROLE "foo"`).WillReturnRows(rows)
-		r, err := readGrants(db, "foo")
-		a.NoError(err)
-		a.Len(r, 1)
-		g := r[0]
-		a.Equal("ROLE", g.GrantedTo.String)
-		a.Equal("bam", g.GranteeName.String)
+		read, err := readGrants(db, "foo")
+		r.NoError(err)
+		r.Len(read, 1)
+		g := read[0]
+		r.Equal("ROLE", g.GrantedTo.String)
+		r.Equal("bam", g.GranteeName.String)
 	})
 }
 
 func Test_revokeRoleFromRole(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`REVOKE ROLE "foo" FROM ROLE "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := revokeRoleFromRole(db, "foo", "bar")
-		a.NoError(err)
+		r.NoError(err)
 
 	})
 
 }
 func Test_revokeRoleFromUser(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`REVOKE ROLE "foo" FROM USER "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := revokeRoleFromUser(db, "foo", "bar")
-		a.NoError(err)
+		r.NoError(err)
 
 	})
 

--- a/pkg/resources/role_grants_test.go
+++ b/pkg/resources/role_grants_test.go
@@ -19,7 +19,7 @@ func TestRoleGrants(t *testing.T) {
 }
 
 func TestRoleGrantsCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := roleGrants(t, "good_name", map[string]interface{}{
 		"role_name": "good_name",
@@ -34,7 +34,7 @@ func TestRoleGrantsCreate(t *testing.T) {
 		mock.ExpectExec(`GRANT ROLE "good_name" TO USER "user2"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadRoleGrants(mock)
 		err := resources.CreateRoleGrants(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -54,7 +54,7 @@ func expectReadRoleGrants(mock sqlmock.Sqlmock) {
 }
 
 func TestRoleGrantsRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := roleGrants(t, "good_name", map[string]interface{}{
 		"role_name": "good_name",
@@ -65,14 +65,14 @@ func TestRoleGrantsRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadRoleGrants(mock)
 		err := resources.ReadRoleGrants(d, db)
-		a.NoError(err)
-		a.Len(d.Get("users").(*schema.Set).List(), 2)
-		a.Len(d.Get("roles").(*schema.Set).List(), 2)
+		r.NoError(err)
+		r.Len(d.Get("users").(*schema.Set).List(), 2)
+		r.Len(d.Get("roles").(*schema.Set).List(), 2)
 	})
 }
 
 func TestRoleGrantsDelete(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := roleGrants(t, "drop_it", map[string]interface{}{
 		"role_name": "drop_it",
@@ -87,6 +87,6 @@ func TestRoleGrantsDelete(t *testing.T) {
 		mock.ExpectExec(`REVOKE ROLE "drop_it" FROM USER "user1"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`REVOKE ROLE "drop_it" FROM USER "user2"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteRoleGrants(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }

--- a/pkg/resources/role_grants_test.go
+++ b/pkg/resources/role_grants_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestRoleGrants(t *testing.T) {
 }
 
 func TestRoleGrantsCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := roleGrants(t, "good_name", map[string]interface{}{
 		"role_name": "good_name",
@@ -55,7 +54,7 @@ func expectReadRoleGrants(mock sqlmock.Sqlmock) {
 }
 
 func TestRoleGrantsRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := roleGrants(t, "good_name", map[string]interface{}{
 		"role_name": "good_name",
@@ -73,7 +72,7 @@ func TestRoleGrantsRead(t *testing.T) {
 }
 
 func TestRoleGrantsDelete(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := roleGrants(t, "drop_it", map[string]interface{}{
 		"role_name": "drop_it",

--- a/pkg/resources/role_test.go
+++ b/pkg/resources/role_test.go
@@ -19,20 +19,20 @@ func TestRole(t *testing.T) {
 }
 
 func TestRoleCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":    "good_name",
 		"comment": "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Role().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE ROLE "good_name" COMMENT='great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadRole(mock)
 		err := resources.CreateRole(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -45,27 +45,27 @@ func expectReadRole(mock sqlmock.Sqlmock) {
 }
 
 func TestRoleRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := role(t, "good_name", map[string]interface{}{"name": "good_name"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadRole(mock)
 		err := resources.ReadRole(d, db)
-		a.NoError(err)
-		a.Equal("mock comment", d.Get("comment").(string))
-		a.Equal("role name", d.Get("name").(string))
+		r.NoError(err)
+		r.Equal("mock comment", d.Get("comment").(string))
+		r.Equal("role name", d.Get("name").(string))
 	})
 }
 
 func TestRoleDelete(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := role(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP ROLE "drop_it"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteRole(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }

--- a/pkg/resources/role_test.go
+++ b/pkg/resources/role_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestRole(t *testing.T) {
 }
 
 func TestRoleCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":    "good_name",
@@ -46,7 +45,7 @@ func expectReadRole(mock sqlmock.Sqlmock) {
 }
 
 func TestRoleRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := role(t, "good_name", map[string]interface{}{"name": "good_name"})
 
@@ -60,7 +59,7 @@ func TestRoleRead(t *testing.T) {
 }
 
 func TestRoleDelete(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := role(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 

--- a/pkg/resources/schema_grant_test.go
+++ b/pkg/resources/schema_grant_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +21,7 @@ func TestSchemaGrant(t *testing.T) {
 }
 
 func TestSchemaGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	for _, test_priv := range []string{"USAGE", "MODIFY"} {
 		in := map[string]interface{}{
@@ -71,7 +70,7 @@ func expectReadSchemaGrant(mock sqlmock.Sqlmock, test_priv string) {
 }
 
 func TestFutureSchemaGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"on_future":     true,

--- a/pkg/resources/schema_grant_test.go
+++ b/pkg/resources/schema_grant_test.go
@@ -21,7 +21,7 @@ func TestSchemaGrant(t *testing.T) {
 }
 
 func TestSchemaGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	for _, test_priv := range []string{"USAGE", "MODIFY"} {
 		in := map[string]interface{}{
@@ -32,7 +32,7 @@ func TestSchemaGrantCreate(t *testing.T) {
 			"shares":        []interface{}{"test-share-1", "test-share-2"},
 		}
 		d := schema.TestResourceDataRaw(t, resources.SchemaGrant().Schema, in)
-		a.NotNil(d)
+		r.NotNil(d)
 
 		WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 			mock.ExpectExec(
@@ -49,7 +49,7 @@ func TestSchemaGrantCreate(t *testing.T) {
 			).WillReturnResult(sqlmock.NewResult(1, 1))
 			expectReadSchemaGrant(mock, test_priv)
 			err := resources.CreateSchemaGrant(d, db)
-			a.NoError(err)
+			r.NoError(err)
 		})
 	}
 }
@@ -70,7 +70,7 @@ func expectReadSchemaGrant(mock sqlmock.Sqlmock, test_priv string) {
 }
 
 func TestFutureSchemaGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"on_future":     true,
@@ -79,7 +79,7 @@ func TestFutureSchemaGrantCreate(t *testing.T) {
 		"roles":         []interface{}{"test-role-1", "test-role-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.SchemaGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -90,7 +90,7 @@ func TestFutureSchemaGrantCreate(t *testing.T) {
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadFutureSchemaGrant(mock)
 		err := resources.CreateSchemaGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/schema_test.go
+++ b/pkg/resources/schema_test.go
@@ -19,7 +19,7 @@ func TestSchema(t *testing.T) {
 }
 
 func TestSchemaCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":         "good_name",
@@ -29,7 +29,7 @@ func TestSchemaCreate(t *testing.T) {
 		"is_managed":   true,
 	}
 	d := schema.TestResourceDataRaw(t, resources.Schema().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -38,7 +38,7 @@ func TestSchemaCreate(t *testing.T) {
 
 		expectReadSchema(mock)
 		err := resources.CreateSchema(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/schema_test.go
+++ b/pkg/resources/schema_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestSchema(t *testing.T) {
 }
 
 func TestSchemaCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":         "good_name",

--- a/pkg/resources/share_test.go
+++ b/pkg/resources/share_test.go
@@ -20,7 +20,7 @@ func TestShare(t *testing.T) {
 }
 
 func TestShareCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":     "test-share",
@@ -28,7 +28,7 @@ func TestShareCreate(t *testing.T) {
 		"accounts": []interface{}{"bob123", "sue456"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.Share().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^CREATE SHARE "test-share" COMMENT='great comment'$`).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -39,7 +39,7 @@ func TestShareCreate(t *testing.T) {
 		mock.ExpectExec(`^DROP DATABASE "TEMP_test-share_\d*"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadShare(mock)
 		err := resources.CreateShare(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -52,13 +52,13 @@ func expectReadShare(mock sqlmock.Sqlmock) {
 }
 
 func TestStripAccountFromName(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := "yt12345.my_share"
-	a.Equal("my_share", resources.StripAccountFromName(s))
+	r.Equal("my_share", resources.StripAccountFromName(s))
 
 	s = "yt12345.my.share"
-	a.Equal("my.share", resources.StripAccountFromName(s))
+	r.Equal("my.share", resources.StripAccountFromName(s))
 
 	s = "no_account_for_some_reason"
-	a.Equal("no_account_for_some_reason", resources.StripAccountFromName(s))
+	r.Equal("no_account_for_some_reason", resources.StripAccountFromName(s))
 }

--- a/pkg/resources/share_test.go
+++ b/pkg/resources/share_test.go
@@ -6,7 +6,6 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/provider"
@@ -21,7 +20,7 @@ func TestShare(t *testing.T) {
 }
 
 func TestShareCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":     "test-share",
@@ -53,7 +52,7 @@ func expectReadShare(mock sqlmock.Sqlmock) {
 }
 
 func TestStripAccountFromName(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := "yt12345.my_share"
 	a.Equal("my_share", resources.StripAccountFromName(s))
 

--- a/pkg/resources/stage_grant_test.go
+++ b/pkg/resources/stage_grant_test.go
@@ -21,7 +21,7 @@ func TestStageGrant(t *testing.T) {
 }
 
 func TestStageGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	for _, test_priv := range []string{"USAGE", "READ"} {
 		in := map[string]interface{}{
@@ -33,7 +33,7 @@ func TestStageGrantCreate(t *testing.T) {
 			"shares":        []interface{}{"test-share-1", "test-share-2"},
 		}
 		d := schema.TestResourceDataRaw(t, resources.StageGrant().Schema, in)
-		a.NotNil(d)
+		r.NotNil(d)
 
 		WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 			mock.ExpectExec(fmt.Sprintf(`^GRANT %s ON STAGE "test-db"."test-schema"."test-stage" TO ROLE "test-role-1"$`, test_priv)).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -42,7 +42,7 @@ func TestStageGrantCreate(t *testing.T) {
 			mock.ExpectExec(fmt.Sprintf(`^GRANT %s ON STAGE "test-db"."test-schema"."test-stage" TO SHARE "test-share-2"$`, test_priv)).WillReturnResult(sqlmock.NewResult(1, 1))
 			expectReadStageGrant(mock, test_priv)
 			err := resources.CreateStageGrant(d, db)
-			a.NoError(err)
+			r.NoError(err)
 		})
 	}
 }

--- a/pkg/resources/stage_grant_test.go
+++ b/pkg/resources/stage_grant_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +21,7 @@ func TestStageGrant(t *testing.T) {
 }
 
 func TestStageGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	for _, test_priv := range []string{"USAGE", "READ"} {
 		in := map[string]interface{}{

--- a/pkg/resources/stage_test.go
+++ b/pkg/resources/stage_test.go
@@ -19,7 +19,7 @@ func TestStage(t *testing.T) {
 }
 
 func TestStageCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":     "test_stage",
@@ -28,7 +28,7 @@ func TestStageCreate(t *testing.T) {
 		"comment":  "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Stage().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -38,7 +38,7 @@ func TestStageCreate(t *testing.T) {
 		expectReadStage(mock)
 		expectReadStageShow(mock)
 		err := resources.CreateStage(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/stage_test.go
+++ b/pkg/resources/stage_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestStage(t *testing.T) {
 }
 
 func TestStageCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":     "test_stage",

--- a/pkg/resources/storage_integration_test.go
+++ b/pkg/resources/storage_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestStorageIntegration(t *testing.T) {
 }
 
 func TestStorageIntegrationCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":                      "test_storage_integration",
@@ -44,7 +43,7 @@ func TestStorageIntegrationCreate(t *testing.T) {
 }
 
 func TestStorageIntegrationRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := storageIntegration(t, "test_storage_integration", map[string]interface{}{"name": "test_storage_integration"})
 
@@ -57,7 +56,7 @@ func TestStorageIntegrationRead(t *testing.T) {
 }
 
 func TestStorageIntegrationDelete(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := storageIntegration(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 

--- a/pkg/resources/storage_integration_test.go
+++ b/pkg/resources/storage_integration_test.go
@@ -19,7 +19,7 @@ func TestStorageIntegration(t *testing.T) {
 }
 
 func TestStorageIntegrationCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":                      "test_storage_integration",
@@ -29,7 +29,7 @@ func TestStorageIntegrationCreate(t *testing.T) {
 		"storage_aws_role_arn":      "we-should-probably-validate-this-string",
 	}
 	d := schema.TestResourceDataRaw(t, resources.StorageIntegration().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -38,12 +38,12 @@ func TestStorageIntegrationCreate(t *testing.T) {
 		expectReadStorageIntegration(mock)
 
 		err := resources.CreateStorageIntegration(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestStorageIntegrationRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := storageIntegration(t, "test_storage_integration", map[string]interface{}{"name": "test_storage_integration"})
 
@@ -51,19 +51,19 @@ func TestStorageIntegrationRead(t *testing.T) {
 		expectReadStorageIntegration(mock)
 
 		err := resources.ReadStorageIntegration(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
 func TestStorageIntegrationDelete(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := storageIntegration(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP STORAGE INTEGRATION "drop_it"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteStorageIntegration(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/table_grant_test.go
+++ b/pkg/resources/table_grant_test.go
@@ -22,7 +22,7 @@ func TestTableGrant(t *testing.T) {
 }
 
 func TestTableGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"table_name":    "test-table",
@@ -33,7 +33,7 @@ func TestTableGrantCreate(t *testing.T) {
 		"shares":        []interface{}{"test-share-1", "test-share-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.TableGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^GRANT SELECT ON TABLE "test-db"."PUBLIC"."test-table" TO ROLE "test-role-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -42,7 +42,7 @@ func TestTableGrantCreate(t *testing.T) {
 		mock.ExpectExec(`^GRANT SELECT ON TABLE "test-db"."PUBLIC"."test-table" TO SHARE "test-share-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadTableGrant(mock)
 		err := resources.CreateTableGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -62,7 +62,7 @@ func expectReadTableGrant(mock sqlmock.Sqlmock) {
 }
 
 func TestFutureTableGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"on_future":     true,
@@ -72,7 +72,7 @@ func TestFutureTableGrantCreate(t *testing.T) {
 		"roles":         []interface{}{"test-role-1", "test-role-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.TableGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -83,7 +83,7 @@ func TestFutureTableGrantCreate(t *testing.T) {
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadFutureTableGrant(mock)
 		err := resources.CreateTableGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 
 	b := require.New(t)

--- a/pkg/resources/table_grant_test.go
+++ b/pkg/resources/table_grant_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -23,7 +22,7 @@ func TestTableGrant(t *testing.T) {
 }
 
 func TestTableGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"table_name":    "test-table",
@@ -63,7 +62,7 @@ func expectReadTableGrant(mock sqlmock.Sqlmock) {
 }
 
 func TestFutureTableGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"on_future":     true,
@@ -87,7 +86,7 @@ func TestFutureTableGrantCreate(t *testing.T) {
 		a.NoError(err)
 	})
 
-	b := assert.New(t)
+	b := require.New(t)
 
 	in = map[string]interface{}{
 		"on_future":     true,

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -31,13 +31,13 @@ func checkBool(path, attr string, value bool) func(*terraform.State) error {
 }
 
 func TestAccUser(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	prefix := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	prefix2 := randomdata.Email()
 	sshkey1, err := testhelpers.Fixture("userkey1")
-	a.NoError(err)
+	r.NoError(err)
 	sshkey2, err := testhelpers.Fixture("userkey2")
-	a.NoError(err)
+	r.NoError(err)
 
 	resource.Test(t, resource.TestCase{
 		Providers: providers(),

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func checkBool(path, attr string, value bool) func(*terraform.State) error {
@@ -31,7 +31,7 @@ func checkBool(path, attr string, value bool) func(*terraform.State) error {
 }
 
 func TestAccUser(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	prefix := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	prefix2 := randomdata.Email()
 	sshkey1, err := testhelpers.Fixture("userkey1")

--- a/pkg/resources/user_test.go
+++ b/pkg/resources/user_test.go
@@ -19,7 +19,7 @@ func TestUser(t *testing.T) {
 }
 
 func TestUserCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":                 "good_name",
@@ -35,13 +35,13 @@ func TestUserCreate(t *testing.T) {
 		"must_change_password": true,
 	}
 	d := schema.TestResourceDataRaw(t, resources.User().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^CREATE USER "good_name" COMMENT='great comment' DEFAULT_NAMESPACE='mynamespace' DEFAULT_ROLE='bestrole' DEFAULT_WAREHOUSE='mywarehouse' LOGIN_NAME='gname' PASSWORD='awesomepassword' RSA_PUBLIC_KEY='asdf' RSA_PUBLIC_KEY_2='asdf2' DISABLED=true MUST_CHANGE_PASSWORD=true$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadUser(mock)
 		err := resources.CreateUser(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -56,41 +56,41 @@ func expectReadUser(mock sqlmock.Sqlmock) {
 }
 
 func TestUserRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := user(t, "good_name", map[string]interface{}{"name": "good_name"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadUser(mock)
 		err := resources.ReadUser(d, db)
-		a.NoError(err)
-		a.Equal("mock comment", d.Get("comment").(string))
-		a.Equal("myloginname", d.Get("login_name").(string))
-		a.Equal(false, d.Get("disabled").(bool))
+		r.NoError(err)
+		r.Equal("mock comment", d.Get("comment").(string))
+		r.Equal("myloginname", d.Get("login_name").(string))
+		r.Equal(false, d.Get("disabled").(bool))
 	})
 }
 
 func TestUserExists(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := user(t, "good_name", map[string]interface{}{"name": "good_name"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadUser(mock)
 		b, err := resources.UserExists(d, db)
-		a.NoError(err)
-		a.True(b)
+		r.NoError(err)
+		r.True(b)
 	})
 }
 
 func TestUserDelete(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := user(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^DROP USER "drop_it"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteUser(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }

--- a/pkg/resources/user_test.go
+++ b/pkg/resources/user_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestUser(t *testing.T) {
 }
 
 func TestUserCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":                 "good_name",
@@ -57,7 +56,7 @@ func expectReadUser(mock sqlmock.Sqlmock) {
 }
 
 func TestUserRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := user(t, "good_name", map[string]interface{}{"name": "good_name"})
 
@@ -72,7 +71,7 @@ func TestUserRead(t *testing.T) {
 }
 
 func TestUserExists(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := user(t, "good_name", map[string]interface{}{"name": "good_name"})
 
@@ -85,7 +84,7 @@ func TestUserExists(t *testing.T) {
 }
 
 func TestUserDelete(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := user(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 

--- a/pkg/resources/view_grant_test.go
+++ b/pkg/resources/view_grant_test.go
@@ -20,7 +20,7 @@ func TestViewGrant(t *testing.T) {
 }
 
 func TestViewGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"view_name":     "test-view",
@@ -31,7 +31,7 @@ func TestViewGrantCreate(t *testing.T) {
 		"shares":        []interface{}{"test-share-1", "test-share-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.ViewGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^GRANT SELECT ON VIEW "test-db"."PUBLIC"."test-view" TO ROLE "test-role-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -40,7 +40,7 @@ func TestViewGrantCreate(t *testing.T) {
 		mock.ExpectExec(`^GRANT SELECT ON VIEW "test-db"."PUBLIC"."test-view" TO SHARE "test-share-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadViewGrant(mock)
 		err := resources.CreateViewGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -60,7 +60,7 @@ func expectReadViewGrant(mock sqlmock.Sqlmock) {
 }
 
 func TestFutureViewGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"on_future":     true,
@@ -70,7 +70,7 @@ func TestFutureViewGrantCreate(t *testing.T) {
 		"roles":         []interface{}{"test-role-1", "test-role-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.ViewGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -81,7 +81,7 @@ func TestFutureViewGrantCreate(t *testing.T) {
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadFutureViewGrant(mock)
 		err := resources.CreateViewGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 
 	b := require.New(t)

--- a/pkg/resources/view_grant_test.go
+++ b/pkg/resources/view_grant_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +20,7 @@ func TestViewGrant(t *testing.T) {
 }
 
 func TestViewGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"view_name":     "test-view",
@@ -61,7 +60,7 @@ func expectReadViewGrant(mock sqlmock.Sqlmock) {
 }
 
 func TestFutureViewGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"on_future":     true,
@@ -85,7 +84,7 @@ func TestFutureViewGrantCreate(t *testing.T) {
 		a.NoError(err)
 	})
 
-	b := assert.New(t)
+	b := require.New(t)
 
 	in = map[string]interface{}{
 		"on_future":     true,

--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -20,7 +20,7 @@ func TestView(t *testing.T) {
 }
 
 func TestViewCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":      "good_name",
@@ -30,7 +30,7 @@ func TestViewCreate(t *testing.T) {
 		"is_secure": true,
 	}
 	d := schema.TestResourceDataRaw(t, resources.View().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
@@ -39,7 +39,7 @@ func TestViewCreate(t *testing.T) {
 
 		expectReadView(mock)
 		err := resources.CreateView(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +20,7 @@ func TestView(t *testing.T) {
 }
 
 func TestViewCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":      "good_name",

--- a/pkg/resources/warehouse_grant_test.go
+++ b/pkg/resources/warehouse_grant_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -23,7 +22,7 @@ func TestWarehouseGrant(t *testing.T) {
 }
 
 func TestWarehouseGrantCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"warehouse_name": "test-warehouse",

--- a/pkg/resources/warehouse_grant_test.go
+++ b/pkg/resources/warehouse_grant_test.go
@@ -22,7 +22,7 @@ func TestWarehouseGrant(t *testing.T) {
 }
 
 func TestWarehouseGrantCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"warehouse_name": "test-warehouse",
@@ -30,14 +30,14 @@ func TestWarehouseGrantCreate(t *testing.T) {
 		"roles":          []interface{}{"test-role-1", "test-role-2"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.WarehouseGrant().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`^GRANT USAGE ON WAREHOUSE "test-warehouse" TO ROLE "test-role-1"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^GRANT USAGE ON WAREHOUSE "test-warehouse" TO ROLE "test-role-2"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadWarehouseGrant(mock)
 		err := resources.CreateWarehouseGrant(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 

--- a/pkg/resources/warehouse_test.go
+++ b/pkg/resources/warehouse_test.go
@@ -19,20 +19,20 @@ func TestWarehouse(t *testing.T) {
 }
 
 func TestWarehouseCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	in := map[string]interface{}{
 		"name":    "good_name",
 		"comment": "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Warehouse().Schema, in)
-	a.NotNil(d)
+	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE WAREHOUSE "good_name" COMMENT='great comment`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadWarehouse(mock)
 		err := resources.CreateWarehouse(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }
 
@@ -42,26 +42,26 @@ func expectReadWarehouse(mock sqlmock.Sqlmock) {
 }
 
 func TestWarehouseRead(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := warehouse(t, "good_name", map[string]interface{}{"name": "good_name"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadWarehouse(mock)
 		err := resources.ReadWarehouse(d, db)
-		a.NoError(err)
-		a.Equal("mock comment", d.Get("comment").(string))
+		r.NoError(err)
+		r.Equal("mock comment", d.Get("comment").(string))
 	})
 }
 
 func TestWarehouseDelete(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
 	d := warehouse(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP WAREHOUSE "drop_it"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteWarehouse(d, db)
-		a.NoError(err)
+		r.NoError(err)
 	})
 }

--- a/pkg/resources/warehouse_test.go
+++ b/pkg/resources/warehouse_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +19,7 @@ func TestWarehouse(t *testing.T) {
 }
 
 func TestWarehouseCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	in := map[string]interface{}{
 		"name":    "good_name",
@@ -43,7 +42,7 @@ func expectReadWarehouse(mock sqlmock.Sqlmock) {
 }
 
 func TestWarehouseRead(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := warehouse(t, "good_name", map[string]interface{}{"name": "good_name"})
 
@@ -56,7 +55,7 @@ func TestWarehouseRead(t *testing.T) {
 }
 
 func TestWarehouseDelete(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	d := warehouse(t, "drop_it", map[string]interface{}{"name": "drop_it"})
 

--- a/pkg/snowflake/database_test.go
+++ b/pkg/snowflake/database_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDatabase(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	db := snowflake.Database("db1")
 	a.NotNil(db)
 
@@ -42,14 +42,14 @@ func TestDatabase(t *testing.T) {
 }
 
 func TestDatabaseCreateFromShare(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	db := snowflake.DatabaseFromShare("db1", "abc123", "share1")
 	q := db.Create()
 	a.Equal(`CREATE DATABASE "db1" FROM SHARE "abc123"."share1"`, q)
 }
 
 func TestDatabaseCreateFromDatabase(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	db := snowflake.DatabaseFromDatabase("db1", "abc123")
 	q := db.Create()
 	a.Equal(`CREATE DATABASE "db1" CLONE "abc123"`, q)

--- a/pkg/snowflake/database_test.go
+++ b/pkg/snowflake/database_test.go
@@ -8,49 +8,49 @@ import (
 )
 
 func TestDatabase(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	db := snowflake.Database("db1")
-	a.NotNil(db)
+	r.NotNil(db)
 
 	q := db.Show()
-	a.Equal("SHOW DATABASES LIKE 'db1'", q)
+	r.Equal("SHOW DATABASES LIKE 'db1'", q)
 
 	q = db.Drop()
-	a.Equal(`DROP DATABASE "db1"`, q)
+	r.Equal(`DROP DATABASE "db1"`, q)
 
 	q = db.Rename("db2")
-	a.Equal(`ALTER DATABASE "db1" RENAME TO "db2"`, q)
+	r.Equal(`ALTER DATABASE "db1" RENAME TO "db2"`, q)
 
 	ab := db.Alter()
-	a.NotNil(ab)
+	r.NotNil(ab)
 
 	ab.SetString(`foo`, `bar`)
 	q = ab.Statement()
 
-	a.Equal(`ALTER DATABASE "db1" SET FOO='bar'`, q)
+	r.Equal(`ALTER DATABASE "db1" SET FOO='bar'`, q)
 
 	ab.SetBool(`bam`, false)
 	q = ab.Statement()
 
-	a.Equal(`ALTER DATABASE "db1" SET FOO='bar' BAM=false`, q)
+	r.Equal(`ALTER DATABASE "db1" SET FOO='bar' BAM=false`, q)
 
 	c := db.Create()
 	c.SetString("foo", "bar")
 	c.SetBool("bam", false)
 	q = c.Statement()
-	a.Equal(`CREATE DATABASE "db1" FOO='bar' BAM=false`, q)
+	r.Equal(`CREATE DATABASE "db1" FOO='bar' BAM=false`, q)
 }
 
 func TestDatabaseCreateFromShare(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	db := snowflake.DatabaseFromShare("db1", "abc123", "share1")
 	q := db.Create()
-	a.Equal(`CREATE DATABASE "db1" FROM SHARE "abc123"."share1"`, q)
+	r.Equal(`CREATE DATABASE "db1" FROM SHARE "abc123"."share1"`, q)
 }
 
 func TestDatabaseCreateFromDatabase(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	db := snowflake.DatabaseFromDatabase("db1", "abc123")
 	q := db.Create()
-	a.Equal(`CREATE DATABASE "db1" CLONE "abc123"`, q)
+	r.Equal(`CREATE DATABASE "db1" CLONE "abc123"`, q)
 }

--- a/pkg/snowflake/escaping_test.go
+++ b/pkg/snowflake/escaping_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestEscapeString(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 
-	a.Equal(`\'`, snowflake.EscapeString(`'`))
-	a.Equal(`\\\'`, snowflake.EscapeString(`\'`))
+	r.Equal(`\'`, snowflake.EscapeString(`'`))
+	r.Equal(`\\\'`, snowflake.EscapeString(`\'`))
 }

--- a/pkg/snowflake/escaping_test.go
+++ b/pkg/snowflake/escaping_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEscapeString(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 
 	a.Equal(`\'`, snowflake.EscapeString(`'`))
 	a.Equal(`\\\'`, snowflake.EscapeString(`\'`))

--- a/pkg/snowflake/future_grant_test.go
+++ b/pkg/snowflake/future_grant_test.go
@@ -8,33 +8,33 @@ import (
 )
 
 func TestFutureSchemaGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	fvg := snowflake.FutureSchemaGrant("test_db")
-	a.Equal(fvg.Name(), "test_db")
+	r.Equal(fvg.Name(), "test_db")
 
 	s := fvg.Show()
-	a.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
+	r.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
 
 	s = fvg.Role("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" TO ROLE "bob"`, s)
+	r.Equal(`GRANT USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" TO ROLE "bob"`, s)
 
 	s = fvg.Role("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" FROM ROLE "bob"`, s)
 }
 
 func TestFutureTableGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	fvg := snowflake.FutureTableGrant("test_db", "PUBLIC")
-	a.Equal(fvg.Name(), "PUBLIC")
+	r.Equal(fvg.Name(), "PUBLIC")
 
 	s := fvg.Show()
-	a.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
+	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
 
 	s = fvg.Role("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
+	r.Equal(`GRANT USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
 	s = fvg.Role("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
 
 	b := require.New(t)
 	fvgd := snowflake.FutureTableGrant("test_db", "")
@@ -51,18 +51,18 @@ func TestFutureTableGrant(t *testing.T) {
 }
 
 func TestFutureViewGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	fvg := snowflake.FutureViewGrant("test_db", "PUBLIC")
-	a.Equal(fvg.Name(), "PUBLIC")
+	r.Equal(fvg.Name(), "PUBLIC")
 
 	s := fvg.Show()
-	a.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
+	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
 
 	s = fvg.Role("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
+	r.Equal(`GRANT USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
 	s = fvg.Role("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
 
 	b := require.New(t)
 	fvgd := snowflake.FutureViewGrant("test_db", "")
@@ -79,16 +79,16 @@ func TestFutureViewGrant(t *testing.T) {
 }
 
 func TestShowFutureGrantsInSchema(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := snowflake.FutureTableGrant("test_db", "PUBLIC").Role("testRole").Show()
-	a.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
+	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
 
 	s = snowflake.FutureTableGrant("test_db", "").Role("testRole").Show()
-	a.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
+	r.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
 
 	s = snowflake.FutureViewGrant("test_db", "PUBLIC").Role("testRole").Show()
-	a.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
+	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
 
 	s = snowflake.FutureViewGrant("test_db", "").Role("testRole").Show()
-	a.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
+	r.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
 }

--- a/pkg/snowflake/future_grant_test.go
+++ b/pkg/snowflake/future_grant_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFutureSchemaGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	fvg := snowflake.FutureSchemaGrant("test_db")
 	a.Equal(fvg.Name(), "test_db")
 
@@ -23,7 +23,7 @@ func TestFutureSchemaGrant(t *testing.T) {
 }
 
 func TestFutureTableGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	fvg := snowflake.FutureTableGrant("test_db", "PUBLIC")
 	a.Equal(fvg.Name(), "PUBLIC")
 
@@ -36,7 +36,7 @@ func TestFutureTableGrant(t *testing.T) {
 	s = fvg.Role("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
 
-	b := assert.New(t)
+	b := require.New(t)
 	fvgd := snowflake.FutureTableGrant("test_db", "")
 	b.Equal(fvgd.Name(), "test_db")
 
@@ -51,7 +51,7 @@ func TestFutureTableGrant(t *testing.T) {
 }
 
 func TestFutureViewGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	fvg := snowflake.FutureViewGrant("test_db", "PUBLIC")
 	a.Equal(fvg.Name(), "PUBLIC")
 
@@ -64,7 +64,7 @@ func TestFutureViewGrant(t *testing.T) {
 	s = fvg.Role("bob").Revoke("USAGE")
 	a.Equal(`REVOKE USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
 
-	b := assert.New(t)
+	b := require.New(t)
 	fvgd := snowflake.FutureViewGrant("test_db", "")
 	b.Equal(fvgd.Name(), "test_db")
 
@@ -79,7 +79,7 @@ func TestFutureViewGrant(t *testing.T) {
 }
 
 func TestShowFutureGrantsInSchema(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := snowflake.FutureTableGrant("test_db", "PUBLIC").Role("testRole").Show()
 	a.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
 

--- a/pkg/snowflake/grant_test.go
+++ b/pkg/snowflake/grant_test.go
@@ -8,152 +8,152 @@ import (
 )
 
 func TestDatabaseGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	dg := snowflake.DatabaseGrant("testDB")
-	a.Equal(dg.Name(), "testDB")
+	r.Equal(dg.Name(), "testDB")
 
 	s := dg.Show()
-	a.Equal(`SHOW GRANTS ON DATABASE "testDB"`, s)
+	r.Equal(`SHOW GRANTS ON DATABASE "testDB"`, s)
 
 	s = dg.Role("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON DATABASE "testDB" TO ROLE "bob"`, s)
+	r.Equal(`GRANT USAGE ON DATABASE "testDB" TO ROLE "bob"`, s)
 
 	s = dg.Role("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON DATABASE "testDB" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON DATABASE "testDB" FROM ROLE "bob"`, s)
 
 	s = dg.Role("bob").Grant("OWNERSHIP")
-	a.Equal(`GRANT OWNERSHIP ON DATABASE "testDB" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+	r.Equal(`GRANT OWNERSHIP ON DATABASE "testDB" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	s = dg.Share("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON DATABASE "testDB" TO SHARE "bob"`, s)
+	r.Equal(`GRANT USAGE ON DATABASE "testDB" TO SHARE "bob"`, s)
 
 	s = dg.Share("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON DATABASE "testDB" FROM SHARE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON DATABASE "testDB" FROM SHARE "bob"`, s)
 }
 
 func TestSchemaGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	sg := snowflake.SchemaGrant("test_db", "testSchema")
-	a.Equal(sg.Name(), "testSchema")
+	r.Equal(sg.Name(), "testSchema")
 
 	s := sg.Show()
-	a.Equal(`SHOW GRANTS ON SCHEMA "test_db"."testSchema"`, s)
+	r.Equal(`SHOW GRANTS ON SCHEMA "test_db"."testSchema"`, s)
 
 	s = sg.Role("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON SCHEMA "test_db"."testSchema" TO ROLE "bob"`, s)
+	r.Equal(`GRANT USAGE ON SCHEMA "test_db"."testSchema" TO ROLE "bob"`, s)
 
 	s = sg.Role("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM ROLE "bob"`, s)
 
 	s = sg.Share("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON SCHEMA "test_db"."testSchema" TO SHARE "bob"`, s)
+	r.Equal(`GRANT USAGE ON SCHEMA "test_db"."testSchema" TO SHARE "bob"`, s)
 
 	s = sg.Share("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM SHARE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM SHARE "bob"`, s)
 
 	s = sg.Role("bob").Grant("OWNERSHIP")
-	a.Equal(`GRANT OWNERSHIP ON SCHEMA "test_db"."testSchema" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+	r.Equal(`GRANT OWNERSHIP ON SCHEMA "test_db"."testSchema" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 }
 
 func TestViewGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	vg := snowflake.ViewGrant("test_db", "PUBLIC", "testView")
-	a.Equal(vg.Name(), "testView")
+	r.Equal(vg.Name(), "testView")
 
 	s := vg.Show()
-	a.Equal(`SHOW GRANTS ON VIEW "test_db"."PUBLIC"."testView"`, s)
+	r.Equal(`SHOW GRANTS ON VIEW "test_db"."PUBLIC"."testView"`, s)
 
 	s = vg.Role("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob"`, s)
+	r.Equal(`GRANT USAGE ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob"`, s)
 
 	s = vg.Role("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM ROLE "bob"`, s)
 
 	s = vg.Share("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON VIEW "test_db"."PUBLIC"."testView" TO SHARE "bob"`, s)
+	r.Equal(`GRANT USAGE ON VIEW "test_db"."PUBLIC"."testView" TO SHARE "bob"`, s)
 
 	s = vg.Share("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM SHARE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM SHARE "bob"`, s)
 
 	s = vg.Role("bob").Grant("OWNERSHIP")
-	a.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+	r.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 }
 
 func TestWarehouseGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	wg := snowflake.WarehouseGrant("test_warehouse")
-	a.Equal(wg.Name(), "test_warehouse")
+	r.Equal(wg.Name(), "test_warehouse")
 
 	s := wg.Show()
-	a.Equal(`SHOW GRANTS ON WAREHOUSE "test_warehouse"`, s)
+	r.Equal(`SHOW GRANTS ON WAREHOUSE "test_warehouse"`, s)
 
 	s = wg.Role("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON WAREHOUSE "test_warehouse" TO ROLE "bob"`, s)
+	r.Equal(`GRANT USAGE ON WAREHOUSE "test_warehouse" TO ROLE "bob"`, s)
 
 	s = wg.Role("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON WAREHOUSE "test_warehouse" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON WAREHOUSE "test_warehouse" FROM ROLE "bob"`, s)
 
 	s = wg.Role("bob").Grant("OWNERSHIP")
-	a.Equal(`GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+	r.Equal(`GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 }
 
 func TestAccountGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	wg := snowflake.AccountGrant()
-	a.Equal(wg.Name(), "")
+	r.Equal(wg.Name(), "")
 
 	// There's an extra space after "ACCOUNT"
 	//  because accounts don't have names
 
 	s := wg.Show()
-	a.Equal("SHOW GRANTS ON ACCOUNT ", s)
+	r.Equal("SHOW GRANTS ON ACCOUNT ", s)
 
 	s = wg.Role("bob").Grant("MANAGE GRANTS")
-	a.Equal(`GRANT MANAGE GRANTS ON ACCOUNT  TO ROLE "bob"`, s)
+	r.Equal(`GRANT MANAGE GRANTS ON ACCOUNT  TO ROLE "bob"`, s)
 
 	s = wg.Role("bob").Revoke("MONITOR USAGE")
-	a.Equal(`REVOKE MONITOR USAGE ON ACCOUNT  FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE MONITOR USAGE ON ACCOUNT  FROM ROLE "bob"`, s)
 }
 
 func TestIntegrationGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	wg := snowflake.IntegrationGrant("test_integration")
-	a.Equal(wg.Name(), "test_integration")
+	r.Equal(wg.Name(), "test_integration")
 
 	s := wg.Show()
-	a.Equal(`SHOW GRANTS ON INTEGRATION "test_integration"`, s)
+	r.Equal(`SHOW GRANTS ON INTEGRATION "test_integration"`, s)
 
 	s = wg.Role("bob").Grant("USAGE")
-	a.Equal(`GRANT USAGE ON INTEGRATION "test_integration" TO ROLE "bob"`, s)
+	r.Equal(`GRANT USAGE ON INTEGRATION "test_integration" TO ROLE "bob"`, s)
 
 	s = wg.Role("bob").Revoke("USAGE")
-	a.Equal(`REVOKE USAGE ON INTEGRATION "test_integration" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE USAGE ON INTEGRATION "test_integration" FROM ROLE "bob"`, s)
 
 	s = wg.Role("bob").Grant("OWNERSHIP")
-	a.Equal(`GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+	r.Equal(`GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 }
 
 func TestResourceMonitorGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	wg := snowflake.ResourceMonitorGrant("test_monitor")
-	a.Equal(wg.Name(), "test_monitor")
+	r.Equal(wg.Name(), "test_monitor")
 
 	s := wg.Show()
-	a.Equal(`SHOW GRANTS ON RESOURCE MONITOR "test_monitor"`, s)
+	r.Equal(`SHOW GRANTS ON RESOURCE MONITOR "test_monitor"`, s)
 
 	s = wg.Role("bob").Grant("MONITOR")
-	a.Equal(`GRANT MONITOR ON RESOURCE MONITOR "test_monitor" TO ROLE "bob"`, s)
+	r.Equal(`GRANT MONITOR ON RESOURCE MONITOR "test_monitor" TO ROLE "bob"`, s)
 
 	s = wg.Role("bob").Revoke("MODIFY")
-	a.Equal(`REVOKE MODIFY ON RESOURCE MONITOR "test_monitor" FROM ROLE "bob"`, s)
+	r.Equal(`REVOKE MODIFY ON RESOURCE MONITOR "test_monitor" FROM ROLE "bob"`, s)
 }
 
 func TestShowGrantsOf(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := snowflake.ViewGrant("test_db", "PUBLIC", "testView").Role("testRole").Show()
-	a.Equal(`SHOW GRANTS OF ROLE "testRole"`, s)
+	r.Equal(`SHOW GRANTS OF ROLE "testRole"`, s)
 
 	s = snowflake.ViewGrant("test_db", "PUBLIC", "testView").Share("testShare").Show()
-	a.Equal(`SHOW GRANTS OF SHARE "testShare"`, s)
+	r.Equal(`SHOW GRANTS OF SHARE "testShare"`, s)
 }

--- a/pkg/snowflake/grant_test.go
+++ b/pkg/snowflake/grant_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDatabaseGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	dg := snowflake.DatabaseGrant("testDB")
 	a.Equal(dg.Name(), "testDB")
 
@@ -32,7 +32,7 @@ func TestDatabaseGrant(t *testing.T) {
 }
 
 func TestSchemaGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	sg := snowflake.SchemaGrant("test_db", "testSchema")
 	a.Equal(sg.Name(), "testSchema")
 
@@ -56,7 +56,7 @@ func TestSchemaGrant(t *testing.T) {
 }
 
 func TestViewGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	vg := snowflake.ViewGrant("test_db", "PUBLIC", "testView")
 	a.Equal(vg.Name(), "testView")
 
@@ -80,7 +80,7 @@ func TestViewGrant(t *testing.T) {
 }
 
 func TestWarehouseGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	wg := snowflake.WarehouseGrant("test_warehouse")
 	a.Equal(wg.Name(), "test_warehouse")
 
@@ -99,7 +99,7 @@ func TestWarehouseGrant(t *testing.T) {
 }
 
 func TestAccountGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	wg := snowflake.AccountGrant()
 	a.Equal(wg.Name(), "")
 
@@ -117,7 +117,7 @@ func TestAccountGrant(t *testing.T) {
 }
 
 func TestIntegrationGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	wg := snowflake.IntegrationGrant("test_integration")
 	a.Equal(wg.Name(), "test_integration")
 
@@ -135,7 +135,7 @@ func TestIntegrationGrant(t *testing.T) {
 }
 
 func TestResourceMonitorGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	wg := snowflake.ResourceMonitorGrant("test_monitor")
 	a.Equal(wg.Name(), "test_monitor")
 
@@ -150,7 +150,7 @@ func TestResourceMonitorGrant(t *testing.T) {
 }
 
 func TestShowGrantsOf(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := snowflake.ViewGrant("test_db", "PUBLIC", "testView").Role("testRole").Show()
 	a.Equal(`SHOW GRANTS OF ROLE "testRole"`, s)
 

--- a/pkg/snowflake/managed_account_test.go
+++ b/pkg/snowflake/managed_account_test.go
@@ -8,19 +8,19 @@ import (
 )
 
 func TestManagedAccount(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	u := snowflake.ManagedAccount("managedaccount1")
-	a.NotNil(u)
+	r.NotNil(u)
 
 	q := u.Show()
-	a.Equal("SHOW MANAGED ACCOUNTS LIKE 'managedaccount1'", q)
+	r.Equal("SHOW MANAGED ACCOUNTS LIKE 'managedaccount1'", q)
 
 	q = u.Drop()
-	a.Equal(`DROP MANAGED ACCOUNT "managedaccount1"`, q)
+	r.Equal(`DROP MANAGED ACCOUNT "managedaccount1"`, q)
 
 	c := u.Create()
 	c.SetString("foo", "bar")
 	c.SetBool("bam", false)
 	q = c.Statement()
-	a.Equal(`CREATE MANAGED ACCOUNT "managedaccount1" FOO='bar' BAM=false`, q)
+	r.Equal(`CREATE MANAGED ACCOUNT "managedaccount1" FOO='bar' BAM=false`, q)
 }

--- a/pkg/snowflake/managed_account_test.go
+++ b/pkg/snowflake/managed_account_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManagedAccount(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	u := snowflake.ManagedAccount("managedaccount1")
 	a.NotNil(u)
 

--- a/pkg/snowflake/pipe_test.go
+++ b/pkg/snowflake/pipe_test.go
@@ -7,42 +7,42 @@ import (
 )
 
 func TestPipeCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	a.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_pipe"`)
+	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_pipe"`)
 
-	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe"`)
+	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe"`)
 
 	s.WithAutoIngest()
-	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE`)
+	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE`)
 
 	s.WithComment("Yeehaw")
-	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw'`)
+	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw'`)
 
 	s.WithCopyStatement("test copy statement ")
-	a.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw' AS test copy statement `)
+	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw' AS test copy statement `)
 }
 
 func TestPipeChangeComment(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	a.Equal(s.ChangeComment("worst pipe ever"), `ALTER PIPE "test_db"."test_schema"."test_pipe" SET COMMENT = 'worst pipe ever'`)
+	r.Equal(s.ChangeComment("worst pipe ever"), `ALTER PIPE "test_db"."test_schema"."test_pipe" SET COMMENT = 'worst pipe ever'`)
 }
 
 func TestPipeRemoveComment(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	a.Equal(s.RemoveComment(), `ALTER PIPE "test_db"."test_schema"."test_pipe" UNSET COMMENT`)
+	r.Equal(s.RemoveComment(), `ALTER PIPE "test_db"."test_schema"."test_pipe" UNSET COMMENT`)
 }
 
 func TestPipeDrop(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	a.Equal(s.Drop(), `DROP PIPE "test_db"."test_schema"."test_pipe"`)
+	r.Equal(s.Drop(), `DROP PIPE "test_db"."test_schema"."test_pipe"`)
 }
 
 func TestPipeShow(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	a.Equal(s.Show(), `SHOW PIPES LIKE 'test_pipe' IN DATABASE "test_db"`)
+	r.Equal(s.Show(), `SHOW PIPES LIKE 'test_pipe' IN DATABASE "test_db"`)
 }

--- a/pkg/snowflake/pipe_test.go
+++ b/pkg/snowflake/pipe_test.go
@@ -3,11 +3,11 @@ package snowflake
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPipeCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
 	a.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_pipe"`)
 
@@ -24,25 +24,25 @@ func TestPipeCreate(t *testing.T) {
 }
 
 func TestPipeChangeComment(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
 	a.Equal(s.ChangeComment("worst pipe ever"), `ALTER PIPE "test_db"."test_schema"."test_pipe" SET COMMENT = 'worst pipe ever'`)
 }
 
 func TestPipeRemoveComment(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
 	a.Equal(s.RemoveComment(), `ALTER PIPE "test_db"."test_schema"."test_pipe" UNSET COMMENT`)
 }
 
 func TestPipeDrop(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
 	a.Equal(s.Drop(), `DROP PIPE "test_db"."test_schema"."test_pipe"`)
 }
 
 func TestPipeShow(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
 	a.Equal(s.Show(), `SHOW PIPES LIKE 'test_pipe' IN DATABASE "test_db"`)
 }

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -8,23 +8,23 @@ import (
 )
 
 func TestResourceMonitor(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	rm := snowflake.ResourceMonitor("resource_monitor")
-	a.NotNil(rm)
+	r.NotNil(rm)
 
 	q := rm.Show()
-	a.Equal(`SHOW RESOURCE MONITORS LIKE 'resource_monitor'`, q)
+	r.Equal(`SHOW RESOURCE MONITORS LIKE 'resource_monitor'`, q)
 
 	q = rm.Create().Statement()
-	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor"`, q)
+	r.Equal(`CREATE RESOURCE MONITOR "resource_monitor"`, q)
 
 	q = rm.Drop()
-	a.Equal(`DROP RESOURCE MONITOR "resource_monitor"`, q)
+	r.Equal(`DROP RESOURCE MONITOR "resource_monitor"`, q)
 
 	ab := rm.Alter()
 	ab.SetFloat("credit_quota", 66.6)
 	q = ab.Statement()
-	a.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66.60`, q)
+	r.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66.60`, q)
 
 	cb := snowflake.ResourceMonitor("resource_monitor").Create()
 	cb.NotifyAt(80).NotifyAt(90).SuspendAt(95).SuspendImmediatelyAt(100)
@@ -32,10 +32,10 @@ func TestResourceMonitor(t *testing.T) {
 
 	cb.SetFloat("credit_quota", 666.66666666)
 	q = cb.Statement()
-	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.67 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+	r.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.67 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 
 	// Check if credit quota can be parsed correctly to float if given an integer
 	cb.SetFloat("credit_quota", 666)
 	q = cb.Statement()
-	a.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.00 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+	r.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666.00 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 }

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResourceMonitor(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	rm := snowflake.ResourceMonitor("resource_monitor")
 	a.NotNil(rm)
 

--- a/pkg/snowflake/role_grant_test.go
+++ b/pkg/snowflake/role_grant_test.go
@@ -8,19 +8,19 @@ import (
 )
 
 func TestRoleGrant(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	rg := snowflake.RoleGrant("role1")
 
 	u := rg.User("user1").Grant()
-	a.Equal(`GRANT ROLE "role1" TO USER "user1"`, u)
+	r.Equal(`GRANT ROLE "role1" TO USER "user1"`, u)
 
-	r := rg.Role("role2").Grant()
-	a.Equal(`GRANT ROLE "role1" TO ROLE "role2"`, r)
+	role := rg.Role("role2").Grant()
+	r.Equal(`GRANT ROLE "role1" TO ROLE "role2"`, role)
 
 	u2 := rg.User("user1").Revoke()
-	a.Equal(`REVOKE ROLE "role1" FROM USER "user1"`, u2)
+	r.Equal(`REVOKE ROLE "role1" FROM USER "user1"`, u2)
 
 	r2 := rg.Role("role2").Revoke()
-	a.Equal(`REVOKE ROLE "role1" FROM ROLE "role2"`, r2)
+	r.Equal(`REVOKE ROLE "role1" FROM ROLE "role2"`, r2)
 
 }

--- a/pkg/snowflake/role_grant_test.go
+++ b/pkg/snowflake/role_grant_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoleGrant(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	rg := snowflake.RoleGrant("role1")
 
 	u := rg.User("user1").Grant()

--- a/pkg/snowflake/schema_test.go
+++ b/pkg/snowflake/schema_test.go
@@ -3,11 +3,11 @@ package snowflake
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSchemaCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.QualifiedName(), `"test"`)
 
@@ -30,73 +30,73 @@ func TestSchemaCreate(t *testing.T) {
 }
 
 func TestSchemaRename(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.Rename("bob"), `ALTER SCHEMA "test" RENAME TO "bob"`)
 }
 
 func TestSchemaSwap(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.Swap("bob"), `ALTER SCHEMA "test" SWAP WITH "bob"`)
 }
 
 func TestSchemaChangeComment(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.ChangeComment("worst schema ever"), `ALTER SCHEMA "test" SET COMMENT = 'worst schema ever'`)
 }
 
 func TestSchemaRemoveComment(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.RemoveComment(), `ALTER SCHEMA "test" UNSET COMMENT`)
 }
 
 func TestSchemaChangeDataRetentionDays(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.ChangeDataRetentionDays(22), `ALTER SCHEMA "test" SET DATA_RETENTION_TIME_IN_DAYS = 22`)
 }
 
 func TestSchemaRemoveDataRetentionDays(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.RemoveDataRetentionDays(), `ALTER SCHEMA "test" UNSET DATA_RETENTION_TIME_IN_DAYS`)
 }
 
 func TestSchemaManage(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.Manage(), `ALTER SCHEMA "test" ENABLE MANAGED ACCESS`)
 }
 
 func TestSchemaUnmanage(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.Unmanage(), `ALTER SCHEMA "test" DISABLE MANAGED ACCESS`)
 }
 
 func TestSchemaDrop(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.Drop(), `DROP SCHEMA "test"`)
 }
 
 func TestSchemaUndrop(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.Undrop(), `UNDROP SCHEMA "test"`)
 }
 
 func TestSchemaUse(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.Use(), `USE SCHEMA "test"`)
 }
 
 func TestSchemaShow(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Schema("test")
 	a.Equal(s.Show(), `SHOW SCHEMAS LIKE 'test'`)
 

--- a/pkg/snowflake/schema_test.go
+++ b/pkg/snowflake/schema_test.go
@@ -7,99 +7,99 @@ import (
 )
 
 func TestSchemaCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.QualifiedName(), `"test"`)
+	r.Equal(s.QualifiedName(), `"test"`)
 
 	s.WithDB("db")
-	a.Equal(s.QualifiedName(), `"db"."test"`)
+	r.Equal(s.QualifiedName(), `"db"."test"`)
 
-	a.Equal(s.Create(), `CREATE SCHEMA "db"."test"`)
+	r.Equal(s.Create(), `CREATE SCHEMA "db"."test"`)
 
 	s.Transient()
-	a.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test"`)
+	r.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test"`)
 
 	s.Managed()
-	a.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS`)
+	r.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS`)
 
 	s.WithDataRetentionDays(7)
-	a.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS DATA_RETENTION_TIME_IN_DAYS = 7`)
+	r.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS DATA_RETENTION_TIME_IN_DAYS = 7`)
 
 	s.WithComment("Yeehaw")
-	a.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS DATA_RETENTION_TIME_IN_DAYS = 7 COMMENT = 'Yeehaw'`)
+	r.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS DATA_RETENTION_TIME_IN_DAYS = 7 COMMENT = 'Yeehaw'`)
 }
 
 func TestSchemaRename(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.Rename("bob"), `ALTER SCHEMA "test" RENAME TO "bob"`)
+	r.Equal(s.Rename("bob"), `ALTER SCHEMA "test" RENAME TO "bob"`)
 }
 
 func TestSchemaSwap(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.Swap("bob"), `ALTER SCHEMA "test" SWAP WITH "bob"`)
+	r.Equal(s.Swap("bob"), `ALTER SCHEMA "test" SWAP WITH "bob"`)
 }
 
 func TestSchemaChangeComment(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.ChangeComment("worst schema ever"), `ALTER SCHEMA "test" SET COMMENT = 'worst schema ever'`)
+	r.Equal(s.ChangeComment("worst schema ever"), `ALTER SCHEMA "test" SET COMMENT = 'worst schema ever'`)
 }
 
 func TestSchemaRemoveComment(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.RemoveComment(), `ALTER SCHEMA "test" UNSET COMMENT`)
+	r.Equal(s.RemoveComment(), `ALTER SCHEMA "test" UNSET COMMENT`)
 }
 
 func TestSchemaChangeDataRetentionDays(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.ChangeDataRetentionDays(22), `ALTER SCHEMA "test" SET DATA_RETENTION_TIME_IN_DAYS = 22`)
+	r.Equal(s.ChangeDataRetentionDays(22), `ALTER SCHEMA "test" SET DATA_RETENTION_TIME_IN_DAYS = 22`)
 }
 
 func TestSchemaRemoveDataRetentionDays(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.RemoveDataRetentionDays(), `ALTER SCHEMA "test" UNSET DATA_RETENTION_TIME_IN_DAYS`)
+	r.Equal(s.RemoveDataRetentionDays(), `ALTER SCHEMA "test" UNSET DATA_RETENTION_TIME_IN_DAYS`)
 }
 
 func TestSchemaManage(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.Manage(), `ALTER SCHEMA "test" ENABLE MANAGED ACCESS`)
+	r.Equal(s.Manage(), `ALTER SCHEMA "test" ENABLE MANAGED ACCESS`)
 }
 
 func TestSchemaUnmanage(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.Unmanage(), `ALTER SCHEMA "test" DISABLE MANAGED ACCESS`)
+	r.Equal(s.Unmanage(), `ALTER SCHEMA "test" DISABLE MANAGED ACCESS`)
 }
 
 func TestSchemaDrop(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.Drop(), `DROP SCHEMA "test"`)
+	r.Equal(s.Drop(), `DROP SCHEMA "test"`)
 }
 
 func TestSchemaUndrop(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.Undrop(), `UNDROP SCHEMA "test"`)
+	r.Equal(s.Undrop(), `UNDROP SCHEMA "test"`)
 }
 
 func TestSchemaUse(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.Use(), `USE SCHEMA "test"`)
+	r.Equal(s.Use(), `USE SCHEMA "test"`)
 }
 
 func TestSchemaShow(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Schema("test")
-	a.Equal(s.Show(), `SHOW SCHEMAS LIKE 'test'`)
+	r.Equal(s.Show(), `SHOW SCHEMAS LIKE 'test'`)
 
 	s.WithDB("db")
-	a.Equal(s.Show(), `SHOW SCHEMAS LIKE 'test' IN DATABASE "db"`)
+	r.Equal(s.Show(), `SHOW SCHEMAS LIKE 'test' IN DATABASE "db"`)
 }

--- a/pkg/snowflake/share_test.go
+++ b/pkg/snowflake/share_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShare(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := snowflake.Share("share1")
 	a.NotNil(s)
 

--- a/pkg/snowflake/share_test.go
+++ b/pkg/snowflake/share_test.go
@@ -8,35 +8,35 @@ import (
 )
 
 func TestShare(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := snowflake.Share("share1")
-	a.NotNil(s)
+	r.NotNil(s)
 
 	q := s.Show()
-	a.Equal("SHOW SHARES LIKE 'share1'", q)
+	r.Equal("SHOW SHARES LIKE 'share1'", q)
 
 	q = s.Drop()
-	a.Equal(`DROP SHARE "share1"`, q)
+	r.Equal(`DROP SHARE "share1"`, q)
 
 	q = s.Rename("share2")
-	a.Equal(`ALTER SHARE "share1" RENAME TO "share2"`, q)
+	r.Equal(`ALTER SHARE "share1" RENAME TO "share2"`, q)
 
 	ab := s.Alter()
-	a.NotNil(ab)
+	r.NotNil(ab)
 
 	ab.SetString(`foo`, `bar`)
 	q = ab.Statement()
 
-	a.Equal(`ALTER SHARE "share1" SET FOO='bar'`, q)
+	r.Equal(`ALTER SHARE "share1" SET FOO='bar'`, q)
 
 	ab.SetBool(`bam`, false)
 	q = ab.Statement()
 
-	a.Equal(`ALTER SHARE "share1" SET FOO='bar' BAM=false`, q)
+	r.Equal(`ALTER SHARE "share1" SET FOO='bar' BAM=false`, q)
 
 	c := s.Create()
 	c.SetString("foo", "bar")
 	c.SetBool("bam", false)
 	q = c.Statement()
-	a.Equal(`CREATE SHARE "share1" FOO='bar' BAM=false`, q)
+	r.Equal(`CREATE SHARE "share1" FOO='bar' BAM=false`, q)
 }

--- a/pkg/snowflake/stage_test.go
+++ b/pkg/snowflake/stage_test.go
@@ -7,102 +7,102 @@ import (
 )
 
 func TestStageCreate(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_stage"`)
+	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_stage"`)
 
-	a.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage"`)
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage"`)
 
 	s.WithCredentials("aws_role='arn:aws:iam::001234567890:role/mysnowflakerole'")
-	a.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`)
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`)
 
 	s.WithEncryption("type='AWS_SSE_KMS' kms_key_id = 'aws/key'")
-	a.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
 
 	s.WithURL("s3://load/encrypted_files/")
-	a.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
 
 	s.WithFileFormat("format_name=my_csv_format")
-	a.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format)`)
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format)`)
 
 	s.WithCopyOptions("on_error='skip_file'")
-	a.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file')`)
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file')`)
 
 	s.WithComment("Yeehaw")
-	a.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') COMMENT = 'Yeehaw'`)
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') COMMENT = 'Yeehaw'`)
 
 	s.WithStorageIntegration("MY_INTEGRATION")
-	a.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') STORAGE_INTEGRATION = MY_INTEGRATION ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') COMMENT = 'Yeehaw'`)
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') STORAGE_INTEGRATION = MY_INTEGRATION ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') COMMENT = 'Yeehaw'`)
 }
 
 func TestStageRename(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.Rename("test_stage2"), `ALTER STAGE "test_db"."test_schema"."test_stage" RENAME TO "test_stage2"`)
+	r.Equal(s.Rename("test_stage2"), `ALTER STAGE "test_db"."test_schema"."test_stage" RENAME TO "test_stage2"`)
 }
 
 func TestStageChangeComment(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.ChangeComment("worst stage ever"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET COMMENT = 'worst stage ever'`)
+	r.Equal(s.ChangeComment("worst stage ever"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET COMMENT = 'worst stage ever'`)
 }
 
 func TestStageChangeURL(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.ChangeURL("s3://load/test/"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET URL = 's3://load/test/'`)
+	r.Equal(s.ChangeURL("s3://load/test/"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET URL = 's3://load/test/'`)
 }
 
 func TestStageChangeFileFormat(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.ChangeFileFormat("format_name=my_csv_format"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (format_name=my_csv_format)`)
+	r.Equal(s.ChangeFileFormat("format_name=my_csv_format"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (format_name=my_csv_format)`)
 }
 
 func TestStageChangeEncryption(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.ChangeEncryption("type='AWS_SSE_KMS' kms_key_id = 'aws/key'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
+	r.Equal(s.ChangeEncryption("type='AWS_SSE_KMS' kms_key_id = 'aws/key'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
 }
 
 func TestStageChangeCredentials(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.ChangeCredentials("aws_role='arn:aws:iam::001234567890:role/mysnowflakerole'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`)
+	r.Equal(s.ChangeCredentials("aws_role='arn:aws:iam::001234567890:role/mysnowflakerole'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`)
 }
 
 func TestStageChangeStorageIntegration(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.ChangeStorageIntegration("MY_INTEGRATION"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET STORAGE_INTEGRATION = MY_INTEGRATION`)
+	r.Equal(s.ChangeStorageIntegration("MY_INTEGRATION"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET STORAGE_INTEGRATION = MY_INTEGRATION`)
 }
 
 func TestStageChangeCopyOptions(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.ChangeCopyOptions("on_error='skip_file'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET COPY_OPTIONS = (on_error='skip_file')`)
+	r.Equal(s.ChangeCopyOptions("on_error='skip_file'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET COPY_OPTIONS = (on_error='skip_file')`)
 }
 
 func TestStageDrop(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.Drop(), `DROP STAGE "test_db"."test_schema"."test_stage"`)
+	r.Equal(s.Drop(), `DROP STAGE "test_db"."test_schema"."test_stage"`)
 }
 
 func TestStageUndrop(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.Undrop(), `UNDROP STAGE "test_db"."test_schema"."test_stage"`)
+	r.Equal(s.Undrop(), `UNDROP STAGE "test_db"."test_schema"."test_stage"`)
 }
 
 func TestStageDescribe(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.Describe(), `DESCRIBE STAGE "test_db"."test_schema"."test_stage"`)
+	r.Equal(s.Describe(), `DESCRIBE STAGE "test_db"."test_schema"."test_stage"`)
 }
 
 func TestStageShow(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	a.Equal(s.Show(), `SHOW STAGES LIKE 'test_stage' IN DATABASE "test_db"`)
+	r.Equal(s.Show(), `SHOW STAGES LIKE 'test_stage' IN DATABASE "test_db"`)
 }

--- a/pkg/snowflake/stage_test.go
+++ b/pkg/snowflake/stage_test.go
@@ -3,11 +3,11 @@ package snowflake
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStageCreate(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_stage"`)
 
@@ -36,73 +36,73 @@ func TestStageCreate(t *testing.T) {
 }
 
 func TestStageRename(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.Rename("test_stage2"), `ALTER STAGE "test_db"."test_schema"."test_stage" RENAME TO "test_stage2"`)
 }
 
 func TestStageChangeComment(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.ChangeComment("worst stage ever"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET COMMENT = 'worst stage ever'`)
 }
 
 func TestStageChangeURL(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.ChangeURL("s3://load/test/"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET URL = 's3://load/test/'`)
 }
 
 func TestStageChangeFileFormat(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.ChangeFileFormat("format_name=my_csv_format"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (format_name=my_csv_format)`)
 }
 
 func TestStageChangeEncryption(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.ChangeEncryption("type='AWS_SSE_KMS' kms_key_id = 'aws/key'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
 }
 
 func TestStageChangeCredentials(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.ChangeCredentials("aws_role='arn:aws:iam::001234567890:role/mysnowflakerole'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`)
 }
 
 func TestStageChangeStorageIntegration(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.ChangeStorageIntegration("MY_INTEGRATION"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET STORAGE_INTEGRATION = MY_INTEGRATION`)
 }
 
 func TestStageChangeCopyOptions(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.ChangeCopyOptions("on_error='skip_file'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET COPY_OPTIONS = (on_error='skip_file')`)
 }
 
 func TestStageDrop(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.Drop(), `DROP STAGE "test_db"."test_schema"."test_stage"`)
 }
 
 func TestStageUndrop(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.Undrop(), `UNDROP STAGE "test_db"."test_schema"."test_stage"`)
 }
 
 func TestStageDescribe(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.Describe(), `DESCRIBE STAGE "test_db"."test_schema"."test_stage"`)
 }
 
 func TestStageShow(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
 	a.Equal(s.Show(), `SHOW STAGES LIKE 'test_stage' IN DATABASE "test_db"`)
 }

--- a/pkg/snowflake/storage_integration_test.go
+++ b/pkg/snowflake/storage_integration_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestStorageIntegration(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	builder := snowflake.StorageIntegration("aws")
-	a.NotNil(builder)
+	r.NotNil(builder)
 
 	q := builder.Show()
-	a.Equal("SHOW STORAGE INTEGRATIONS LIKE 'aws'", q)
+	r.Equal("SHOW STORAGE INTEGRATIONS LIKE 'aws'", q)
 
 	c := builder.Create()
 
@@ -22,5 +22,5 @@ func TestStorageIntegration(t *testing.T) {
 	c.SetBool(`enabled`, true)
 	q = c.Statement()
 
-	a.Equal(`CREATE STORAGE INTEGRATION "aws" TYPE='EXTERNAL_STAGE' STORAGE_ALLOWED_LOCATIONS=('s3://my-bucket/my-path/', 's3://another-bucket/') ENABLED=true`, q)
+	r.Equal(`CREATE STORAGE INTEGRATION "aws" TYPE='EXTERNAL_STAGE' STORAGE_ALLOWED_LOCATIONS=('s3://my-bucket/my-path/', 's3://another-bucket/') ENABLED=true`, q)
 }

--- a/pkg/snowflake/storage_integration_test.go
+++ b/pkg/snowflake/storage_integration_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStorageIntegration(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	builder := snowflake.StorageIntegration("aws")
 	a.NotNil(builder)
 

--- a/pkg/snowflake/user_test.go
+++ b/pkg/snowflake/user_test.go
@@ -8,35 +8,35 @@ import (
 )
 
 func TestUser(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	u := snowflake.User("user1")
-	a.NotNil(u)
+	r.NotNil(u)
 
 	q := u.Show()
-	a.Equal("SHOW USERS LIKE 'user1'", q)
+	r.Equal("SHOW USERS LIKE 'user1'", q)
 
 	q = u.Drop()
-	a.Equal(`DROP USER "user1"`, q)
+	r.Equal(`DROP USER "user1"`, q)
 
 	q = u.Rename("user2")
-	a.Equal(`ALTER USER "user1" RENAME TO "user2"`, q)
+	r.Equal(`ALTER USER "user1" RENAME TO "user2"`, q)
 
 	ab := u.Alter()
-	a.NotNil(ab)
+	r.NotNil(ab)
 
 	ab.SetString(`foo`, `bar`)
 	q = ab.Statement()
 
-	a.Equal(`ALTER USER "user1" SET FOO='bar'`, q)
+	r.Equal(`ALTER USER "user1" SET FOO='bar'`, q)
 
 	ab.SetBool(`bam`, false)
 	q = ab.Statement()
 
-	a.Equal(`ALTER USER "user1" SET FOO='bar' BAM=false`, q)
+	r.Equal(`ALTER USER "user1" SET FOO='bar' BAM=false`, q)
 
 	c := u.Create()
 	c.SetString("foo", "bar")
 	c.SetBool("bam", false)
 	q = c.Statement()
-	a.Equal(`CREATE USER "user1" FOO='bar' BAM=false`, q)
+	r.Equal(`CREATE USER "user1" FOO='bar' BAM=false`, q)
 }

--- a/pkg/snowflake/user_test.go
+++ b/pkg/snowflake/user_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUser(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	u := snowflake.User("user1")
 	a.NotNil(u)
 

--- a/pkg/snowflake/view_test.go
+++ b/pkg/snowflake/view_test.go
@@ -3,11 +3,11 @@ package snowflake
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestView(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	v := View("test")
 	a.NotNil(v)
 	a.False(v.secure)
@@ -62,7 +62,7 @@ func TestView(t *testing.T) {
 }
 
 func TestQualifiedName(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	v := View("view")
 	a.Equal(v.QualifiedName(), `"view"`)
 
@@ -77,7 +77,7 @@ func TestQualifiedName(t *testing.T) {
 }
 
 func TestRename(t *testing.T) {
-	a := assert.New(t)
+	a := require.New(t)
 	v := View("test")
 
 	q := v.Rename("test2")

--- a/pkg/snowflake/view_test.go
+++ b/pkg/snowflake/view_test.go
@@ -7,87 +7,87 @@ import (
 )
 
 func TestView(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	v := View("test")
-	a.NotNil(v)
-	a.False(v.secure)
-	a.Equal(v.QualifiedName(), `"test"`)
+	r.NotNil(v)
+	r.False(v.secure)
+	r.Equal(v.QualifiedName(), `"test"`)
 
 	v.WithSecure()
-	a.True(v.secure)
+	r.True(v.secure)
 
 	v.WithComment("great comment")
-	a.Equal("great comment", v.comment)
+	r.Equal("great comment", v.comment)
 
 	v.WithStatement("SELECT * FROM DUMMY LIMIT 1")
-	a.Equal("SELECT * FROM DUMMY LIMIT 1", v.statement)
+	r.Equal("SELECT * FROM DUMMY LIMIT 1", v.statement)
 
 	v.WithStatement("SELECT * FROM DUMMY WHERE blah = 'blahblah' LIMIT 1")
 
 	q := v.Create()
-	a.Equal(`CREATE SECURE VIEW "test" COMMENT = 'great comment' AS SELECT * FROM DUMMY WHERE blah = 'blahblah' LIMIT 1`, q)
+	r.Equal(`CREATE SECURE VIEW "test" COMMENT = 'great comment' AS SELECT * FROM DUMMY WHERE blah = 'blahblah' LIMIT 1`, q)
 
 	q = v.Secure()
-	a.Equal(`ALTER VIEW "test" SET SECURE`, q)
+	r.Equal(`ALTER VIEW "test" SET SECURE`, q)
 
 	q = v.Unsecure()
-	a.Equal(`ALTER VIEW "test" UNSET SECURE`, q)
+	r.Equal(`ALTER VIEW "test" UNSET SECURE`, q)
 
 	q = v.ChangeComment("bad comment")
-	a.Equal(`ALTER VIEW "test" SET COMMENT = 'bad comment'`, q)
+	r.Equal(`ALTER VIEW "test" SET COMMENT = 'bad comment'`, q)
 
 	q = v.RemoveComment()
-	a.Equal(`ALTER VIEW "test" UNSET COMMENT`, q)
+	r.Equal(`ALTER VIEW "test" UNSET COMMENT`, q)
 
 	q = v.Drop()
-	a.Equal(`DROP VIEW "test"`, q)
+	r.Equal(`DROP VIEW "test"`, q)
 
 	q = v.Show()
-	a.Equal(`SHOW VIEWS LIKE 'test'`, q)
+	r.Equal(`SHOW VIEWS LIKE 'test'`, q)
 
 	v.WithDB("mydb")
-	a.Equal(v.QualifiedName(), `"mydb".."test"`)
+	r.Equal(v.QualifiedName(), `"mydb".."test"`)
 
 	q = v.Create()
-	a.Equal(`CREATE SECURE VIEW "mydb".."test" COMMENT = 'great comment' AS SELECT * FROM DUMMY WHERE blah = 'blahblah' LIMIT 1`, q)
+	r.Equal(`CREATE SECURE VIEW "mydb".."test" COMMENT = 'great comment' AS SELECT * FROM DUMMY WHERE blah = 'blahblah' LIMIT 1`, q)
 
 	q = v.Secure()
-	a.Equal(`ALTER VIEW "mydb".."test" SET SECURE`, q)
+	r.Equal(`ALTER VIEW "mydb".."test" SET SECURE`, q)
 
 	q = v.Show()
-	a.Equal(`SHOW VIEWS LIKE 'test' IN DATABASE "mydb"`, q)
+	r.Equal(`SHOW VIEWS LIKE 'test' IN DATABASE "mydb"`, q)
 
 	q = v.Drop()
-	a.Equal(`DROP VIEW "mydb".."test"`, q)
+	r.Equal(`DROP VIEW "mydb".."test"`, q)
 }
 
 func TestQualifiedName(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	v := View("view")
-	a.Equal(v.QualifiedName(), `"view"`)
+	r.Equal(v.QualifiedName(), `"view"`)
 
 	v = View("view").WithDB("db")
-	a.Equal(v.QualifiedName(), `"db".."view"`)
+	r.Equal(v.QualifiedName(), `"db".."view"`)
 
 	v = View("view").WithSchema("schema")
-	a.Equal(v.QualifiedName(), `"schema"."view"`)
+	r.Equal(v.QualifiedName(), `"schema"."view"`)
 
 	v = View("view").WithDB("db").WithSchema("schema")
-	a.Equal(v.QualifiedName(), `"db"."schema"."view"`)
+	r.Equal(v.QualifiedName(), `"db"."schema"."view"`)
 }
 
 func TestRename(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	v := View("test")
 
 	q := v.Rename("test2")
-	a.Equal(`ALTER VIEW "test" RENAME TO "test2"`, q)
+	r.Equal(`ALTER VIEW "test" RENAME TO "test2"`, q)
 
 	v.WithDB("testDB")
 	q = v.Rename("test3")
-	a.Equal(`ALTER VIEW "testDB".."test2" RENAME TO "testDB".."test3"`, q)
+	r.Equal(`ALTER VIEW "testDB".."test2" RENAME TO "testDB".."test3"`, q)
 
 	v = View("test4").WithSchema("testSchema")
 	q = v.Rename("test5")
-	a.Equal(`ALTER VIEW "testSchema"."test4" RENAME TO "testSchema"."test5"`, q)
+	r.Equal(`ALTER VIEW "testSchema"."test4" RENAME TO "testSchema"."test5"`, q)
 }


### PR DESCRIPTION
Replace all usage of the testify/assert library with its equivalent
testify/require.

testify/assert is commonly misunderstood by developers who expect it to
terminate test runs on the first failure. However that is not what it
does. To halt tests on first failure you need to use testify/require.

## Test Plan
* [ ] acceptance tests

## References
*  https://godoc.org/github.com/stretchr/testify