### PR TITLE
[fix] If NULL_IF list is empty fix it with brackets

### DIFF
--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -9,7 +9,6 @@ import (
 )
 
 func fixFileFormat(inputFileFormat string) string {
-        println("TFDEBUG - Fixing file format", inputFileFormat)
 	return strings.Replace(inputFileFormat, "NULL_IF = []", "NULL_IF = ()", 1)
 }
 

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -8,6 +8,11 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+func fixFileFormat(inputFileFormat string) string {
+        println("TFDEBUG - Fixing file format", inputFileFormat)
+	return strings.Replace(inputFileFormat, "NULL_IF = []", "NULL_IF = ()", 1)
+}
+
 // StageBuilder abstracts the creation of SQL queries for a Snowflake stage
 type StageBuilder struct {
 	name               string
@@ -115,7 +120,7 @@ func (sb *StageBuilder) Create() string {
 	}
 
 	if sb.fileFormat != "" {
-		q.WriteString(fmt.Sprintf(` FILE_FORMAT = (%v)`, sb.fileFormat))
+		q.WriteString(fmt.Sprintf(` FILE_FORMAT = (%v)`, fixFileFormat(sb.fileFormat)))
 	}
 
 	if sb.copyOptions != "" {
@@ -166,7 +171,7 @@ func (sb *StageBuilder) ChangeEncryption(e string) string {
 
 // ChangeFileFormat returns the SQL query that will update the file format on the stage.
 func (sb *StageBuilder) ChangeFileFormat(f string) string {
-	return fmt.Sprintf(`ALTER STAGE %v SET FILE_FORMAT = (%v)`, sb.QualifiedName(), f)
+	return fmt.Sprintf(`ALTER STAGE %v SET FILE_FORMAT = (%v)`, sb.QualifiedName(), fixFileFormat(f))
 }
 
 // ChangeCopyOptions returns the SQL query that will update the copy options on the stage.

--- a/pkg/snowflake/stage_test.go
+++ b/pkg/snowflake/stage_test.go
@@ -59,6 +59,12 @@ func TestStageChangeFileFormat(t *testing.T) {
 	r.Equal(s.ChangeFileFormat("format_name=my_csv_format"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (format_name=my_csv_format)`)
 }
 
+func TestStageChangeFileFormatToEmptyList(t *testing.T) {
+	r := require.New(t)
+	s := Stage("test_stage", "test_db", "test_schema")
+	r.Equal(s.ChangeFileFormat("TYPE = parquet NULL_IF = [] COMPRESSION = none"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (TYPE = parquet NULL_IF = () COMPRESSION = none)`)
+}
+
 func TestStageChangeEncryption(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ x] …

## References
<!-- issues documentation links, etc  -->

* This fix should avoid getting an SQL error when a stage has defined a NULL_IF = [] file format property. The provider now does not run `NULL_IF = []` but it executes `NULL_IF = ()`