### PR TITLE
[fix] issues with \r\n and ; line endings

### DIFF
--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -41,21 +41,11 @@ var pipeSchema = map[string]*schema.Schema{
 		Description: "Specifies a comment for the pipe.",
 	},
 	"copy_statement": {
-		Type:        schema.TypeString,
-		Required:    true,
-		ForceNew:    true,
-		Description: "Specifies the copy statement for the pipe.",
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			// standardise line endings
-			old = strings.ReplaceAll(old, "\r\n", "\n")
-			new = strings.ReplaceAll(new, "\r\n", "\n")
-
-			// trim off any trailing line endings
-			if strings.TrimRight(old, ";\r\n") == strings.TrimRight(new, ";\r\n") {
-				return true
-			}
-			return false
-		},
+		Type:             schema.TypeString,
+		Required:         true,
+		ForceNew:         true,
+		Description:      "Specifies the copy statement for the pipe.",
+		DiffSuppressFunc: pipeCopyStatementDiffSuppress,
 	},
 	"auto_ingest": {
 		Type:        schema.TypeBool,
@@ -89,6 +79,18 @@ func Pipe() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 	}
+}
+
+func pipeCopyStatementDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// standardise line endings
+	old = strings.ReplaceAll(old, "\r\n", "\n")
+	new = strings.ReplaceAll(new, "\r\n", "\n")
+
+	// trim off any trailing line endings
+	if strings.TrimRight(old, ";\r\n") == strings.TrimRight(new, ";\r\n") {
+		return true
+	}
+	return false
 }
 
 type pipeID struct {

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -46,7 +46,12 @@ var pipeSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 		Description: "Specifies the copy statement for the pipe.",
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			if strings.TrimSuffix(old, "\n") == strings.TrimSuffix(new, "\n") {
+			// standardise line endings
+			old = strings.ReplaceAll(old, "\r\n", "\n")
+			new = strings.ReplaceAll(new, "\r\n", "\n")
+
+			// trim off any trailing line endings
+			if strings.TrimRight(old, ";\r\n") == strings.TrimRight(new, ";\r\n") {
 				return true
 			}
 			return false

--- a/pkg/resources/pipe_internal_test.go
+++ b/pkg/resources/pipe_internal_test.go
@@ -70,3 +70,99 @@ func TestPipeStruct(t *testing.T) {
 	r.Equal("database|name", newPipe.DatabaseName)
 	r.Equal("pipe|name", newPipe.PipeName)
 }
+
+const pipeCopyStatementTemplate string = "COPY INTO MY_DATABASE.MY_SCHEMA.%[4]s (%[1]s%[2]sID%[1]s%[2]s,VALUE%[1]s) FROM (%[1]s%[2]sSELECT%[1]s%[2]s%[2]sSRC.$1%[1]s%[2]s%[2]s,SRC.$2%[1]s%[2]sFROM @MY_DATABASE.MY_SCHEMA.MY_STAGE AS SRC%[1]s)%[1]sFILE_FORMAT = (%[1]s%[2]sFORMAT_NAME = MY_DATABASE.MY_SCHEMA.JSON%[1]s)%[1]sON_ERROR = CONTINUE%[3]s"
+
+func generatecopyStatement(lineEnding string, indent string, includeSemiColon bool, tableName string) string {
+	semiColon := ""
+
+	if includeSemiColon {
+		semiColon = ";"
+	}
+
+	return fmt.Sprintf(
+		pipeCopyStatementTemplate,
+		lineEnding,
+		indent,
+		semiColon,
+		tableName,
+	)
+}
+
+func TestPipeCopyStatementDiffSuppress(t *testing.T) {
+	type testCaseData struct {
+		declared  string
+		showPipes string
+		expected  bool
+	}
+
+	testCases := map[string]testCaseData{
+		"TestDiffSuppressSingleLine": {
+			declared:  generatecopyStatement("", " ", false, "MY_TABLE"),
+			showPipes: generatecopyStatement("", " ", false, "MY_TABLE"),
+			expected:  true,
+		},
+		"TestDiffSuppressMultiLineUnix": {
+			declared:  generatecopyStatement("\n", "  ", false, "MY_TABLE"),
+			showPipes: generatecopyStatement("\n", "  ", false, "MY_TABLE"),
+			expected:  true,
+		},
+		"TestDiffSuppressMultiLineWindows": {
+			declared:  generatecopyStatement("\n", "  ", false, "MY_TABLE"),
+			showPipes: generatecopyStatement("\r\n", "  ", false, "MY_TABLE"),
+			expected:  true,
+		},
+		"TestDiffSuppressSingleLineWithEndStatement": {
+			declared:  generatecopyStatement("", " ", true, "MY_TABLE"),
+			showPipes: generatecopyStatement("", " ", false, "MY_TABLE"),
+			expected:  true,
+		},
+		"TestDiffSuppressMultiLineUnixWithEndStatement": {
+			declared:  generatecopyStatement("\n", "  ", true, "MY_TABLE"),
+			showPipes: generatecopyStatement("\n", "  ", false, "MY_TABLE"),
+			expected:  true,
+		},
+		"TestDiffSuppressMultiLineWindowsWithEndStatement": {
+			declared:  generatecopyStatement("\n", "  ", true, "MY_TABLE"),
+			showPipes: generatecopyStatement("\r\n", "  ", false, "MY_TABLE"),
+			expected:  true,
+		},
+		"TestNoDiffSuppressSingleLine": {
+			declared:  generatecopyStatement("", " ", false, "MY_TABLE"),
+			showPipes: generatecopyStatement("", " ", false, "MY_OTHER_TABLE"),
+			expected:  false,
+		},
+		"TestNoDiffSuppressMultiLineUnix": {
+			declared:  generatecopyStatement("\n", "  ", false, "MY_TABLE"),
+			showPipes: generatecopyStatement("\n", "  ", false, "MY_OTHER_TABLE"),
+			expected:  false,
+		},
+		"TestNoDiffSuppressMultiLineWindows": {
+			declared:  generatecopyStatement("\n", "  ", false, "MY_TABLE"),
+			showPipes: generatecopyStatement("\r\n", "  ", false, "MY_OTHER_TABLE"),
+			expected:  false,
+		},
+		"TestNoDiffSuppressSingleLineWithEndStatement": {
+			declared:  generatecopyStatement("", " ", true, "MY_TABLE"),
+			showPipes: generatecopyStatement("", " ", false, "MY_OTHER_TABLE"),
+			expected:  false,
+		},
+		"TestNoDiffSuppressMultiLineUnixWithEndStatement": {
+			declared:  generatecopyStatement("\n", "  ", true, "MY_TABLE"),
+			showPipes: generatecopyStatement("\n", "  ", false, "MY_OTHER_TABLE"),
+			expected:  false,
+		},
+		"TestNoDiffSuppressMultiLineWindowsWithEndStatement": {
+			declared:  generatecopyStatement("\n", "  ", true, "MY_TABLE"),
+			showPipes: generatecopyStatement("\r\n", "  ", false, "MY_OTHER_TABLE"),
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			r.Equal(testCase.expected, pipeCopyStatementDiffSuppress("", testCase.declared, testCase.showPipes, nil))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

Fixes issue whereby line `\r\n` endings and trailing `;` are not returned in the same format as originally declared in the result of a `SHOW PIPE` statement.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* Fixes #246