### PR TITLE
[feature] ok-to-test allows testing on forked branches with secrets

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,118 @@
+# Run secret-dependent integration tests only after /ok-to-test approval
+on:
+  pull_request:
+  repository_dispatch:
+    types: [ok-to-test-command]
+
+name: Integration tests
+
+jobs:
+  # Branch-based pull request
+  integration-trusted:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+
+    - name: Branch based PR checkout
+      uses: actions/checkout@v2
+
+    # Insert integration tests needing secrets
+    strategy:
+      matrix:
+        target:
+          - check-docs
+          - check-mod
+          - lint-ci
+          - test-acceptance-ci
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15.2'
+      - name: Install dependencies
+        run: make setup
+
+      - name: make ${{ matrix.target }}
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_GITHUB_API_TOKEN }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
+        run: make ${{ matrix.target }}
+
+  # Repo owner has commented /ok-to-test on a (fork-based) pull request
+  integration-fork:
+    runs-on: ubuntu-latest
+    if:
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.sha == github.event.client_payload.pull_request.head.sha
+    steps:
+
+    # Check out merge commit
+    - name: Fork based /ok-to-test checkout
+      uses: actions/checkout@v2
+      with:
+        ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+
+    # Integration tests needing secrets
+    strategy:
+      matrix:
+        target:
+          - check-docs
+          - check-mod
+          - lint-ci
+          - test-acceptance-ci
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15.2'
+      - name: Install dependencies
+        run: make setup
+
+      - name: make ${{ matrix.target }}
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_GITHUB_API_TOKEN }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
+        run: make ${{ matrix.target }}
+
+    - run: |
+        echo "Integration tests... success! ;-)"
+
+    # Update check run called "integration-fork"
+    - uses: actions/github-script@v1
+      id: update-check-run
+      if: ${{ always() }}
+      env:
+        number: ${{ github.event.client_payload.pull_request.number }}
+        job: ${{ github.job }}
+        # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+        conclusion: ${{ job.status }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { data: pull } = await github.pulls.get({
+            ...context.repo,
+            pull_number: process.env.number
+          });
+          const ref = pull.head.sha;
+
+          const { data: checks } = await github.checks.listForRef({
+            ...context.repo,
+            ref
+          });
+
+          const check = checks.check_runs.filter(c => c.name === process.env.job);
+
+          const { data: result } = await github.checks.update({
+            ...context.repo,
+            check_run_id: check[0].id,
+            status: 'completed',
+            conclusion: process.env.conclusion
+          });
+
+          return result;

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,7 @@ jobs:
   # Branch-based pull request
   integration-trusted:
     runs-on: ubuntu-latest
+    # Runs tests when a PR is opened from the original repo (not a forked repo), which protects the secrets and builds for trusted contributors
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       matrix:
@@ -39,6 +40,7 @@ jobs:
   integration-fork:
     runs-on: ubuntu-latest
     if:
+    # Strict rule to check the latest commit sha with the one provided in the ok-to-test command
       github.event_name == 'repository_dispatch' &&
       github.event.client_payload.slash_command.sha == github.event.client_payload.pull_request.head.sha
     # Integration tests needing secrets
@@ -53,7 +55,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
-      - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: '1.15.2'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,11 +11,6 @@ jobs:
   integration-trusted:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-
-    - name: Branch based PR checkout
-      uses: actions/checkout@v2
-
     strategy:
       matrix:
         target:
@@ -46,14 +41,6 @@ jobs:
     if:
       github.event_name == 'repository_dispatch' &&
       github.event.client_payload.slash_command.sha == github.event.client_payload.pull_request.head.sha
-    steps:
-
-    # Check out merge commit
-    - name: Fork based /ok-to-test checkout
-      uses: actions/checkout@v2
-      with:
-        ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
-
     # Integration tests needing secrets
     strategy:
       matrix:
@@ -63,6 +50,9 @@ jobs:
           - lint-ci
           - test
     steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
