### PR TITLE
Add pipe grant

### DIFF
--- a/pkg/resources/pipe_grant.go
+++ b/pkg/resources/pipe_grant.go
@@ -1,0 +1,153 @@
+package resources
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
+)
+
+var validPipePrivileges = newPrivilegeSet(
+	privilegeAll,
+	privilegeOwnership,
+)
+
+var pipeGrantSchema = map[string]*schema.Schema{
+	"pipe_name": &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The name of the pipe on which to grant privileges.",
+		ForceNew:    true,
+	},
+	"schema_name": &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The name of the schema containing the current pipe on which to grant privileges.",
+		ForceNew:    true,
+	},
+	"database_name": &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The name of the database containing the current pipe on which to grant privileges.",
+		ForceNew:    true,
+	},
+	"privilege": &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Description:  "The privilege to grant on the pipe.",
+		Default:      "USAGE",
+		ValidateFunc: validation.StringInSlice(validPipePrivileges.toList(), true),
+		ForceNew:     true,
+	},
+	"roles": &schema.Schema{
+		Type:        schema.TypeSet,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Optional:    true,
+		Description: "Grants privilege to these roles.",
+		ForceNew:    true,
+	},
+	"shares": &schema.Schema{
+		Type:        schema.TypeSet,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Optional:    true,
+		Description: "Grants privilege to these shares.",
+		ForceNew:    true,
+	},
+}
+
+// PipeGrant returns a pointer to the resource representing a pipe grant
+func PipeGrant() *schema.Resource {
+	return &schema.Resource{
+		Create: CreatePipeGrant,
+		Read:   ReadPipeGrant,
+		Delete: DeletePipeGrant,
+
+		Schema: pipeGrantSchema,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+// CreatePipeGrant implements schema.CreateFunc
+func CreatePipeGrant(data *schema.ResourceData, meta interface{}) error {
+	var pipeName string
+	if _, ok := data.GetOk("pipe_name"); ok {
+		pipeName = data.Get("pipe_name").(string)
+	} else {
+		pipeName = ""
+	}
+	schemaName := data.Get("schema_name").(string)
+	dbName := data.Get("database_name").(string)
+	priv := data.Get("privilege").(string)
+
+	var builder snowflake.GrantBuilder
+	builder = snowflake.PipeGrant(dbName, schemaName, pipeName)
+
+	err := createGenericGrant(data, meta, builder)
+	if err != nil {
+		return err
+	}
+
+	grant := &grantID{
+		ResourceName: dbName,
+		SchemaName:   schemaName,
+		ObjectName:   pipeName,
+		Privilege:    priv,
+	}
+	dataIDInput, err := grant.String()
+	if err != nil {
+		return err
+	}
+	data.SetId(dataIDInput)
+
+	return ReadPipeGrant(data, meta)
+}
+
+// ReadPipeGrant implements schema.ReadFunc
+func ReadPipeGrant(data *schema.ResourceData, meta interface{}) error {
+	grantID, err := grantIDFromString(data.Id())
+	if err != nil {
+		return err
+	}
+	dbName := grantID.ResourceName
+	schemaName := grantID.SchemaName
+	pipeName := grantID.ObjectName
+	priv := grantID.Privilege
+
+	err = data.Set("database_name", dbName)
+	if err != nil {
+		return err
+	}
+	err = data.Set("schema_name", schemaName)
+	if err != nil {
+		return err
+	}
+	err = data.Set("pipe_name", pipeName)
+	if err != nil {
+		return err
+	}
+	err = data.Set("privilege", priv)
+	if err != nil {
+		return err
+	}
+
+	builder := snowflake.PipeGrant(dbName, schemaName, pipeName)
+
+	return readGenericGrant(data, meta, builder, false, validPipePrivileges)
+}
+
+// DeletePipeGrant implements schema.DeleteFunc
+func DeletePipeGrant(data *schema.ResourceData, meta interface{}) error {
+	grantID, err := grantIDFromString(data.Id())
+	if err != nil {
+		return err
+	}
+	dbName := grantID.ResourceName
+	schemaName := grantID.SchemaName
+	pipeName := grantID.ObjectName
+
+	builder := snowflake.PipeGrant(dbName, schemaName, pipeName)
+
+	return deleteGenericGrant(data, meta, builder)
+}

--- a/pkg/resources/pipe_grant_test.go
+++ b/pkg/resources/pipe_grant_test.go
@@ -1,0 +1,62 @@
+package resources_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/provider"
+	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
+	. "github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipeGrant(t *testing.T) {
+	r := require.New(t)
+	err := resources.PipeGrant().InternalValidate(provider.Provider().Schema, true)
+	r.NoError(err)
+}
+
+func TestPipeGrantCreate(t *testing.T) {
+	r := require.New(t)
+
+	test_priv := "ALL"
+	in := map[string]interface{}{
+		"pipe_name":     "test-pipe",
+		"schema_name":   "test-schema",
+		"database_name": "test-db",
+		"privilege":     test_priv,
+		"roles":         []interface{}{"test-role-1", "test-role-2"},
+		"shares":        []interface{}{"test-share-1", "test-share-2"},
+	}
+	d := schema.TestResourceDataRaw(t, resources.PipeGrant().Schema, in)
+	r.NotNil(d)
+
+	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(fmt.Sprintf(`^GRANT %s ON PIPE "test-db"."test-schema"."test-pipe" TO ROLE "test-role-1"$`, test_priv)).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(fmt.Sprintf(`^GRANT %s ON PIPE "test-db"."test-schema"."test-pipe" TO ROLE "test-role-2"$`, test_priv)).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(fmt.Sprintf(`^GRANT %s ON PIPE "test-db"."test-schema"."test-pipe" TO SHARE "test-share-1"$`, test_priv)).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(fmt.Sprintf(`^GRANT %s ON PIPE "test-db"."test-schema"."test-pipe" TO SHARE "test-share-2"$`, test_priv)).WillReturnResult(sqlmock.NewResult(1, 1))
+		expectReadPipeGrant(mock, test_priv)
+		err := resources.CreatePipeGrant(d, db)
+		r.NoError(err)
+	})
+}
+
+func expectReadPipeGrant(mock sqlmock.Sqlmock, test_priv string) {
+	rows := sqlmock.NewRows([]string{
+		"created_on", "privilege", "granted_on", "name", "granted_to", "grantee_name", "grant_option", "granted_by",
+	}).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), test_priv, "PIPE", "test-pipe", "ROLE", "test-role-1", false, "bob",
+	).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), test_priv, "PIPE", "test-pipe", "ROLE", "test-role-2", false, "bob",
+	).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), test_priv, "PIPE", "test-pipe", "SHARE", "test-share-1", false, "bob",
+	).AddRow(
+		time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), test_priv, "PIPE", "test-pipe", "SHARE", "test-share-2", false, "bob",
+	)
+	mock.ExpectQuery(`^SHOW GRANTS ON PIPE "test-db"."test-schema"."test-pipe"$`).WillReturnRows(rows)
+}

