### PR TITLE
Fix download.sh to work with new GitHub release tags

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -50,7 +50,7 @@ execute() {
   srcdir="${tmpdir}"
   (cd "${tmpdir}" && untar "${TARBALL}")
   install -d "${BINDIR}"
-  for binexe in "terraform-provider-snowflake" ; do
+  for binexe in "terraform-provider-snowflake_${TAG}" ; do
     if [ "$OS" = "windows" ]; then
       binexe="${binexe}.exe"
     fi


### PR DESCRIPTION
The godownloader generated script wasn't working with the new release structure of this project -adding a _${TAG} to ensure it works with downloading the latest version.