### PR TITLE
[fix] refactor db scanning code to be more resilient

### DIFF
--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 )
 
@@ -87,7 +86,7 @@ func createDatabaseFromShare(data *schema.ResourceData, meta interface{}) error 
 	name := data.Get("name").(string)
 	builder := snowflake.DatabaseFromShare(name, prov.(string), share.(string))
 
-	err := DBExec(db, builder.Create())
+	err := snowflake.Exec(db, builder.Create())
 	if err != nil {
 		return errors.Wrapf(err, "error creating database %v from share %v.%v", name, prov, share)
 	}
@@ -104,7 +103,7 @@ func createDatabaseFromDatabase(data *schema.ResourceData, meta interface{}) err
 	name := data.Get("name").(string)
 	builder := snowflake.DatabaseFromDatabase(name, sourceDb)
 
-	err := DBExec(db, builder.Create())
+	err := snowflake.Exec(db, builder.Create())
 	if err != nil {
 		return errors.Wrapf(err, "error creating a clone database %v from database %v", name, sourceDb)
 	}
@@ -128,14 +127,10 @@ type database struct {
 
 func ReadDatabase(data *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
-	sdb := sqlx.NewDb(db, "snowflake")
-
 	name := data.Id()
 
 	stmt := snowflake.Database(name).Show()
-
-	log.Printf("[DEBUG] stmt %s", stmt)
-	row := sdb.QueryRowx(stmt)
+	row := snowflake.QueryRow(db, stmt)
 
 	database := &database{}
 	err := row.StructScan(database)

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -113,18 +113,6 @@ func createDatabaseFromDatabase(data *schema.ResourceData, meta interface{}) err
 	return ReadDatabase(data, meta)
 }
 
-type database struct {
-	CreatedOn     sql.NullString `db:"created_on"`
-	DBName        sql.NullString `db:"name"`
-	IsDefault     sql.NullString `db:"is_default"`
-	IsCurrent     sql.NullString `db:"is_current"`
-	Origin        sql.NullString `db:"origin"`
-	Owner         sql.NullString `db:"owner"`
-	Comment       sql.NullString `db:"comment"`
-	Options       sql.NullString `db:"options"`
-	RetentionTime sql.NullString `db:"retention_time"`
-}
-
 func ReadDatabase(data *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := data.Id()
@@ -132,8 +120,7 @@ func ReadDatabase(data *schema.ResourceData, meta interface{}) error {
 	stmt := snowflake.Database(name).Show()
 	row := snowflake.QueryRow(db, stmt)
 
-	database := &database{}
-	err := row.StructScan(database)
+	database, err := snowflake.ScanDatabase(row)
 
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -171,14 +171,14 @@ func createGenericGrant(data *schema.ResourceData, meta interface{}, builder sno
 	}
 
 	for _, role := range roles {
-		err := DBExec(db, builder.Role(role).Grant(priv))
+		err := snowflake.Exec(db, builder.Role(role).Grant(priv))
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, share := range shares {
-		err := DBExec(db, builder.Share(share).Grant(priv))
+		err := snowflake.Exec(db, builder.Share(share).Grant(priv))
 		if err != nil {
 			return err
 		}
@@ -353,14 +353,14 @@ func deleteGenericGrant(data *schema.ResourceData, meta interface{}, builder sno
 	}
 
 	for _, role := range roles {
-		err := DBExec(db, builder.Role(role).Revoke(priv))
+		err := snowflake.Exec(db, builder.Role(role).Revoke(priv))
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, share := range shares {
-		err := DBExec(db, builder.Share(share).Revoke(priv))
+		err := snowflake.Exec(db, builder.Share(share).Revoke(priv))
 		if err != nil {
 			return err
 		}

--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -268,10 +268,8 @@ func readGenericGrant(data *schema.ResourceData, meta interface{}, builder snowf
 }
 
 func readGenericCurrentGrants(db *sql.DB, builder snowflake.GrantBuilder) ([]*grant, error) {
-	conn := sqlx.NewDb(db, "snowflake")
-
 	stmt := builder.Show()
-	rows, err := conn.Queryx(stmt)
+	rows, err := snowflake.Query(db, stmt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/managed_account.go
+++ b/pkg/resources/managed_account.go
@@ -133,7 +133,6 @@ func ReadManagedAccount(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// TODO turn this into a loop after we switch to scaning in a struct
 	err = data.Set("name", a.Name.String)
 	if err != nil {
 		return err

--- a/pkg/resources/managed_account.go
+++ b/pkg/resources/managed_account.go
@@ -127,45 +127,43 @@ func ReadManagedAccount(data *schema.ResourceData, meta interface{}) error {
 	id := data.Id()
 
 	stmt := snowflake.ManagedAccount(id).Show()
-	row := db.QueryRow(stmt)
-	var name, cloud, region, locator, createdOn, url, comment sql.NullString
-	var isReader bool
-	err := row.Scan(&name, &cloud, &region, &locator, &createdOn, &url, &isReader, &comment)
+	row := snowflake.QueryRow(db, stmt)
+	a, err := snowflake.ScanManagedAccount(row)
 	if err != nil {
 		return err
 	}
 
 	// TODO turn this into a loop after we switch to scaning in a struct
-	err = data.Set("name", name.String)
+	err = data.Set("name", a.Name.String)
 	if err != nil {
 		return err
 	}
-	err = data.Set("cloud", cloud.String)
-	if err != nil {
-		return err
-	}
-
-	err = data.Set("region", region.String)
+	err = data.Set("cloud", a.Cloud.String)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("locator", locator.String)
+	err = data.Set("region", a.Region.String)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("created_on", createdOn.String)
+	err = data.Set("locator", a.Locator.String)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("url", url.String)
+	err = data.Set("created_on", a.CreatedOn.String)
 	if err != nil {
 		return err
 	}
 
-	if isReader {
+	err = data.Set("url", a.Url.String)
+	if err != nil {
+		return err
+	}
+
+	if a.IsReader {
 		err = data.Set("type", "READER")
 		if err != nil {
 			return err
@@ -174,7 +172,7 @@ func ReadManagedAccount(data *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Unable to determine the account type")
 	}
 
-	err = data.Set("comment", comment.String)
+	err = data.Set("comment", a.Comment.String)
 
 	return err
 }

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -156,7 +156,7 @@ func CreatePipe(data *schema.ResourceData, meta interface{}) error {
 
 	q := builder.Create()
 
-	err := DBExec(db, q)
+	err := snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error creating pipe %v", name)
 	}
@@ -256,7 +256,7 @@ func UpdatePipe(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("comment") {
 		_, comment := data.GetChange("comment")
 		q := builder.ChangeComment(comment.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating pipe comment on %v", data.Id())
 		}
@@ -281,7 +281,7 @@ func DeletePipe(data *schema.ResourceData, meta interface{}) error {
 
 	q := snowflake.Pipe(pipe, dbName, schema).Drop()
 
-	err = DBExec(db, q)
+	err = snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error deleting pipe %v", data.Id())
 	}

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -185,50 +185,51 @@ func ReadPipe(data *schema.ResourceData, meta interface{}) error {
 
 	dbName := pipeID.DatabaseName
 	schema := pipeID.SchemaName
-	pipe := pipeID.PipeName
+	name := pipeID.PipeName
 
-	sq := snowflake.Pipe(pipe, dbName, schema).Show()
-	pipeShow, err := showPipe(db, sq)
+	sq := snowflake.Pipe(name, dbName, schema).Show()
+	row := snowflake.QueryRow(db, sq)
+	pipe, err := snowflake.ScanPipe(row)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("name", pipe)
+	err = data.Set("name", pipe.Name)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("database", dbName)
+	err = data.Set("database", pipe.DatabaseName)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("schema", schema)
+	err = data.Set("schema", pipe.SchemaName)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("copy_statement", pipeShow.definition)
+	err = data.Set("copy_statement", pipe.Definition)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("owner", pipeShow.owner)
+	err = data.Set("owner", pipe.Owner)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("comment", pipeShow.comment)
+	err = data.Set("comment", pipe.Comment)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("notification_channel", pipeShow.notificationChannel)
+	err = data.Set("notification_channel", pipe.NotificationChannel)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("auto_ingest", pipeShow.notificationChannel != "")
+	err = data.Set("auto_ingest", pipe.NotificationChannel != "")
 	if err != nil {
 		return err
 	}
@@ -315,34 +316,4 @@ func PipeExists(data *schema.ResourceData, meta interface{}) (bool, error) {
 	}
 
 	return false, nil
-}
-
-type showPipeResult struct {
-	createdOn           string
-	name                string
-	databaseName        string
-	schemaName          string
-	definition          string
-	owner               string
-	notificationChannel string
-	comment             string
-}
-
-func showPipe(db *sql.DB, query string) (showPipeResult, error) {
-	var r showPipeResult
-	row := db.QueryRow(query)
-	err := row.Scan(
-		&r.createdOn,
-		&r.name,
-		&r.databaseName,
-		&r.schemaName,
-		&r.definition,
-		&r.owner,
-		&r.notificationChannel,
-		&r.comment,
-	)
-	if err != nil {
-		return r, err
-	}
-	return r, nil
 }

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"database/sql"
-	"log"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -38,7 +37,7 @@ func CreateResource(
 				}
 			}
 		}
-		err := DBExec(db, qb.Statement())
+		err := snowflake.Exec(db, qb.Statement())
 
 		if err != nil {
 			return errors.Wrapf(err, "error creating %s", t)
@@ -70,7 +69,7 @@ func UpdateResource(
 
 			stmt := builder(oldName).Rename(newName)
 
-			err := DBExec(db, stmt)
+			err := snowflake.Exec(db, stmt)
 			if err != nil {
 				return errors.Wrapf(err, "error renaming %s %s to %s", t, oldName, newName)
 			}
@@ -106,7 +105,7 @@ func UpdateResource(
 				}
 			}
 
-			err := DBExec(db, qb.Statement())
+			err := snowflake.Exec(db, qb.Statement())
 			if err != nil {
 				return errors.Wrapf(err, "error altering %s", t)
 			}
@@ -122,7 +121,7 @@ func DeleteResource(t string, builder func(string) *snowflake.Builder) func(*sch
 
 		stmt := builder(name).Drop()
 
-		err := DBExec(db, stmt)
+		err := snowflake.Exec(db, stmt)
 		if err != nil {
 			return errors.Wrapf(err, "error dropping %s %s", t, name)
 		}
@@ -130,11 +129,4 @@ func DeleteResource(t string, builder func(string) *snowflake.Builder) func(*sch
 		data.SetId("")
 		return nil
 	}
-}
-
-func DBExec(db *sql.DB, query string) error {
-	log.Print("[DEBUG] stmt ", query)
-
-	_, err := db.Exec(query)
-	return err
 }

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -12,23 +12,6 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
 )
 
-type resourceMonitor struct {
-	Name                 sql.NullString  `db:"name"`
-	CreditQuota          sql.NullFloat64 `db:"credit_quota"`
-	UsedCredits          sql.NullString  `db:"used_credits"`
-	RemainingCredits     sql.NullString  `db:"remaining_credits"`
-	Level                sql.NullString  `db:"level"`
-	Frequency            sql.NullString  `db:"frequency"`
-	StartTime            sql.NullString  `db:"start_time"`
-	EndTime              sql.NullString  `db:"end_time"`
-	NotifyAt             sql.NullString  `db:"notify_at"`
-	SuspendAt            sql.NullString  `db:"suspend_at"`
-	SuspendImmediatelyAt sql.NullString  `db:"suspend_immediately_at"`
-	CreatedOn            sql.NullString  `db:"created_on"`
-	Owner                sql.NullString  `db:"owner"`
-	Comment              sql.NullString  `db:"comment"`
-}
-
 var validFrequencies = []string{"MONTHLY", "DAILY", "WEEKLY", "YEARLY", "NEVER"}
 
 var resourceMonitorSchema = map[string]*schema.Schema{
@@ -157,8 +140,7 @@ func ReadResourceMonitor(data *schema.ResourceData, meta interface{}) error {
 
 	row := snowflake.QueryRow(db, stmt)
 
-	rm := &resourceMonitor{}
-	err := row.StructScan(rm)
+	rm, err := snowflake.ScanResourceMonitor(row)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -2,13 +2,11 @@ package resources
 
 import (
 	"database/sql"
-	"log"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
@@ -142,7 +140,7 @@ func CreateResourceMonitor(data *schema.ResourceData, meta interface{}) error {
 
 	stmt := cb.Statement()
 
-	err := DBExec(db, stmt)
+	err := snowflake.Exec(db, stmt)
 	if err != nil {
 		return errors.Wrapf(err, "error creating resource monitor %v", name)
 	}
@@ -155,15 +153,11 @@ func CreateResourceMonitor(data *schema.ResourceData, meta interface{}) error {
 // ReadResourceMonitor implements schema.ReadFunc
 func ReadResourceMonitor(data *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
-	sdb := sqlx.NewDb(db, "snowflake")
-
 	stmt := snowflake.ResourceMonitor(data.Id()).Show()
 
-	log.Printf("[DEBUG] stmt %v\n", stmt)
-	row := sdb.QueryRowx(stmt)
+	row := snowflake.QueryRow(db, stmt)
 
 	rm := &resourceMonitor{}
-
 	err := row.StructScan(rm)
 	if err != nil {
 		return err
@@ -258,7 +252,7 @@ func DeleteResourceMonitor(data *schema.ResourceData, meta interface{}) error {
 
 	stmt := snowflake.ResourceMonitor(data.Id()).Drop()
 
-	err := DBExec(db, stmt)
+	err := snowflake.Exec(db, stmt)
 	if err != nil {
 		return errors.Wrapf(err, "error deleting resource monitor %v", data.Id())
 	}

--- a/pkg/resources/role.go
+++ b/pkg/resources/role.go
@@ -43,18 +43,17 @@ func ReadRole(data *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := data.Id()
 
-	row := db.QueryRow(fmt.Sprintf("SHOW ROLES LIKE '%s'", id))
-	var createdOn, name, isDefault, isCurrent, isInherited, assignedToUsers, grantedToRoles, grantedRoles, owner, comment sql.NullString
-	err := row.Scan(&createdOn, &name, &isDefault, &isCurrent, &isInherited, &assignedToUsers, &grantedToRoles, &grantedRoles, &owner, &comment)
+	row := snowflake.QueryRow(db, fmt.Sprintf("SHOW ROLES LIKE '%s'", id))
+	role, err := snowflake.ScanRole(row)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("name", name.String)
+	err = data.Set("name", role.Name.String)
 	if err != nil {
 		return err
 	}
-	err = data.Set("comment", comment.String)
+	err = data.Set("comment", role.Comment.String)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/role_grants.go
+++ b/pkg/resources/role_grants.go
@@ -76,13 +76,13 @@ func CreateRoleGrants(data *schema.ResourceData, meta interface{}) error {
 
 func grantRoleToRole(db *sql.DB, role1, role2 string) error {
 	g := snowflake.RoleGrant(role1)
-	err := DBExec(db, g.Role(role2).Grant())
+	err := snowflake.Exec(db, g.Role(role2).Grant())
 	return err
 }
 
 func grantRoleToUser(db *sql.DB, role1, user string) error {
 	g := snowflake.RoleGrant(role1)
-	err := DBExec(db, g.User(user).Grant())
+	err := snowflake.Exec(db, g.User(user).Grant())
 	return err
 }
 
@@ -193,13 +193,13 @@ func DeleteRoleGrants(data *schema.ResourceData, meta interface{}) error {
 
 func revokeRoleFromRole(db *sql.DB, role1, role2 string) error {
 	rg := snowflake.RoleGrant(role1).Role(role2)
-	err := DBExec(db, rg.Revoke())
+	err := snowflake.Exec(db, rg.Revoke())
 	return err
 }
 
 func revokeRoleFromUser(db *sql.DB, role1, user string) error {
 	rg := snowflake.RoleGrant(role1).User(user)
-	err := DBExec(db, rg.Revoke())
+	err := snowflake.Exec(db, rg.Revoke())
 	return err
 }
 

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -182,7 +182,6 @@ func ReadSchema(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// TODO turn this into a loop after we switch to scaning in a struct
 	err = data.Set("name", s.Name.String)
 	if err != nil {
 		return err

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -145,7 +145,7 @@ func CreateSchema(data *schema.ResourceData, meta interface{}) error {
 
 	q := builder.Create()
 
-	err := DBExec(db, q)
+	err := snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error creating schema %v", name)
 	}
@@ -254,7 +254,7 @@ func UpdateSchema(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("comment") {
 		_, comment := data.GetChange("comment")
 		q := builder.ChangeComment(comment.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating schema comment on %v", data.Id())
 		}
@@ -271,7 +271,7 @@ func UpdateSchema(data *schema.ResourceData, meta interface{}) error {
 			q = builder.Unmanage()
 		}
 
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error changing management state on %v", data.Id())
 		}
@@ -284,7 +284,7 @@ func UpdateSchema(data *schema.ResourceData, meta interface{}) error {
 		_, days := data.GetChange("data_retention_days")
 
 		q := builder.ChangeDataRetentionDays(days.(int))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating data retention days on %v", data.Id())
 		}
@@ -306,7 +306,7 @@ func DeleteSchema(data *schema.ResourceData, meta interface{}) error {
 
 	q := snowflake.Schema(schema).WithDB(dbName).Drop()
 
-	err = DBExec(db, q)
+	err = snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error deleting schema %v", data.Id())
 	}

--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -130,26 +130,23 @@ func ReadShare(data *schema.ResourceData, meta interface{}) error {
 	id := data.Id()
 
 	stmt := snowflake.Share(id).Show()
-	row := db.QueryRow(stmt)
+	row := snowflake.QueryRow(db, stmt)
 
-	var createdOn, kind, name, databaseName, to, owner, comment sql.NullString
-	err := row.Scan(&createdOn, &kind, &name, &databaseName, &to, &owner, &comment)
+	s, err := snowflake.ScanShare(row)
 	if err != nil {
 		return err
 	}
 
-	// TODO turn this into a loop after we switch to scanning in a struct
-	err = data.Set("name", StripAccountFromName(name.String))
+	err = data.Set("name", StripAccountFromName(s.Name.String))
 	if err != nil {
 		return err
 	}
-	err = data.Set("comment", comment.String)
+	err = data.Set("comment", s.Comment.String)
 	if err != nil {
 		return err
 	}
 
-	// accs := strings.Split(to.String, ", ")
-	accs := strings.FieldsFunc(to.String, func(c rune) bool { return c == ',' })
+	accs := strings.FieldsFunc(s.To.String, func(c rune) bool { return c == ',' })
 	err = data.Set("accounts", accs)
 
 	return err

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -184,7 +184,7 @@ func CreateStage(data *schema.ResourceData, meta interface{}) error {
 
 	q := builder.Create()
 
-	err := DBExec(db, q)
+	err := snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error creating stage %v", name)
 	}
@@ -301,7 +301,7 @@ func UpdateStage(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("url") {
 		_, url := data.GetChange("url")
 		q := builder.ChangeURL(url.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating stage url on %v", data.Id())
 		}
@@ -312,7 +312,7 @@ func UpdateStage(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("credentials") {
 		_, credentials := data.GetChange("credentials")
 		q := builder.ChangeCredentials(credentials.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating stage credentials on %v", data.Id())
 		}
@@ -323,7 +323,7 @@ func UpdateStage(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("storage_integration") {
 		_, si := data.GetChange("storage_integration")
 		q := builder.ChangeStorageIntegration(si.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating stage storage integration on %v", data.Id())
 		}
@@ -334,7 +334,7 @@ func UpdateStage(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("encryption") {
 		_, encryption := data.GetChange("encryption")
 		q := builder.ChangeEncryption(encryption.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating stage encryption on %v", data.Id())
 		}
@@ -344,7 +344,7 @@ func UpdateStage(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("file_format") {
 		_, fileFormat := data.GetChange("file_format")
 		q := builder.ChangeFileFormat(fileFormat.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating stage file formaat on %v", data.Id())
 		}
@@ -354,7 +354,7 @@ func UpdateStage(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("copy_options") {
 		_, copyOptions := data.GetChange("copy_options")
 		q := builder.ChangeCopyOptions(copyOptions.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating stage copy options on %v", data.Id())
 		}
@@ -364,7 +364,7 @@ func UpdateStage(data *schema.ResourceData, meta interface{}) error {
 	if data.HasChange("comment") {
 		_, comment := data.GetChange("comment")
 		q := builder.ChangeComment(comment.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating stage comment on %v", data.Id())
 		}
@@ -389,7 +389,7 @@ func DeleteStage(data *schema.ResourceData, meta interface{}) error {
 
 	q := snowflake.Stage(stage, dbName, schema).Drop()
 
-	err = DBExec(db, q)
+	err = snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error deleting stage %v", data.Id())
 	}

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -217,63 +217,65 @@ func ReadStage(data *schema.ResourceData, meta interface{}) error {
 	stage := stageID.StageName
 
 	q := snowflake.Stage(stage, dbName, schema).Describe()
-	stageDesc, err := descStage(db, q)
+	stageDesc, err := snowflake.DescStage(db, q)
 	if err != nil {
 		return err
 	}
 
 	sq := snowflake.Stage(stage, dbName, schema).Show()
-	stageShow, err := showStage(db, sq)
+	row := snowflake.QueryRow(db, sq)
+
+	s, err := snowflake.ScanStageShow(row)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("name", stage)
+	err = data.Set("name", s.Name)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("database", dbName)
+	err = data.Set("database", s.DatabaseName)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("schema", schema)
+	err = data.Set("schema", s.SchemaName)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("url", stageDesc.url)
+	err = data.Set("url", stageDesc.Url)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("file_format", stageDesc.fileFormat)
+	err = data.Set("file_format", stageDesc.FileFormat)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("copy_options", stageDesc.copyOptions)
+	err = data.Set("copy_options", stageDesc.CopyOptions)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("storage_integration", stageShow.storageIntegration)
+	err = data.Set("storage_integration", s.StorageIntegration)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("comment", stageShow.comment)
+	err = data.Set("comment", s.Comment)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("aws_external_id", stageDesc.awsExternalID)
+	err = data.Set("aws_external_id", stageDesc.AwsExternalID)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("snowflake_iam_user", stageDesc.snowflakeIamUser)
+	err = data.Set("snowflake_iam_user", stageDesc.SnowflakeIamUser)
 	if err != nil {
 		return err
 	}
@@ -423,100 +425,4 @@ func StageExists(data *schema.ResourceData, meta interface{}) (bool, error) {
 	}
 
 	return false, nil
-}
-
-type showStageResult struct {
-	createdOn           *string
-	name                *string
-	databaseName        *string
-	schemaName          *string
-	url                 *string
-	hasCredentials      *string
-	hasEncryptionKey    *string
-	owner               *string
-	comment             *string
-	region              *string
-	stageType           *string
-	cloud               *string
-	notificationChannel *string
-	storageIntegration  *string
-}
-
-func showStage(db *sql.DB, query string) (showStageResult, error) {
-	var r showStageResult
-	row := db.QueryRow(query)
-	err := row.Scan(
-		&r.createdOn,
-		&r.name,
-		&r.databaseName,
-		&r.schemaName,
-		&r.url,
-		&r.hasCredentials,
-		&r.hasEncryptionKey,
-		&r.owner,
-		&r.comment,
-		&r.region,
-		&r.stageType,
-		&r.cloud,
-		&r.notificationChannel,
-		&r.storageIntegration,
-	)
-	if err != nil {
-		return r, err
-	}
-
-	return r, nil
-}
-
-type descStageResult struct {
-	url              string
-	awsExternalID    string
-	snowflakeIamUser string
-	fileFormat       string
-	copyOptions      string
-}
-
-func descStage(db *sql.DB, query string) (descStageResult, error) {
-	var r descStageResult
-	var ff []string
-	var co []string
-	rows, err := db.Query(query)
-	if err != nil {
-		return r, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var parentProperty string
-		var property string
-		var propertyType string
-		var propertyValue string
-		var propertyDefault string
-		if err := rows.Scan(&parentProperty, &property, &propertyType, &propertyValue, &propertyDefault); err != nil {
-			return r, err
-		}
-
-		switch property {
-		case "URL":
-			r.url = strings.Trim(propertyValue, "[\"]")
-		case "AWS_EXTERNAL_ID":
-			r.awsExternalID = propertyValue
-		case "SNOWFLAKE_IAM_USER":
-			r.snowflakeIamUser = propertyValue
-		}
-
-		switch parentProperty {
-		case "STAGE_FILE_FORMAT":
-			if propertyValue != propertyDefault {
-				ff = append(ff, fmt.Sprintf("%s = %s", property, propertyValue))
-			}
-		case "STAGE_COPY_OPTIONS":
-			if propertyValue != propertyDefault {
-				co = append(co, fmt.Sprintf("%s = %s", property, propertyValue))
-			}
-		}
-	}
-
-	r.fileFormat = strings.Join(ff, " ")
-	r.copyOptions = strings.Join(co, " ")
-	return r, nil
 }

--- a/pkg/resources/storage_integration.go
+++ b/pkg/resources/storage_integration.go
@@ -139,33 +139,33 @@ func ReadStorageIntegration(data *schema.ResourceData, meta interface{}) error {
 	id := data.Id()
 
 	stmt := snowflake.StorageIntegration(data.Id()).Show()
-	row := db.QueryRow(stmt)
+	row := snowflake.QueryRow(db, stmt)
 
 	// Some properties can come from the SHOW INTEGRATION call
-	var name, integrationType, category, createdOn sql.NullString
-	var enabled sql.NullBool
-	if err := row.Scan(&name, &integrationType, &category, &enabled, &createdOn); err != nil {
+
+	s, err := snowflake.ScanStorageIntegration(row)
+	if err != nil {
 		return fmt.Errorf("Could not show storage integration: %w", err)
 	}
 
 	// Note: category must be STORAGE or something is broken
-	if c := category.String; c != "STORAGE" {
+	if c := s.Category.String; c != "STORAGE" {
 		return fmt.Errorf("Expected %v to be a STORAGE integration, got %v", id, c)
 	}
 
-	if err := data.Set("name", name.String); err != nil {
+	if err := data.Set("name", s.Name.String); err != nil {
 		return err
 	}
 
-	if err := data.Set("type", integrationType.String); err != nil {
+	if err := data.Set("type", s.IntegrationType.String); err != nil {
 		return err
 	}
 
-	if err := data.Set("created_on", createdOn.String); err != nil {
+	if err := data.Set("created_on", s.CreatedOn.String); err != nil {
 		return err
 	}
 
-	if err := data.Set("enabled", enabled.Bool); err != nil {
+	if err := data.Set("enabled", s.Enabled.Bool); err != nil {
 		return err
 	}
 

--- a/pkg/resources/storage_integration.go
+++ b/pkg/resources/storage_integration.go
@@ -123,7 +123,7 @@ func CreateStorageIntegration(data *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	err = DBExec(db, stmt.Statement())
+	err = snowflake.Exec(db, stmt.Statement())
 	if err != nil {
 		return fmt.Errorf("error creating storage integration: %w", err)
 	}
@@ -258,7 +258,7 @@ func UpdateStorageIntegration(data *schema.ResourceData, meta interface{}) error
 	if data.HasChange("storage_blocked_locations") {
 		v := data.Get("storage_blocked_locations").([]interface{})
 		if len(v) == 0 {
-			err := DBExec(db, fmt.Sprintf(`ALTER STORAGE INTEGRATION %v UNSET STORAGE_BLOCKED_LOCATIONS`, data.Id()))
+			err := snowflake.Exec(db, fmt.Sprintf(`ALTER STORAGE INTEGRATION %v UNSET STORAGE_BLOCKED_LOCATIONS`, data.Id()))
 			if err != nil {
 				return fmt.Errorf("error unsetting storage_blocked_locations: %w", err)
 			}
@@ -283,7 +283,7 @@ func UpdateStorageIntegration(data *schema.ResourceData, meta interface{}) error
 	}
 
 	if runSetStatement {
-		if err := DBExec(db, stmt.Statement()); err != nil {
+		if err := snowflake.Exec(db, stmt.Statement()); err != nil {
 			return fmt.Errorf("error updating storage integration: %w", err)
 		}
 	}

--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -153,50 +153,48 @@ func ReadUser(data *schema.ResourceData, meta interface{}) error {
 	id := data.Id()
 
 	stmt := snowflake.User(id).Show()
-	row := db.QueryRow(stmt)
-	var name, createdOn, loginName, displayName, firstName, lastName, email, minsToUnlock, daysToExpiry, comment, mustChangePassword, snowflakeLock, defaultWarehouse, defaultNamespace, defaultRole, extAuthnDuo, extAuthnUID, minsToBypassMfa, owner, lastSuccessLogin, expiresAtTime, lockedUntilTime, hasPassword sql.NullString
-	var disabled, hasRsaPublicKey bool
-	err := row.Scan(&name, &createdOn, &loginName, &displayName, &firstName, &lastName, &email, &minsToUnlock, &daysToExpiry, &comment, &disabled, &mustChangePassword, &snowflakeLock, &defaultWarehouse, &defaultNamespace, &defaultRole, &extAuthnDuo, &extAuthnUID, &minsToBypassMfa, &owner, &lastSuccessLogin, &expiresAtTime, &lockedUntilTime, &hasPassword, &hasRsaPublicKey)
+	row := snowflake.QueryRow(db, stmt)
+
+	u, err := snowflake.ScanUser(row)
 	if err != nil {
 		return err
 	}
 
-	// TODO turn this into a loop after we switch to scaning in a struct
-	err = data.Set("name", name.String)
+	err = data.Set("name", u.Name.String)
 	if err != nil {
 		return err
 	}
-	err = data.Set("comment", comment.String)
-	if err != nil {
-		return err
-	}
-
-	err = data.Set("login_name", loginName.String)
+	err = data.Set("comment", u.Comment.String)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("disabled", disabled)
+	err = data.Set("login_name", u.LoginName.String)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("default_role", defaultRole.String)
+	err = data.Set("disabled", u.Disabled)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("default_namespace", defaultNamespace.String)
+	err = data.Set("default_role", u.DefaultRole.String)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("default_warehouse", defaultWarehouse.String)
+	err = data.Set("default_namespace", u.DefaultNamespace.String)
 	if err != nil {
 		return err
 	}
 
-	err = data.Set("has_rsa_public_key", hasRsaPublicKey)
+	err = data.Set("default_warehouse", u.DefaultWarehouse.String)
+	if err != nil {
+		return err
+	}
+
+	err = data.Set("has_rsa_public_key", u.HasRsaPublicKey)
 
 	return err
 }

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -112,7 +112,7 @@ func CreateView(data *schema.ResourceData, meta interface{}) error {
 
 	q := builder.Create()
 	log.Print("[DEBUG] xxx ", q)
-	err := DBExec(db, q)
+	err := snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error creating view %v", name)
 	}
@@ -193,7 +193,7 @@ func UpdateView(data *schema.ResourceData, meta interface{}) error {
 		_, name := data.GetChange("name")
 
 		q := builder.Rename(name.(string))
-		err := DBExec(db, q)
+		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error renaming view %v", data.Id())
 		}
@@ -207,13 +207,13 @@ func UpdateView(data *schema.ResourceData, meta interface{}) error {
 
 		if c := comment.(string); c == "" {
 			q := builder.RemoveComment()
-			err := DBExec(db, q)
+			err := snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error unsetting comment for view %v", data.Id())
 			}
 		} else {
 			q := builder.ChangeComment(c)
-			err := DBExec(db, q)
+			err := snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error updating comment for view %v", data.Id())
 			}
@@ -228,13 +228,13 @@ func UpdateView(data *schema.ResourceData, meta interface{}) error {
 
 		if secure.(bool) {
 			q := builder.Secure()
-			err := DBExec(db, q)
+			err := snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error setting secure for view %v", data.Id())
 			}
 		} else {
 			q := builder.Unsecure()
-			err := DBExec(db, q)
+			err := snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error unsetting secure for view %v", data.Id())
 			}
@@ -254,7 +254,7 @@ func DeleteView(data *schema.ResourceData, meta interface{}) error {
 
 	q := snowflake.View(view).WithDB(dbName).WithSchema(schema).Drop()
 
-	err = DBExec(db, q)
+	err = snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error deleting view %v", data.Id())
 	}

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -139,7 +139,6 @@ func ReadView(data *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// TODO turn this into a loop after we switch to scaning in a struct
 	err = data.Set("name", name.String)
 	if err != nil {
 		return err

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -3,46 +3,11 @@ package resources
 import (
 	"database/sql"
 	"strings"
-	"time"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
-
-// warehouse is a go representation of a grant that can be used in conjunction
-// with github.com/jmoiron/sqlx
-type warehouse struct {
-	Name            string    `db:"name"`
-	State           string    `db:"state"`
-	Type            string    `db:"type"`
-	Size            string    `db:"size"`
-	MinClusterCount int64     `db:"min_cluster_count"`
-	MaxClusterCount int64     `db:"max_cluster_count"`
-	StartedClusters int64     `db:"started_clusters"`
-	Running         int64     `db:"running"`
-	Queued          int64     `db:"queued"`
-	IsDefault       string    `db:"is_default"`
-	IsCurrent       string    `db:"is_current"`
-	AutoSuspend     int64     `db:"auto_suspend"`
-	AutoResume      bool      `db:"auto_resume"`
-	Available       string    `db:"available"`
-	Provisioning    string    `db:"provisioning"`
-	Quiescing       string    `db:"quiescing"`
-	Other           string    `db:"other"`
-	CreatedOn       time.Time `db:"created_on"`
-	ResumedOn       time.Time `db:"resumed_on"`
-	UpdatedOn       time.Time `db:"updated_on"`
-	Owner           string    `db:"owner"`
-	Comment         string    `db:"comment"`
-	ResourceMonitor string    `db:"resource_monitor"`
-	Actives         int64     `db:"actives"`
-	Pendings        int64     `db:"pendings"`
-	Failed          int64     `db:"failed"`
-	Suspended       int64     `db:"suspended"`
-	UUID            string    `db:"uuid"`
-	ScalingPolicy   string    `db:"scaling_policy"`
-}
 
 // warehouseCreateProperties are only available via the CREATE statement
 var warehouseCreateProperties = []string{"initially_suspended", "wait_for_provisioning", "statement_timeout_in_seconds"}
@@ -166,10 +131,7 @@ func ReadWarehouse(data *schema.ResourceData, meta interface{}) error {
 	stmt := snowflake.Warehouse(data.Id()).Show()
 
 	row := snowflake.QueryRow(db, stmt)
-
-	w := &warehouse{}
-
-	err := row.StructScan(w)
+	w, err := snowflake.ScanWarehouse(row)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -2,14 +2,12 @@ package resources
 
 import (
 	"database/sql"
-	"log"
 	"strings"
 	"time"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/jmoiron/sqlx"
 )
 
 // warehouse is a go representation of a grant that can be used in conjunction
@@ -165,12 +163,9 @@ func CreateWarehouse(data *schema.ResourceData, meta interface{}) error {
 // ReadWarehouse implements schema.ReadFunc
 func ReadWarehouse(data *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
-	sdb := sqlx.NewDb(db, "snowflake")
-
 	stmt := snowflake.Warehouse(data.Id()).Show()
 
-	log.Printf("[DEBUG] stmt %v\n", stmt)
-	row := sdb.QueryRowx(stmt)
+	row := snowflake.QueryRow(db, stmt)
 
 	w := &warehouse{}
 

--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -1,7 +1,10 @@
 package snowflake
 
 import (
+	"database/sql"
 	"fmt"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // Database returns a pointer to a Builder for a database
@@ -50,4 +53,22 @@ func DatabaseFromDatabase(name, database string) *DatabaseCloneBuilder {
 // Create returns the SQL statement required to create a database from a source database
 func (dsb *DatabaseCloneBuilder) Create() string {
 	return fmt.Sprintf(`CREATE DATABASE "%v" CLONE "%v"`, dsb.name, dsb.database)
+}
+
+type database struct {
+	CreatedOn     sql.NullString `db:"created_on"`
+	DBName        sql.NullString `db:"name"`
+	IsDefault     sql.NullString `db:"is_default"`
+	IsCurrent     sql.NullString `db:"is_current"`
+	Origin        sql.NullString `db:"origin"`
+	Owner         sql.NullString `db:"owner"`
+	Comment       sql.NullString `db:"comment"`
+	Options       sql.NullString `db:"options"`
+	RetentionTime sql.NullString `db:"retention_time"`
+}
+
+func ScanDatabase(row *sqlx.Row) (*database, error) {
+	d := &database{}
+	e := row.StructScan(d)
+	return d, e
 }

--- a/pkg/snowflake/exec.go
+++ b/pkg/snowflake/exec.go
@@ -14,13 +14,18 @@ func Exec(db *sql.DB, query string) error {
 	return err
 }
 
+// QueryRow will run stmt against the db and return the row. We use
+// [DB.Unsafe](https://godoc.org/github.com/jmoiron/sqlx#DB.Unsafe) so that we can scan to structs
+// without worrying about newly introduced columns
 func QueryRow(db *sql.DB, stmt string) *sqlx.Row {
 	log.Print("[DEBUG] stmt ", stmt)
 	sdb := sqlx.NewDb(db, "snowflake").Unsafe()
 	return sdb.QueryRowx(stmt)
 }
 
-// TODO https://godoc.org/github.com/jmoiron/sqlx#Stmt.Unsafe
+// Query will run stmt against the db and return the rows. We use
+// [DB.Unsafe](https://godoc.org/github.com/jmoiron/sqlx#DB.Unsafe) so that we can scan to structs
+// without worrying about newly introduced columns
 func Query(db *sql.DB, stmt string) (*sqlx.Rows, error) {
 	sdb := sqlx.NewDb(db, "snowflake").Unsafe()
 	return sdb.Queryx(stmt)

--- a/pkg/snowflake/exec.go
+++ b/pkg/snowflake/exec.go
@@ -1,0 +1,21 @@
+package snowflake
+
+import (
+	"database/sql"
+	"log"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func Exec(db *sql.DB, query string) error {
+	log.Print("[DEBUG] stmt ", query)
+
+	_, err := db.Exec(query)
+	return err
+}
+
+func QueryRow(db *sql.DB, stmt string) *sqlx.Row {
+	log.Print("[DEBUG] stmt ", stmt)
+	sdb := sqlx.NewDb(db, "snowflake")
+	return sdb.QueryRowx(stmt)
+}

--- a/pkg/snowflake/exec.go
+++ b/pkg/snowflake/exec.go
@@ -20,6 +20,7 @@ func QueryRow(db *sql.DB, stmt string) *sqlx.Row {
 	return sdb.QueryRowx(stmt)
 }
 
+// TODO https://godoc.org/github.com/jmoiron/sqlx#Stmt.Unsafe
 func Query(db *sql.DB, stmt string) (*sqlx.Rows, error) {
 	sdb := sqlx.NewDb(db, "snowflake").Unsafe()
 	return sdb.Queryx(stmt)

--- a/pkg/snowflake/exec.go
+++ b/pkg/snowflake/exec.go
@@ -19,3 +19,8 @@ func QueryRow(db *sql.DB, stmt string) *sqlx.Row {
 	sdb := sqlx.NewDb(db, "snowflake")
 	return sdb.QueryRowx(stmt)
 }
+
+func Query(db *sql.DB, stmt string) (*sqlx.Rows, err) {
+	sdb := sqlx.NewDb(db, "snowflake")
+	return sdb.Queryx(stmt)
+}

--- a/pkg/snowflake/exec.go
+++ b/pkg/snowflake/exec.go
@@ -16,11 +16,11 @@ func Exec(db *sql.DB, query string) error {
 
 func QueryRow(db *sql.DB, stmt string) *sqlx.Row {
 	log.Print("[DEBUG] stmt ", stmt)
-	sdb := sqlx.NewDb(db, "snowflake")
+	sdb := sqlx.NewDb(db, "snowflake").Unsafe()
 	return sdb.QueryRowx(stmt)
 }
 
 func Query(db *sql.DB, stmt string) (*sqlx.Rows, error) {
-	sdb := sqlx.NewDb(db, "snowflake")
+	sdb := sqlx.NewDb(db, "snowflake").Unsafe()
 	return sdb.Queryx(stmt)
 }

--- a/pkg/snowflake/exec.go
+++ b/pkg/snowflake/exec.go
@@ -20,7 +20,7 @@ func QueryRow(db *sql.DB, stmt string) *sqlx.Row {
 	return sdb.QueryRowx(stmt)
 }
 
-func Query(db *sql.DB, stmt string) (*sqlx.Rows, err) {
+func Query(db *sql.DB, stmt string) (*sqlx.Rows, error) {
 	sdb := sqlx.NewDb(db, "snowflake")
 	return sdb.Queryx(stmt)
 }

--- a/pkg/snowflake/managed_account.go
+++ b/pkg/snowflake/managed_account.go
@@ -1,5 +1,11 @@
 package snowflake
 
+import (
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
 // ManagedAccount returns a pointer to a Builder that abstracts the DDL
 // operations for a reader account.
 //
@@ -14,4 +20,21 @@ func ManagedAccount(name string) *Builder {
 		entityType: ManagedAccountType,
 		name:       name,
 	}
+}
+
+type managedAccount struct {
+	Name      sql.NullString `db:"name"`
+	Cloud     sql.NullString `db:"cloud"`
+	Region    sql.NullString `db:"region"`
+	Locator   sql.NullString `db:"locator"`
+	CreatedOn sql.NullString `db:"created_on"`
+	Url       sql.NullString `db:"url"`
+	Comment   sql.NullString `db:"comment"`
+	IsReader  bool           `db:"is_reader"`
+}
+
+func ScanManagedAccount(row *sqlx.Row) (*managedAccount, error) {
+	a := &managedAccount{}
+	e := row.StructScan(a)
+	return a, e
 }

--- a/pkg/snowflake/pipe.go
+++ b/pkg/snowflake/pipe.go
@@ -3,6 +3,8 @@ package snowflake
 import (
 	"fmt"
 	"strings"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // PipeBuilder abstracts the creation of SQL queries for a Snowflake schema
@@ -110,4 +112,21 @@ func (pb *PipeBuilder) Drop() string {
 // Show returns the SQL query that will show a pipe.
 func (pb *PipeBuilder) Show() string {
 	return fmt.Sprintf(`SHOW PIPES LIKE '%v' IN DATABASE "%v"`, pb.name, pb.db)
+}
+
+type pipe struct {
+	Createdon           string `db:"created_on"`
+	Name                string `db:"name"`
+	DatabaseName        string `db:"database_name"`
+	SchemaName          string `db:"schema_name"`
+	Definition          string `db:"definition"`
+	Owner               string `db:"owner"`
+	NotificationChannel string `db:"notification_channel"`
+	Comment             string `db:"comment"`
+}
+
+func ScanPipe(row *sqlx.Row) (*pipe, error) {
+	p := &pipe{}
+	e := row.StructScan(p)
+	return p, e
 }

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -1,8 +1,11 @@
 package snowflake
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // ResourceMonitorBuilder extends the generic builder to provide support for triggers
@@ -112,4 +115,27 @@ func (rcb *ResourceMonitorCreateBuilder) Statement() string {
 	}
 
 	return sb.String()
+}
+
+type resourceMonitor struct {
+	Name                 sql.NullString  `db:"name"`
+	CreditQuota          sql.NullFloat64 `db:"credit_quota"`
+	UsedCredits          sql.NullString  `db:"used_credits"`
+	RemainingCredits     sql.NullString  `db:"remaining_credits"`
+	Level                sql.NullString  `db:"level"`
+	Frequency            sql.NullString  `db:"frequency"`
+	StartTime            sql.NullString  `db:"start_time"`
+	EndTime              sql.NullString  `db:"end_time"`
+	NotifyAt             sql.NullString  `db:"notify_at"`
+	SuspendAt            sql.NullString  `db:"suspend_at"`
+	SuspendImmediatelyAt sql.NullString  `db:"suspend_immediately_at"`
+	CreatedOn            sql.NullString  `db:"created_on"`
+	Owner                sql.NullString  `db:"owner"`
+	Comment              sql.NullString  `db:"comment"`
+}
+
+func ScanResourceMonitor(row *sqlx.Row) (*resourceMonitor, error) {
+	rm := &resourceMonitor{}
+	err := row.StructScan(rm)
+	return rm, err
 }

--- a/pkg/snowflake/role.go
+++ b/pkg/snowflake/role.go
@@ -20,6 +20,6 @@ type role struct {
 
 func ScanRole(row *sqlx.Row) (*role, error) {
 	r := &role{}
-	e := row.StructScan(r)
-	return r, e
+	err := row.StructScan(r)
+	return r, err
 }

--- a/pkg/snowflake/role.go
+++ b/pkg/snowflake/role.go
@@ -1,8 +1,25 @@
 package snowflake
 
+import (
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
 func Role(name string) *Builder {
 	return &Builder{
 		entityType: RoleType,
 		name:       name,
 	}
+}
+
+type role struct {
+	Name    sql.NullString `db:"name"`
+	Comment sql.NullString `db:"comment"`
+}
+
+func ScanRole(row *sqlx.Row) (*role, error) {
+	r := &role{}
+	e := row.StructScan(r)
+	return r, e
 }

--- a/pkg/snowflake/schema.go
+++ b/pkg/snowflake/schema.go
@@ -186,6 +186,6 @@ type schema struct {
 
 func ScanSchema(row *sqlx.Row) (*schema, error) {
 	r := &schema{}
-	e := row.StructScan(r)
-	return r, e
+	err := row.StructScan(r)
+	return r, err
 }

--- a/pkg/snowflake/schema.go
+++ b/pkg/snowflake/schema.go
@@ -178,10 +178,10 @@ func (sb *SchemaBuilder) Show() string {
 
 type schema struct {
 	Name          sql.NullString `db:"name"`
-	DatabaseName  sql.NullString `db:"databaseName"`
+	DatabaseName  sql.NullString `db:"database_name"`
 	Comment       sql.NullString `db:"comment"`
 	Options       sql.NullString `db:"options"`
-	RetentionTime sql.NullInt64  `db:"retentionTime"`
+	RetentionTime sql.NullInt64  `db:"retention_time"`
 }
 
 func ScanSchema(row *sqlx.Row) (*schema, error) {

--- a/pkg/snowflake/schema.go
+++ b/pkg/snowflake/schema.go
@@ -1,8 +1,11 @@
 package snowflake
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // SchemaBuilder abstracts the creation of SQL queries for a Snowflake schema
@@ -171,4 +174,18 @@ func (sb *SchemaBuilder) Show() string {
 	}
 
 	return q.String()
+}
+
+type schema struct {
+	Name          sql.NullString `db:"name"`
+	DatabaseName  sql.NullString `db:"databaseName"`
+	Comment       sql.NullString `db:"comment"`
+	Options       sql.NullString `db:"options"`
+	RetentionTime sql.NullInt64  `db:"retentionTime"`
+}
+
+func ScanSchema(row *sqlx.Row) (*schema, error) {
+	r := &schema{}
+	e := row.StructScan(r)
+	return r, e
 }

--- a/pkg/snowflake/share.go
+++ b/pkg/snowflake/share.go
@@ -31,6 +31,6 @@ type share struct {
 
 func ScanShare(row *sqlx.Row) (*share, error) {
 	r := &share{}
-	e := row.StructScan(r)
-	return r, e
+	err := row.StructScan(r)
+	return r, err
 }

--- a/pkg/snowflake/share.go
+++ b/pkg/snowflake/share.go
@@ -1,5 +1,11 @@
 package snowflake
 
+import (
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
 // Share returns a pointer to a Builder that abstracts the DDL operations for a share.
 //
 // Supported DDL operations are:
@@ -15,4 +21,16 @@ func Share(name string) *Builder {
 		entityType: ShareType,
 		name:       name,
 	}
+}
+
+type share struct {
+	Name    sql.NullString `db:"name"`
+	To      sql.NullString `db:"to"`
+	Comment sql.NullString `db:"comment"`
+}
+
+func ScanShare(row *sqlx.Row) (*share, error) {
+	r := &share{}
+	e := row.StructScan(r)
+	return r, e
 }

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -196,7 +196,7 @@ func (sb *StageBuilder) Show() string {
 
 type stage struct {
 	Name               *string `db:"name"`
-	DatabaseName       *string `db:"Database_name"`
+	DatabaseName       *string `db:"database_name"`
 	SchemaName         *string `db:"schema_name"`
 	Comment            *string `db:"comment"`
 	StorageIntegration *string `db:"storage_integration"`
@@ -217,11 +217,11 @@ type descStageResult struct {
 }
 
 type descStageRow struct {
-	parentProperty  string
-	property        string
-	propertyType    string
-	propertyValue   string
-	propertyDefault string
+	parentProperty  string `db:"parent_property"`
+	property        string `db:"property"`
+	propertyType    string `db:"property_type"`
+	propertyValue   string `db:"property_value"`
+	propertyDefault string `db:"property_default"`
 }
 
 func DescStage(db *sql.DB, query string) (descStageResult, error) {

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -204,8 +204,8 @@ type stage struct {
 
 func ScanStageShow(row *sqlx.Row) (*stage, error) {
 	r := &stage{}
-	e := row.StructScan(r)
-	return r, e
+	err := row.StructScan(r)
+	return r, err
 }
 
 type descStageResult struct {
@@ -223,7 +223,7 @@ type descStageRow struct {
 	propertyDefault string `db:"property_default"`
 }
 
-func DescStage(db *sql.DB, query string) (descStageResult, error) {
+func DescStage(db *sql.DB, query string) (*descStageResult, error) {
 	var r descStageResult
 	var ff []string
 	var co []string

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -219,7 +219,6 @@ type descStageResult struct {
 type descStageRow struct {
 	parentProperty  string `db:"parent_property"`
 	property        string `db:"property"`
-	propertyType    string `db:"property_type"`
 	propertyValue   string `db:"property_value"`
 	propertyDefault string `db:"property_default"`
 }

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -1,8 +1,11 @@
 package snowflake
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // StageBuilder abstracts the creation of SQL queries for a Snowflake stage
@@ -189,4 +192,77 @@ func (sb *StageBuilder) Describe() string {
 // Show returns the SQL query that will show a stage.
 func (sb *StageBuilder) Show() string {
 	return fmt.Sprintf(`SHOW STAGES LIKE '%v' IN DATABASE "%v"`, sb.name, sb.db)
+}
+
+type stage struct {
+	Name               *string `db:"name"`
+	DatabaseName       *string `db:"Database_name"`
+	SchemaName         *string `db:"schema_name"`
+	Comment            *string `db:"comment"`
+	StorageIntegration *string `db:"storage_integration"`
+}
+
+func ScanStageShow(row *sqlx.Row) (*stage, error) {
+	r := &stage{}
+	e := row.StructScan(r)
+	return r, e
+}
+
+type descStageResult struct {
+	Url              string
+	AwsExternalID    string
+	SnowflakeIamUser string
+	FileFormat       string
+	CopyOptions      string
+}
+
+type descStageRow struct {
+	parentProperty  string
+	property        string
+	propertyType    string
+	propertyValue   string
+	propertyDefault string
+}
+
+func DescStage(db *sql.DB, query string) (descStageResult, error) {
+	var r descStageResult
+	var ff []string
+	var co []string
+	rows, err := Query(db, query)
+	if err != nil {
+		return r, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+
+		row := &descStageRow{}
+		if err := rows.StructScan(row); err != nil {
+			return r, err
+		}
+
+		switch row.property {
+		case "URL":
+			r.Url = strings.Trim(row.propertyValue, "[\"]")
+		case "AWS_EXTERNAL_ID":
+			r.AwsExternalID = row.propertyValue
+		case "SNOWFLAKE_IAM_USER":
+			r.SnowflakeIamUser = row.propertyValue
+		}
+
+		switch row.parentProperty {
+		case "STAGE_FILE_FORMAT":
+			if row.propertyValue != row.propertyDefault {
+				ff = append(ff, fmt.Sprintf("%s = %s", row.property, row.propertyValue))
+			}
+		case "STAGE_COPY_OPTIONS":
+			if row.propertyValue != row.propertyDefault {
+				co = append(co, fmt.Sprintf("%s = %s", row.property, row.propertyValue))
+			}
+		}
+	}
+
+	r.FileFormat = strings.Join(ff, " ")
+	r.CopyOptions = strings.Join(co, " ")
+	return r, nil
 }

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -224,7 +224,7 @@ type descStageRow struct {
 }
 
 func DescStage(db *sql.DB, query string) (*descStageResult, error) {
-	var r descStageResult
+	r := &descStageResult{}
 	var ff []string
 	var co []string
 	rows, err := Query(db, query)

--- a/pkg/snowflake/storage_integration.go
+++ b/pkg/snowflake/storage_integration.go
@@ -33,6 +33,6 @@ type storageIntegration struct {
 
 func ScanStorageIntegration(row *sqlx.Row) (*storageIntegration, error) {
 	r := &storageIntegration{}
-	e := row.StructScan(r)
-	return r, e
+	err := row.StructScan(r)
+	return r, err
 }

--- a/pkg/snowflake/storage_integration.go
+++ b/pkg/snowflake/storage_integration.go
@@ -1,5 +1,11 @@
 package snowflake
 
+import (
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
 // StorageIntegration returns a pointer to a Builder that abstracts the DDL operations for a storage integration.
 //
 // Supported DDL operations are:
@@ -15,4 +21,18 @@ func StorageIntegration(name string) *Builder {
 		entityType: StorageIntegrationType,
 		name:       name,
 	}
+}
+
+type storageIntegration struct {
+	Name            sql.NullString `db:"name"`
+	Category        sql.NullString `db:"category"`
+	IntegrationType sql.NullString `db:"integration_type"`
+	CreatedOn       sql.NullString `db:"created_on"`
+	Enabled         sql.NullBool   `db:"enabled"`
+}
+
+func ScanStorageIntegration(row *sqlx.Row) (*storageIntegration, error) {
+	r := &storageIntegration{}
+	e := row.StructScan(r)
+	return r, e
 }

--- a/pkg/snowflake/user.go
+++ b/pkg/snowflake/user.go
@@ -1,8 +1,31 @@
 package snowflake
 
+import (
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
 func User(name string) *Builder {
 	return &Builder{
 		entityType: UserType,
 		name:       name,
 	}
+}
+
+type user struct {
+	Comment          sql.NullString `db:"comment"`
+	DefaultNamespace sql.NullString `db:"default_namespace"`
+	DefaultRole      sql.NullString `db:"default_role"`
+	DefaultWarehouse sql.NullString `db:"default_warehouse"`
+	Disabled         bool           `db:"disabled"`
+	HasRsaPublicKey  bool           `db:"has_rsa_public_key"`
+	LoginName        sql.NullString `db:"login_name"`
+	Name             sql.NullString `db:"name"`
+}
+
+func ScanUser(row *sqlx.Row) (*user, error) {
+	r := &user{}
+	e := row.StructScan(r)
+	return r, e
 }

--- a/pkg/snowflake/user.go
+++ b/pkg/snowflake/user.go
@@ -26,6 +26,6 @@ type user struct {
 
 func ScanUser(row *sqlx.Row) (*user, error) {
 	r := &user{}
-	e := row.StructScan(r)
-	return r, e
+	err := row.StructScan(r)
+	return r, err
 }

--- a/pkg/snowflake/view.go
+++ b/pkg/snowflake/view.go
@@ -1,8 +1,11 @@
 package snowflake
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // ViewBuilder abstracts the creation of SQL queries for a Snowflake View
@@ -145,4 +148,19 @@ func (vb *ViewBuilder) Show() string {
 // Drop returns the SQL query that will drop the row representing this view.
 func (vb *ViewBuilder) Drop() string {
 	return fmt.Sprintf(`DROP VIEW %v`, vb.QualifiedName())
+}
+
+type view struct {
+	Comment      sql.NullString `db:"comment"`
+	IsSecure     bool           `db:"is_secure"`
+	Name         sql.NullString `db:"name"`
+	SchemaName   sql.NullString `db:"schema_name"`
+	Text         sql.NullString `db:"text"`
+	DatabaseName sql.NullString `db:"database_name"`
+}
+
+func ScanView(row *sqlx.Row) (*view, error) {
+	r := &view{}
+	e := row.StructScan(r)
+	return r, e
 }

--- a/pkg/snowflake/view.go
+++ b/pkg/snowflake/view.go
@@ -161,6 +161,6 @@ type view struct {
 
 func ScanView(row *sqlx.Row) (*view, error) {
 	r := &view{}
-	e := row.StructScan(r)
-	return r, e
+	err := row.StructScan(r)
+	return r, err
 }

--- a/pkg/snowflake/warehouse.go
+++ b/pkg/snowflake/warehouse.go
@@ -49,6 +49,6 @@ type warehouse struct {
 
 func ScanWarehouse(row *sqlx.Row) (*warehouse, error) {
 	w := &warehouse{}
-	e := row.StructScan(w)
-	return w, e
+	err := row.StructScan(w)
+	return w, err
 }

--- a/pkg/snowflake/warehouse.go
+++ b/pkg/snowflake/warehouse.go
@@ -1,8 +1,54 @@
 package snowflake
 
+import (
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
 func Warehouse(name string) *Builder {
 	return &Builder{
 		name:       name,
 		entityType: WarehouseType,
 	}
+}
+
+// warehouse is a go representation of a grant that can be used in conjunction
+// with github.com/jmoiron/sqlx
+type warehouse struct {
+	Name            string    `db:"name"`
+	State           string    `db:"state"`
+	Type            string    `db:"type"`
+	Size            string    `db:"size"`
+	MinClusterCount int64     `db:"min_cluster_count"`
+	MaxClusterCount int64     `db:"max_cluster_count"`
+	StartedClusters int64     `db:"started_clusters"`
+	Running         int64     `db:"running"`
+	Queued          int64     `db:"queued"`
+	IsDefault       string    `db:"is_default"`
+	IsCurrent       string    `db:"is_current"`
+	AutoSuspend     int64     `db:"auto_suspend"`
+	AutoResume      bool      `db:"auto_resume"`
+	Available       string    `db:"available"`
+	Provisioning    string    `db:"provisioning"`
+	Quiescing       string    `db:"quiescing"`
+	Other           string    `db:"other"`
+	CreatedOn       time.Time `db:"created_on"`
+	ResumedOn       time.Time `db:"resumed_on"`
+	UpdatedOn       time.Time `db:"updated_on"`
+	Owner           string    `db:"owner"`
+	Comment         string    `db:"comment"`
+	ResourceMonitor string    `db:"resource_monitor"`
+	Actives         int64     `db:"actives"`
+	Pendings        int64     `db:"pendings"`
+	Failed          int64     `db:"failed"`
+	Suspended       int64     `db:"suspended"`
+	UUID            string    `db:"uuid"`
+	ScalingPolicy   string    `db:"scaling_policy"`
+}
+
+func ScanWarehouse(row *sqlx.Row) (*warehouse, error) {
+	w := &warehouse{}
+	e := row.StructScan(w)
+	return w, e
 }


### PR DESCRIPTION
Scan all queries with sqlx.StructScan in unsafe mode so that we are resilient to snowflake adding new columns.

Because we have been using sql.Row.Scan, which requires that you list variables for each column you want to pull out (in order), if snowflake added a new column to any of our queries, code would break.

## Test Plan
* [x] acceptance tests

## References
* Fixes #161 