### PR TITLE
update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chanzuckerberg/czi-shared-infra
+* @chanzuckerberg/terraform-provider-snowflake


### PR DESCRIPTION
As the czi-shared-infra team has grown (and we've stared auto-assigning
reviewers) it is the case that probably not everyone has enough context
to review code here.

Changing to a shorter list of myself, eduardo and allison.

## Test Plan
* none

## References
* 