### PR TITLE
[fix] statement extraction logic for view resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,11 @@ coverage: ## run the go coverage tool, reading file coverage.out
 .PHONY: coverage
 
 test: fmt deps ## run the tests
-	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+ ifeq (, $(shell which gotest))
+	go test -failfast -cover ./...
+ else
+	gotest -failfast -cover ./...
+ endif
 .PHONY: test
 
 test-acceptance: fmt deps ## runs all tests, including the acceptance tests which create and destroys real resources

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -171,14 +171,27 @@ func ReadView(data *schema.ResourceData, meta interface{}) error {
 
 func ExtractViewStatement(input string) string {
 	// Want to only capture the Select part of the query because before that is the Create part of the view which we no longer care about
-	cleanString := space.ReplaceAllString(input, " ")
-	indexOfSelect := strings.Index(strings.ToUpper(cleanString), " AS SELECT")
-	log.Printf("[DEBUG] indexOfSelect: %d", indexOfSelect)
-	if indexOfSelect == -1 {
-		indexOfSelect = strings.Index(strings.ToUpper(cleanString), " AS WITH")
-		log.Printf("[DEBUG] indexOfSelect: %d", indexOfSelect)
+	targetStrings := []string{
+		" AS SELECT",
+		" AS WITH",
+		" AS (SELECT",
+		" AS (WITH",
 	}
-	return cleanString[indexOfSelect+4:]
+
+	cleanString := space.ReplaceAllString(input, " ")
+
+	var indexOfStatement = -1
+
+	for _, target := range targetStrings {
+		idx := strings.Index(strings.ToUpper(cleanString), target)
+		if idx > 0 {
+			indexOfStatement = idx
+			break
+		}
+	}
+	log.Printf("[DEBUG] indexOfSelect: %d", indexOfStatement)
+
+	return cleanString[indexOfStatement+4:]
 }
 
 // UpdateView implements schema.UpdateFunc

--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -86,6 +86,7 @@ func Test_extractViewStatement(t *testing.T) {
 	}{
 		{"select", args{"create view asdf as select * from foo"}, "select * from foo"},
 		{"cte", args{"create view jkl as with roles as (SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES) select * from roles;"}, "with roles as (SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES) select * from roles;"},
+		{"select-parens", args{"create view asdf as (select * from foo)"}, "(select * from foo)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -74,3 +74,24 @@ func TestDiffSuppressStatement(t *testing.T) {
 		})
 	}
 }
+
+func Test_extractViewStatement(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"select", args{"create view asdf as select * from foo"}, "select * from foo"},
+		{"cte", args{"create view jkl as with roles as (SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES) select * from roles;"}, "with roles as (SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES) select * from roles;"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resources.ExtractViewStatement(tt.args.input); got != tt.want {
+				t.Errorf("extractViewStatement() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Support CTE when extracting queries from view definitions.

When a view definition gets returned from snowflake it has the `create
view ...` at the beginning. To compare that sql statement to our state
we need to strip down to the query statement used to define the contents
of the view. Typically that statement starts with SELECT. When Common
Table Expressions (CTEs) are used WITH can start the statement.

As with some other PRs, I would love to have a proper SQL statement
parser here, but for now, just incrementally make our hacks better.

## Test Plan
* [x] acceptance tests
* [x] manual test on snowflake infra repo

## References
* https://docs.snowflake.com/en/user-guide/queries-cte.html