@@ -78,40 +68,35 @@ jobs:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
         run: make ${{ matrix.target }}
+      - uses: actions/github-script@v1
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
 
-    - run: |
-        echo "Integration tests... success! ;-)"
+            const { data: checks } = await github.checks.listForRef({
+              ...context.repo,
+              ref
+            });
 
-    # Update check run called "integration-fork"
-    - uses: actions/github-script@v1
-      id: update-check-run
-      if: ${{ always() }}
-      env:
-        number: ${{ github.event.client_payload.pull_request.number }}
-        job: ${{ github.job }}
-        # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
-        conclusion: ${{ job.status }}
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const { data: pull } = await github.pulls.get({
-            ...context.repo,
-            pull_number: process.env.number
-          });
-          const ref = pull.head.sha;
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
 
-          const { data: checks } = await github.checks.listForRef({
-            ...context.repo,
-            ref
-          });
+            const { data: result } = await github.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
 
-          const check = checks.check_runs.filter(c => c.name === process.env.job);
-
-          const { data: result } = await github.checks.update({
-            ...context.repo,
-            check_run_id: check[0].id,
-            status: 'completed',
-            conclusion: process.env.conclusion
-          });
-
-          return result;
+            return result;

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,6 @@ jobs:
     - name: Branch based PR checkout
       uses: actions/checkout@v2
 
-    # Insert integration tests needing secrets
     strategy:
       matrix:
         target:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,9 +15,6 @@ jobs:
     strategy:
       matrix:
         target:
-          - check-docs
-          - check-mod
-          - lint-ci
           - test
     steps:
       - uses: actions/checkout@v2
@@ -47,9 +44,6 @@ jobs:
     strategy:
       matrix:
         target:
-          - check-docs
-          - check-mod
-          - lint-ci
           - test
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - test
+          - test-acceptance
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - test
+          - test-acceptance
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
           - check-docs
           - check-mod
           - lint-ci
-          - test-acceptance-ci
+          - test
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -61,7 +61,7 @@ jobs:
           - check-docs
           - check-mod
           - lint-ci
-          - test-acceptance-ci
+          - test
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -9,10 +9,6 @@ jobs:
   ok-to-test:
     runs-on: ubuntu-latest
     steps:
-    # Generate a GitHub App installation access token from an App ID and private key
-    # To create a new GitHub App:
-    #   https://developer.github.com/apps/building-github-apps/creating-a-github-app/
-    # See app.yml for an example app manifest
     - name: Generate token
       id: generate_token
       uses: tibdex/github-app-token@v1

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -26,7 +26,6 @@ jobs:
         TOKEN: ${{ steps.generate_token.outputs.token }}
       with:
         token: ${{ env.TOKEN }} # GitHub App installation access token
-        # token: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # PAT or OAuth token will also work
         reaction-token: ${{ secrets.GITHUB_TOKEN }}
         issue-type: pull-request
         commands: ok-to-test

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,34 @@
+# If someone with write access comments "/ok-to-test" on a pull request, emit a repository_dispatch event
+name: Label
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ok-to-test:
+    runs-on: ubuntu-latest
+    steps:
+    # Generate a GitHub App installation access token from an App ID and private key
+    # To create a new GitHub App:
+    #   https://developer.github.com/apps/building-github-apps/creating-a-github-app/
+    # See app.yml for an example app manifest
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.OK_TO_TEST_APP_ID }}
+        private_key: ${{ secrets.OK_TO_TEST_PRIVATE_KEY }}
+
+    - name: Slash Command Dispatch
+      uses: peter-evans/slash-command-dispatch@v1
+      env:
+        TOKEN: ${{ steps.generate_token.outputs.token }}
+      with:
+        token: ${{ env.TOKEN }} # GitHub App installation access token
+        # token: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # PAT or OAuth token will also work
+        reaction-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-type: pull-request
+        commands: ok-to-test
+        named-args: true
+        permission: write

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,7 +1,7 @@
 # Run unit tests that don't require secrets on any branch/fork pull request
 on:
   pull_request:
