### PR TITLE
[feature] masking policy schema grant

### DIFF
--- a/pkg/resources/privileges.go
+++ b/pkg/resources/privileges.go
@@ -37,6 +37,7 @@ const (
 	privilegeCreateExternalTable    privilege = "CREATE EXTERNAL TABLE"
 	privilegeCreateMaterializedView privilege = "CREATE MATERIALIZED VIEW"
 	privilegeCreateTemporaryTable   privilege = "CREATE TEMPORARY TABLE"
+	privilegeCreateMaskingPolicy    privilege = "CREATE MASKING POLICY"
 
 	privilegeCreateRole        privilege = "CREATE ROLE"
 	privilegeCreateUser        privilege = "CREATE USER"

--- a/pkg/resources/schema_grant.go
+++ b/pkg/resources/schema_grant.go
@@ -29,6 +29,7 @@ var validSchemaPrivileges = newPrivilegeSet(
 	privilegeCreateExternalTable,
 	privilegeCreateMaterializedView,
 	privilegeCreateTemporaryTable,
+	privilegeCreateMaskingPolicy,
 )
 
 var schemaGrantSchema = map[string]*schema.Schema{


### PR DESCRIPTION
This PR adds a missing schema grant of "CREATE MASKING POLICY".  

This Snowflake documentation shows this is a valid privilege in the schemaPrivileges section:
https://docs.snowflake.com/en/sql-reference/sql/grant-privilege.html#syntax

## Test Plan
I've ran the `make test` locally. This privilege is no different than any other schema privileges. 

## References
This should resolve this issue, which I opened: 
https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/256
