### PR TITLE
Use merge ref for checkout for repository_dispatch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,14 @@ jobs:
           fi
 
       - name: pull_request actions/checkout
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v2
+
+      - name: pull_request actions/checkout
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v2
+        with:
+          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
 
       - name: setup-go
         uses: actions/setup-go@v2


### PR DESCRIPTION
forked PRs are building tests off of main exhibit A: https://github.com/chanzuckerberg/terraform-provider-snowflake/runs/1665216382?check_suite_focus=true

Trying to put this back to see what it uses instead.