### PR TITLE
[fix] typo snowflake_integration_grant in doc

### DIFF
--- a/docs/resources/integration_grant.md
+++ b/docs/resources/integration_grant.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_integratin_grant grant {
+resource snowflake_integration_grant grant {
   integration_name = "integration"
 
   privilege = "USAGE"

--- a/examples/resources/snowflake_integration_grant/resource.tf
+++ b/examples/resources/snowflake_integration_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_integratin_grant grant {
+resource snowflake_integration_grant grant {
   integration_name = "integration"
 
   privilege = "USAGE"


### PR DESCRIPTION
Fix typo of resource name in code example

## References

* https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/integration_grant
* https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/375