### PR TITLE
[feature] sensitive flag on stage credentials

### DIFF
--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -44,6 +44,7 @@ var stageSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "Specifies the credentials for the stage.",
+		Sensitive:   true,
 	},
 	"storage_integration": &schema.Schema{
 		Type:        schema.TypeString,


### PR DESCRIPTION
The contents of the credentials field on snowflake_stage resources appear on the command line when running `terraform plan` and `terraform apply`.  terraform cloud or Gitflow based tools such as atlantis will subsequently expose these credentials when threading into github.   This change follows terraform best-practices guide to hide sensitive data.

## Test Plan
* [X] built locally and verified credentials are not shown
* [X] local internal/unit/acceptance tests

## References
* https://www.terraform.io/docs/extend/best-practices/sensitive-state.html#using-the-sensitive-flag