### PR TITLE
adds oauth access token to provider schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ To export the variables into your provider:
 export SNOWFLAKE_USER="..."
 export SNOWFLAKE_PRIVATE_KEY_PATH="~/.ssh/snowflake_key"
 ```
+### OAuth Access Token
+If you have an OAuth access token, export these credentials as environment variables:
+```shell
+export SNOWFLAKE_USER='...''
+export SNOWFLAKE_OAUTH_ACCESS_TOKEN='...''
+```
+
+Note that once this access token expires, you'll need to request a new one through an external application.
 
 ### Username and Password Environment Variables
 If you choose to use Username and Password Authentication, export these credentials:


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
Adds OAuth access token support as requested [in this ticket](https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/37).

Note this does not add logic around renewing the access token. If the access token is not valid, the user is presented with the Snowflake error.

We have a use case where we would like to generate short-lived OAuth tokens and distribute to an application or user for a brief period of time.

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] Manual acceptance test: Generated valid oauth access token from Snowflake account with the correct roles, and verified that the roles are correct
* [ ] Manual acceptance test: Verified that when an empty access token is used, Snowflake reports "missing password"
* [ ] Unit test: DSN unit test corresponding to tests above

## References
<!-- issues documentation links, etc  -->
* [Snowflake OAuth Flow for Custom Clients](https://docs.snowflake.com/en/user-guide/oauth-custom.html#configure-snowflake-oauth-for-custom-clients)