--- a/pkg/snowflake/grant.go
+++ b/pkg/snowflake/grant.go
@@ -80,7 +80,7 @@ func StageGrant(db, schema, stage string) GrantBuilder {
 	}
 }
 
-// PipeGrant returns a pointer to a CurrentGrantBuilder for a stage
+// PipeGrant returns a pointer to a CurrentGrantBuilder for a pipe
 func PipeGrant(db, schema, pipe string) GrantBuilder {
 	return &CurrentGrantBuilder{
 		name:          pipe,

--- a/pkg/snowflake/grant.go
+++ b/pkg/snowflake/grant.go
@@ -15,6 +15,7 @@ const (
 	databaseType  grantType = "DATABASE"
 	schemaType    grantType = "SCHEMA"
 	stageType     grantType = "STAGE"
+	pipeType      grantType = "PIPE"
 	viewType      grantType = "VIEW"
 	tableType     grantType = "TABLE"
 	warehouseType grantType = "WAREHOUSE"
@@ -76,6 +77,15 @@ func StageGrant(db, schema, stage string) GrantBuilder {
 		name:          stage,
 		qualifiedName: fmt.Sprintf(`"%v"."%v"."%v"`, db, schema, stage),
 		grantType:     stageType,
+	}
+}
+
+// PipeGrant returns a pointer to a CurrentGrantBuilder for a stage
+func PipeGrant(db, schema, pipe string) GrantBuilder {
+	return &CurrentGrantBuilder{
+		name:          pipe,
+		qualifiedName: fmt.Sprintf(`"%v"."%v"."%v"`, db, schema, pipe),
+		grantType:     pipeType,
 	}
 }
 


### PR DESCRIPTION
Add a snowflake pipe grant resource. Currently pipes only support ALL and OWNERSHIP privilege statements. (https://docs.snowflake.com/en/user-guide/security-access-control-privileges.html#pipe-privileges)

This was almost a find and replace exercise on the stage_grant resource. 

I have added unit tests but not acceptance tests.