### PR TITLE
[fix] run warehouse grant tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test: fmt deps ## run the tests
 .PHONY: test
 
 test-acceptance: fmt deps ## runs all tests, including the acceptance tests which create and destroys real resources
-	SKIP_WAREHOUSE_GRANT_TESTS=1 SKIP_MANAGED_ACCOUNT_TEST=1 TF_ACC=1 $(go_test) -v -coverprofile=coverage.txt -covermode=atomic $(TESTARGS) ./...
+	SKIP_MANAGED_ACCOUNT_TEST=1 TF_ACC=1 $(go_test) -v -coverprofile=coverage.txt -covermode=atomic $(TESTARGS) ./...
 .PHONY: test-acceptance
 
 deps:


### PR DESCRIPTION
These had been disabled due to flakiness. They appear to be fine now, so
re-enabling.


## Test Plan
* [ ] acceptance tests
