### PR TITLE
[fix] task sql quoting

### DIFF
--- a/pkg/snowflake/escaping.go
+++ b/pkg/snowflake/escaping.go
@@ -9,3 +9,10 @@ func EscapeString(in string) string {
 	out = strings.Replace(out, `'`, `\'`, -1)
 	return out
 }
+
+// UnescapeString reverses EscapeString
+func UnescapeString(in string) string {
+	out := strings.Replace(in, `\\`, `\`, -1)
+	out = strings.Replace(out, `\'`, `'`, -1)
+	return out
+}

--- a/pkg/snowflake/task.go
+++ b/pkg/snowflake/task.go
@@ -153,7 +153,7 @@ func (tb *TaskBuilder) Create() string {
 	}
 
 	if tb.sql_statement != "" {
-		q.WriteString(fmt.Sprintf(` AS %v`, tb.sql_statement))
+		q.WriteString(fmt.Sprintf(` AS %v`, UnescapeString(tb.sql_statement)))
 	}
 
 	return q.String()
@@ -238,7 +238,7 @@ func (tb *TaskBuilder) ChangeCondition(newCondition string) string {
 
 // ChangeSqlStatement returns the sql that will update the sql the task executes.
 func (tb *TaskBuilder) ChangeSqlStatement(newStatement string) string {
-	return fmt.Sprintf(`ALTER TASK %v MODIFY AS %v`, tb.QualifiedName(), newStatement)
+	return fmt.Sprintf(`ALTER TASK %v MODIFY AS %v`, tb.QualifiedName(), UnescapeString(newStatement))
 }
 
 // Suspend returns the sql that will suspend the task.

--- a/pkg/snowflake/task_test.go
+++ b/pkg/snowflake/task_test.go
@@ -32,8 +32,8 @@ func TestTaskCreate(t *testing.T) {
 	st.WithCondition("SYSTEM$STREAM_HAS_DATA('MYSTREAM')")
 	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM')`)
 
-	st.WithStatement("INSERT INTO mytable(ts) VALUES(CURRENT_TIMESTAMP)")
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM') AS INSERT INTO mytable(ts) VALUES(CURRENT_TIMESTAMP)`)
+	st.WithStatement("SELECT * FROM table WHERE column = 'name'")
+	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM') AS SELECT * FROM table WHERE column = 'name'`)
 }
 
 func TestChangeWarehouse(t *testing.T) {


### PR DESCRIPTION
Snowflake doesn't like the sql string returned by terraform because when it contains quotes. It escapes the quotes by default. This PR removes `\` and unescapes the sql.
