### PR TITLE
[fix] statement extraction logic for view resource

### DIFF
--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -74,3 +74,24 @@ func TestDiffSuppressStatement(t *testing.T) {
 		})
 	}
 }
+
+func Test_extractViewStatement(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"select", args{"create view asdf as select * from foo"}, "select * from foo"},
+		{"cte", args{"create view jkl as with roles as (SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES) select * from roles;"}, "with roles as (SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES) select * from roles;"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resources.ExtractViewStatement(tt.args.input); got != tt.want {
+				t.Errorf("extractViewStatement() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Support CTE when extracting queries from view definitions.

When a view definition gets returned from snowflake it has the `create
view ...` at the beginning. To compare that sql statement to our state
we need to strip down to the query statement used to define the contents
of the view. Typically that statement starts with SELECT. When Common
Table Expressions (CTEs) are used WITH can start the statement.

As with some other PRs, I would love to have a proper SQL statement
parser here, but for now, just incrementally make our hacks better.

## Test Plan
* [ ] acceptance tests
* [ ] manual tests on our snowflake infra repo

## References
*  https://docs.snowflake.com/en/user-guide/queries-cte.html