### PR TITLE
Temporarily enable GitHub action debug statements for slash command dispatch

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -20,6 +20,7 @@ jobs:
       uses: peter-evans/slash-command-dispatch@v2
       env:
         TOKEN: ${{ steps.generate_token.outputs.token }}
+        ACTIONS_STEP_DEBUG: true
       with:
         token: ${{ env.TOKEN }} # GitHub App installation access token
         reaction-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
See https://github.com/actions/toolkit/blob/master/docs/action-debugging.md#how-to-access-step-debug-logs. The slash command dispatch is nicely instrumented with core.debug statements I am hoping to see by enabling this variable.


## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 