### PR TITLE
publish to terraform registry

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -45,7 +45,7 @@ signs:
       - "-o"
       - "${signature}"
       - "-k"
-      - "E29CCA1AAD621CDE"
+      - "{{.Env.KEYBASE_KEY_ID}}"
 
 
 release:

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,25 +1,50 @@
-before:
-  hooks:
-    - make clean
-
 builds:
-  - binary: terraform-provider-snowflake_{{ .Tag }}
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - darwin
-      - linux
-    goarch:
-      - amd64
-    ldflags:
-      - "-w -s -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.GitSha={{.Commit}} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Version={{.Version}} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Dirty={{.Env.DIRTY}}"
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - freebsd
+    - openbsd
+    - solaris
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+  ldflags:
+    - "-w -s -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.GitSha={{.Commit}} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Version={{.Version}} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Dirty={{.Env.DIRTY}}"
+  ignore:
+    - goos: darwin
+      goarch: '386'
+    - goos: openbsd
+      goarch: arm
+    - goos: openbsd
+      goarch: arm64
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:
-  - files:
-    - none*
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+
+signs:
+  - artifacts: checksum
+    cmd: keybase
+    args:
+      - pgp
+      - sign
+      - "--key"
+      - "E29CCA1AAD621CDE"
+      - "--outfile"
+      - "${signature}"
+      - "--detached"
+      - "--infile"
+      - "${artifact}"
 
 release:
   prerelease: true
-
-env_files:
-  github_token: ~/.config/goreleaser/github_token

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -41,13 +41,12 @@ signs:
       - "-b"
       - "-d"
       - "-i"
-      - "terraform-provider-snowflake_{{ .Version }}_SHA256SUMS"
+      - "${artifact}"
       - "-o"
       - "${signature}"
       - "-k"
       - "E29CCA1AAD621CDE"
 
-# 
 
 release:
   prerelease: true

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -38,13 +38,16 @@ signs:
     args:
       - pgp
       - sign
-      - "--key"
-      - "E29CCA1AAD621CDE"
-      - "--outfile"
+      - "-b"
+      - "-d"
+      - "-i"
+      - "terraform-provider-snowflake_{{ .Version }}_SHA256SUMS"
+      - "-o"
       - "${signature}"
-      - "--detached"
-      - "--infile"
-      - "${artifact}"
+      - "-k"
+      - "E29CCA1AAD621CDE"
+
+# 
 
 release:
   prerelease: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,25 +1,48 @@
-before:
-  hooks:
-    - make clean
-
 builds:
-  - binary: terraform-provider-snowflake_{{ .Tag }}
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - darwin
-      - linux
-    goarch:
-      - amd64
-    ldflags:
-      - "-w -s -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.GitSha={{.Commit}} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Version={{.Version}} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Dirty={{.Env.DIRTY}}"
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - freebsd
+    - openbsd
+    - solaris
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+  ldflags:
+    - "-w -s -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.GitSha={{.Commit}} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Version={{.Version}} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Dirty={{.Env.DIRTY}}"
+  ignore:
+    - goos: darwin
+      goarch: '386'
+    - goos: openbsd
+      goarch: arm
+    - goos: openbsd
+      goarch: arm64
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:
-  - files:
-    - none*
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
-release:
-  prerelease: false
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
 
-env_files:
-  github_token: ~/.config/goreleaser/github_token
+signs:
+  - artifacts: checksum
+    cmd: keybase
+    args:
+      - pgp
+      - sign
+      - "-b"
+      - "-d"
+      - "-i"
+      - "${artifact}"
+      - "-o"
+      - "${signature}"
+      - "-k"
+      - "{{.Env.KEYBASE_KEY_ID}}"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SHA=$(shell git rev-parse --short HEAD)
 VERSION=$(shell cat VERSION)
 export DIRTY=$(shell if `git diff-index --quiet HEAD --`; then echo false; else echo true;  fi)
