### PR TITLE
[fix] bug with percent signs in queries

### DIFF
--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"database/sql"
-	"fmt"
 	"log"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
@@ -133,10 +132,9 @@ func DeleteResource(t string, builder func(string) *snowflake.Builder) func(*sch
 	}
 }
 
-func DBExec(db *sql.DB, query string, args ...interface{}) error {
-	stmt := fmt.Sprintf(query, args...)
-	log.Printf("[DEBUG] stmt %s", stmt)
+func DBExec(db *sql.DB, query string) error {
+	log.Print("[DEBUG] stmt ", query)
 
-	_, err := db.Exec(stmt)
+	_, err := db.Exec(query)
 	return err
 }

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 
@@ -110,7 +111,7 @@ func CreateView(data *schema.ResourceData, meta interface{}) error {
 	}
 
 	q := builder.Create()
-
+	log.Print("[DEBUG] xxx ", q)
 	err := DBExec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error creating view %v", name)


### PR DESCRIPTION
Fix bug where we were breaking queries with '%' in them.

This would make it impossible to have a view query with a '%' and have
the query round-trip back from snowflake. The workaround was to escape
with '%%', but then you have a constant diff in your terraform plan.

Fixes #143

## Test Plan
* [ ] acceptance tests

## References
* #143 