### PR TITLE
fix:build: Add trimpath Go flag to build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,8 @@ builds:
     - '386'
     - arm
     - arm64
+  flags:
+    - -trimpath
   ldflags:
     - "-w -s -X github.com/chanzuckerberg/go-misc/ver.GitSha={{.Commit}} -X github.com/chanzuckerberg/go-misc/ver.Version={{.Version}} -X github.com/chanzuckerberg/go-misc/ver.Dirty={{.Env.DIRTY}}"
   ignore:


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
Trimpath Go flag to builds. This way my local machine paths won't get baked into the binary.

## Test Plan
Copy/pasted from https://github.com/goreleaser/goreleaser/blob/master/.goreleaser.yml#L21

## References
<!-- issues documentation links, etc  -->

* https://github.com/goreleaser/goreleaser/blob/master/.goreleaser.yml