### PR TITLE
[fix]: CI: Move lint target to integration.yml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         target:
           - test-acceptance
+          - lint-ci
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -45,6 +46,7 @@ jobs:
       matrix:
         target:
           - test-acceptance
+          - lint-ci
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,8 +1,6 @@
 # Run unit tests that don't require secrets on any branch/fork pull request
 on:
   pull_request:
-    types: [review_requested, edited, synchronized]
-
 name: Unit tests
 
 jobs:
@@ -13,7 +11,6 @@ jobs:
         target:
           - check-docs
           - check-mod
-          - lint-ci
           - test
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
`lint-ci` requires a reviewdog token, moving to the workflow with secrets in context

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 