### PR TITLE
[fix] Change revoke code for OWNERSHIP privilege since it was dropped from Snowflake

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -647,6 +647,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/snowflake/grant.go
+++ b/pkg/snowflake/grant.go
@@ -305,6 +305,12 @@ func (ge *CurrentGrantExecutable) Grant(p string, w bool) string {
 
 // Revoke returns the SQL that will revoke privileges on the grant from the grantee
 func (ge *CurrentGrantExecutable) Revoke(p string) string {
+	// Since 10/2020 Snowflake dropped support for REVOKE OWNERSHIP.
+	// It's only possible to transfer it to another role now, so we grant it to Terraform's role.
+	if p == `OWNERSHIP` {
+		return fmt.Sprintf(`SET currentRole=CURRENT_ROLE(); GRANT %v ON %v %v TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`,
+			p, ge.grantType, ge.grantName)
+	}
 	return fmt.Sprintf(`REVOKE %v ON %v %v FROM %v "%v"`,
 		p, ge.grantType, ge.grantName, ge.granteeType, ge.granteeName)
 }

--- a/pkg/snowflake/grant_test.go
+++ b/pkg/snowflake/grant_test.go
@@ -24,6 +24,9 @@ func TestDatabaseGrant(t *testing.T) {
 	s = dg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON DATABASE "testDB" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
+	s = dg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON DATABASE "testDB" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+
 	s = dg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON DATABASE "testDB" TO SHARE "bob"`, s)
 
@@ -53,6 +56,9 @@ func TestSchemaGrant(t *testing.T) {
 
 	s = sg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON SCHEMA "test_db"."testSchema" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = sg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON SCHEMA "test_db"."testSchema" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestViewGrant(t *testing.T) {
@@ -77,6 +83,9 @@ func TestViewGrant(t *testing.T) {
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestMaterializedViewGrant(t *testing.T) {
@@ -101,6 +110,9 @@ func TestMaterializedViewGrant(t *testing.T) {
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestExternalTableGrant(t *testing.T) {
@@ -125,6 +137,9 @@ func TestExternalTableGrant(t *testing.T) {
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestFileFormatGrant(t *testing.T) {
@@ -149,6 +164,9 @@ func TestFileFormatGrant(t *testing.T) {
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestFunctionGrant(t *testing.T) {
@@ -173,6 +191,9 @@ func TestFunctionGrant(t *testing.T) {
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestProcedureGrant(t *testing.T) {
@@ -197,6 +218,9 @@ func TestProcedureGrant(t *testing.T) {
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestWarehouseGrant(t *testing.T) {
@@ -215,6 +239,9 @@ func TestWarehouseGrant(t *testing.T) {
 
 	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = wg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 
 }
 
@@ -253,6 +280,9 @@ func TestIntegrationGrant(t *testing.T) {
 
 	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = wg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestResourceMonitorGrant(t *testing.T) {
@@ -268,6 +298,12 @@ func TestResourceMonitorGrant(t *testing.T) {
 
 	s = wg.Role("bob").Revoke("MODIFY")
 	r.Equal(`REVOKE MODIFY ON RESOURCE MONITOR "test_monitor" FROM ROLE "bob"`, s)
+
+	s = wg.Role("bob").Grant("OWNERSHIP", false)
+	r.Equal(`GRANT OWNERSHIP ON RESOURCE MONITOR "test_monitor" TO ROLE "bob" COPY CURRENT GRANTS`, s)
+
+	s = wg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON RESOURCE MONITOR "test_monitor" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
 }
 
 func TestShowGrantsOf(t *testing.T) {


### PR DESCRIPTION
As discussed in this issue (https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/304), since 10/2020 Snowflake dropped support for OWNERSHIP revoking.
The proposed solution will use CURRENT_ROLE() to return Terraform's role and grant the OWNERSHIP to it. This way we are still able to grant OWNERSHIP from the resource to any other role via Terraform.