-    types: [review_requested, edited]
+    types: [review_requested, edited, synchronized]
 
 name: Unit tests
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,8 +1,13 @@
-on: push
+# Run unit tests on any branch/fork pull request
+on:
+  pull_request
+
+name: Unit tests
 
 jobs:
-  run:
+  unit:
     runs-on: ubuntu-latest
+    # Integration tests needing secrets
     strategy:
       matrix:
         target:
@@ -26,3 +31,4 @@ jobs:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
         run: make ${{ matrix.target }}
+    - run: echo "Unit tests... success! ;-)"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,6 +1,7 @@
-# Run unit tests on any branch/fork pull request
+# Run unit tests that don't require secrets on any branch/fork pull request
 on:
-  pull_request
+  pull_request:
+    types: [review_requested, edited]
 
 name: Unit tests
 
@@ -24,4 +25,3 @@ jobs:
 
       - name: make ${{ matrix.target }}
         run: make ${{ matrix.target }}
-    - run: echo "Unit tests... success! ;-)"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,6 +22,5 @@ jobs:
           go-version: '1.15.2'
       - name: Install dependencies
         run: make setup
-
       - name: make ${{ matrix.target }}
         run: make ${{ matrix.target }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,14 +7,13 @@ name: Unit tests
 jobs:
   unit:
     runs-on: ubuntu-latest
-    # Integration tests needing secrets
     strategy:
       matrix:
         target:
           - check-docs
           - check-mod
           - lint-ci
-          - test-acceptance-ci
+          - test
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -24,11 +23,5 @@ jobs:
         run: make setup
 
       - name: make ${{ matrix.target }}
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_GITHUB_API_TOKEN }}
-          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
-          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
-          SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
         run: make ${{ matrix.target }}
     - run: echo "Unit tests... success! ;-)"

--- a/Makefile
+++ b/Makefile
@@ -114,5 +114,6 @@ check-mod:
 .PHONY: check-mod
 
 fmt:
+	go get golang.org/x/tools/cmd/goimports
 	goimports -w -d $$(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./dist/*")
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,6 @@ test-acceptance: fmt deps ## runs all tests, including the acceptance tests whic
 	SKIP_WAREHOUSE_GRANT_TESTS=1 SKIP_SHARE_TESTS=1 SKIP_MANAGED_ACCOUNT_TEST=1 TF_ACC=1 go test -v -coverprofile=coverage.txt -covermode=atomic $(TESTARGS) ./...
 .PHONY: test-acceptance
 
-test-acceptance-ci: ## runs all tests, including the acceptance tests which create and destroys real resources
-	SKIP_WAREHOUSE_GRANT_TESTS=1 SKIP_SHARE_TESTS=1 SKIP_MANAGED_ACCOUNT_TEST=1 TF_ACC=1 go test -v -coverprofile=coverage.txt -covermode=atomic $(TESTARGS) ./...
-.PHONY: test-acceptance
-
 deps:
 	go mod tidy
 .PHONY: deps


### PR DESCRIPTION
**References:**
https://github.com/imjohnbo/ok-to-test

**Method:**
Copied over the `.github/workflows` files and modified to use the preferred method of authentication: 
`Preferred: GitHub App installation access token with contents: write and metadata: read permissions`

We had to follow [these instructions](https://docs.github.com/en/free-pro-team@latest/developers/apps/creating-a-github-app) to create a new Github App for the `chanzuckerberg` organization, not a personal account app. We were able to create and use the `app id` in the app settings and a private key after creating the app. Both are stored in Github secrets now. We changed the githash condition to be [more strict](https://github.com/chanzuckerberg/terraform-provider-snowflake/compare/adoami/ok-to-test?expand=1#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bR49) than the [one written in the original project](https://github.com/imjohnbo/ok-to-test/blob/master/.github/workflows/integration.yml#L24-L27).

