### PR TITLE
[fix] skip test broken by snowflake

### DIFF
--- a/pkg/resources/task_acceptance_test.go
+++ b/pkg/resources/task_acceptance_test.go
@@ -157,7 +157,7 @@ var (
 )
 
 func Test_AccTask(t *testing.T) {
-	t.Skip("broken by a change to snowflake")
+	t.Skip("broken by a change to snowflake. see example https://travis-ci.com/github/chanzuckerberg/terraform-provider-snowflake/jobs/367972245#L676")
 
 	resource.Test(t, resource.TestCase{
 		Providers: providers(),

--- a/pkg/resources/task_acceptance_test.go
+++ b/pkg/resources/task_acceptance_test.go
@@ -157,6 +157,8 @@ var (
 )
 
 func Test_AccTask(t *testing.T) {
+	t.Skip("broken by a change to snowflake")
+
 	resource.Test(t, resource.TestCase{
 		Providers: providers(),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Snowflake appears to have changed something which is now causing this
test to fail. Skipping it for now while I find someone who can address
the problem.

cc @henriblancke  and @chriskuchin  who worked on this originally. Any chance one of you could look at this?

## Test Plan
* [ ] acceptance tests

## References
* https://github.com/chanzuckerberg/terraform-provider-snowflake/pull/196 