-# TODO add release flag
 LDFLAGS=-ldflags "-w -s -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.GitSha=${SHA} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Version=${VERSION} -X github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version.Dirty=${DIRTY}"
 export BASE_BINARY_NAME=terraform-provider-snowflake_v$(VERSION)
 export GO111MODULE=on
@@ -29,13 +28,19 @@ lint-all: fmt ## run the fast go linters
 	./bin/golangci-lint run
 .PHONY: lint-all
 
-release: ## run a release
+check-release-prereqs:
+ifndef KEYBASE_KEY_ID
+	$(error KEYBASE_KEY_ID is undefined)
+endif
+.PHONY: check-release-prereqs
+
+release: check-release-prereqs ## run a release
 	./bin/bff bump
 	git push
 	goreleaser release
 .PHONY: release
 
-release-prerelease: build ## release to github as a 'pre-release'
+release-prerelease: check-release-prereqs build ## release to github as a 'pre-release'
 	version=`./$(BASE_BINARY_NAME) -version`; \
 	git tag v"$$version"; \
 	# git push

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ release: check-release-prereqs ## run a release
 release-prerelease: check-release-prereqs build ## release to github as a 'pre-release'
 	version=`./$(BASE_BINARY_NAME) -version`; \
 	git tag v"$$version"; \
-	# git push
+	git push
 	git push --tags
 	goreleaser release -f .goreleaser.prerelease.yml --debug --rm-dist
 .PHONY: release-prerelease

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ release: check-release-prereqs ## run a release
 release-prerelease: check-release-prereqs build ## release to github as a 'pre-release'
 	version=`./$(BASE_BINARY_NAME) -version`; \
 	git tag v"$$version"; \
-	# git push
 	git push --tags
 	goreleaser release -f .goreleaser.prerelease.yml --debug --rm-dist
 .PHONY: release-prerelease

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ release: check-release-prereqs ## run a release
 release-prerelease: check-release-prereqs build ## release to github as a 'pre-release'
 	version=`./$(BASE_BINARY_NAME) -version`; \
 	git tag v"$$version"; \
+	# git push
 	git push --tags
 	goreleaser release -f .goreleaser.prerelease.yml --debug --rm-dist
 .PHONY: release-prerelease

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ release: ## run a release
 release-prerelease: build ## release to github as a 'pre-release'
 	version=`./$(BASE_BINARY_NAME) -version`; \
 	git tag v"$$version"; \
-	git push
+	# git push
 	git push --tags
-	goreleaser release -f .goreleaser.prerelease.yml --debug
+	goreleaser release -f .goreleaser.prerelease.yml --debug --rm-dist
 .PHONY: release-prerelease
 
 release-snapshot: ## run a release

--- a/README.md
+++ b/README.md
@@ -483,3 +483,10 @@ If you are using the Standard Snowflake plan, it's recommended you also set up t
 * `SKIP_DATABASE_TESTS` - to skip tests with retention time larger than 1 day
 * `SKIP_WAREHOUSE_TESTS` - to skip tests with multi warehouses
 
+## Releasing
+
+**Note: Currently only @ryanking and @edulop91 have keys that are whitelisted in the terraform registry, so only they can do releases.**
+
+Releases are done by [goreleaser](https://goreleaser.com/) and run by our make files. There two goreleaser configs, `.goreleaser.yml` for regular releases and `.goreleaser.prerelease.yml` for doing prereleases (for testing).
+
+As of recently releases are also [published to the terraform registry](https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest). That publishing requires that releases by signed. We do that signing via goreleaser using individual keybase keys. They key you want to use to sign must be passed in with the `KEYBASE_KEY_ID` environment variable.


### PR DESCRIPTION
Publish this provider to the terraform registry.

In terraform 0.13 third party providers can be published to the terraform registry. This PR implements the necessary pieces, including signing all releases.

## Test Plan
* [x] pushed 0.13.0+b2a3596 to the registry at https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest?pollNotifications=true

## References
* https://docs.google.com/document/d/1J4p5KFH129wZbSF0XUioDbHSB7uZA-l2o1psLa-3YS4/edit