### PR TITLE
[fix] storage_integration alter type

### DIFF
--- a/pkg/resources/storage_integration.go
+++ b/pkg/resources/storage_integration.go
@@ -28,6 +28,7 @@ var storageIntegrationSchema = map[string]*schema.Schema{
 		Optional:     true,
 		Default:      "EXTERNAL_STAGE",
 		ValidateFunc: validation.StringInSlice([]string{"EXTERNAL_STAGE"}, true),
+		ForceNew: true,
 	},
 	"enabled": {
 		Type:     schema.TypeBool,

--- a/pkg/resources/storage_integration.go
+++ b/pkg/resources/storage_integration.go
@@ -235,11 +235,6 @@ func UpdateStorageIntegration(d *schema.ResourceData, meta interface{}) error {
 		stmt.SetString("COMMENT", d.Get("comment").(string))
 	}
 
-	if d.HasChange("type") {
-		runSetStatement = true
-		stmt.SetString("TYPE", d.Get("type").(string))
-	}
-
 	if d.HasChange("enabled") {
 		runSetStatement = true
 		stmt.SetBool(`ENABLED`, d.Get("enabled").(bool))


### PR DESCRIPTION
This PR fixes https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/325.  While the type of EXTERNAL_STAGE must be supplied when creating a storage integration, the type does not actually appear in the `SHOW INTEGRATIONS` result set.  This causes the provider to try and alter the integration, which will fail as the type cannot be altered after the fact.

This change removes the altering of the storage integration.  