### PR TITLE
[fix] DSN generation in tests

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -97,7 +97,16 @@ func Provider() *schema.Provider {
 }
 
 func ConfigureProvider(s *schema.ResourceData) (interface{}, error) {
-	dsn, err := DSN(s)
+	account := s.Get("account").(string)
+	user := s.Get("username").(string)
+	password := s.Get("password").(string)
+	browserAuth := s.Get("browser_auth").(bool)
+	privateKeyPath := s.Get("private_key_path").(string)
+	oauthAccessToken := s.Get("oauth_access_token").(string)
+	region := s.Get("region").(string)
+	role := s.Get("role").(string)
+
+	dsn, err := DSN(account, user, password, browserAuth, privateKeyPath, oauthAccessToken, region, role)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build dsn for snowflake connection")
@@ -111,15 +120,15 @@ func ConfigureProvider(s *schema.ResourceData) (interface{}, error) {
 	return db, nil
 }
 
-func DSN(s *schema.ResourceData) (string, error) {
-	account := s.Get("account").(string)
-	user := s.Get("username").(string)
-	password := s.Get("password").(string)
-	browserAuth := s.Get("browser_auth").(bool)
-	privateKeyPath := s.Get("private_key_path").(string)
-	oauthAccessToken := s.Get("oauth_access_token").(string)
-	region := s.Get("region").(string)
-	role := s.Get("role").(string)
+func DSN(
+	account,
+	user,
+	password string,
+	browserAuth bool,
+	privateKeyPath,
+	oauthAccessToken,
+	region,
+	role string) (string, error) {
 
 	// us-west-2 is their default region, but if you actually specify that it won't trigger their default code
 	//  https://github.com/snowflakedb/gosnowflake/blob/52137ce8c32eaf93b0bd22fc5c7297beff339812/dsn.go#L61
@@ -148,8 +157,10 @@ func DSN(s *schema.ResourceData) (string, error) {
 	} else if oauthAccessToken != "" {
 		config.Authenticator = gosnowflake.AuthTypeOAuth
 		config.Token = oauthAccessToken
-	} else {
+	} else if password != "" {
 		config.Password = password
+	} else {
+		return "", errors.New("no authentication method provided")
 	}
 
 	return gosnowflake.DSN(&config)


### PR DESCRIPTION
Refactor to make it easier to have consistent test results when testing
our DSN generation.

Previously the approach we were using would implicitly read environment
variables, which means that if you had any relevant ones set (like
`SNOWFLAKE_USER`) the test code would use that.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests

## References
* 