### PR TITLE
[breaking] Fix to properly distinguish between similarly named views in other databases and schemas

### DIFF
--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -33,6 +33,7 @@ SQL
 
 - **database** (String, Required) The database in which to create the view. Don't use the | character.
 - **name** (String, Required) Specifies the identifier for the view; must be unique for the schema in which the view is created. Don't use the | character.
+- **schema** (String, Required) The schema in which to create the view. Don't use the | character.
 - **statement** (String, Required) Specifies the query used to create the view.
 
 ### Optional
@@ -41,7 +42,6 @@ SQL
 - **id** (String, Optional) The ID of this resource.
 - **is_secure** (Boolean, Optional) Specifies that the view is secure.
 - **or_replace** (Boolean, Optional) Overwrites the View if it exists.
-- **schema** (String, Optional) The schema in which to create the view. Don't use the | character.
 
 ## Import
 

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -29,7 +29,6 @@ var viewSchema = map[string]*schema.Schema{
 	"schema": {
 		Type:        schema.TypeString,
 		Required:    true,
-		Default:     "PUBLIC",
 		Description: "The schema in which to create the view. Don't use the | character.",
 		ForceNew:    true,
 	},
@@ -137,6 +136,7 @@ func ReadView(d *schema.ResourceData, meta interface{}) error {
 	q := snowflake.View(view).WithDB(dbName).WithSchema(schema).Show()
 	row := snowflake.QueryRow(db, q)
 	v, err := snowflake.ScanView(row)
+	fmt.Println(err)
 	if err == sql.ErrNoRows {
 		// If not found, mark resource to be removed from statefile during apply or refresh
 		log.Printf("[DEBUG] view (%s) not found", d.Id())

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -139,7 +139,6 @@ func ReadView(d *schema.ResourceData, meta interface{}) error {
 	q := snowflake.View(view).WithDB(dbName).WithSchema(schema).Show()
 	row := snowflake.QueryRow(db, q)
 	v, err := snowflake.ScanView(row)
-	fmt.Println(err)
 	if err == sql.ErrNoRows {
 		// If not found, mark resource to be removed from statefile during apply or refresh
 		log.Printf("[DEBUG] view (%s) not found", d.Id())

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -114,8 +114,11 @@ func CreateView(d *schema.ResourceData, meta interface{}) error {
 		builder.WithComment(v.(string))
 	}
 
-	q := builder.Create()
-	err := snowflake.Exec(db, q)
+	q, err := builder.Create()
+	if err != nil {
+		return err
+	}
+	err = snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error creating view %v", name)
 	}
@@ -196,8 +199,11 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("name") {
 		name := d.Get("name")
 
-		q := builder.Rename(name.(string))
-		err := snowflake.Exec(db, q)
+		q, err := builder.Rename(name.(string))
+		if err != nil {
+			return err
+		}
+		err = snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error renaming view %v", d.Id())
 		}
@@ -209,14 +215,20 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 		comment := d.Get("comment")
 
 		if c := comment.(string); c == "" {
-			q := builder.RemoveComment()
-			err := snowflake.Exec(db, q)
+			q, err := builder.RemoveComment()
+			if err != nil {
+				return err
+			}
+			err = snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error unsetting comment for view %v", d.Id())
 			}
 		} else {
-			q := builder.ChangeComment(c)
-			err := snowflake.Exec(db, q)
+			q, err := builder.ChangeComment(c)
+			if err != nil {
+				return err
+			}
+			err = snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error updating comment for view %v", d.Id())
 			}
@@ -226,14 +238,20 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 		secure := d.Get("is_secure")
 
 		if secure.(bool) {
-			q := builder.Secure()
-			err := snowflake.Exec(db, q)
+			q, err := builder.Secure()
+			if err != nil {
+				return err
+			}
+			err = snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error setting secure for view %v", d.Id())
 			}
 		} else {
-			q := builder.Unsecure()
-			err := snowflake.Exec(db, q)
+			q, err := builder.Unsecure()
+			if err != nil {
+				return err
+			}
+			err = snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error unsetting secure for view %v", d.Id())
 			}
@@ -251,7 +269,10 @@ func DeleteView(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	q := snowflake.View(view).WithDB(dbName).WithSchema(schema).Drop()
+	q, err := snowflake.View(view).WithDB(dbName).WithSchema(schema).Drop()
+	if err != nil {
+		return err
+	}
 
 	err = snowflake.Exec(db, q)
 	if err != nil {

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -28,7 +28,7 @@ var viewSchema = map[string]*schema.Schema{
 	},
 	"schema": {
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		Default:     "PUBLIC",
 		Description: "The schema in which to create the view. Don't use the | character.",
 		ForceNew:    true,
@@ -116,7 +116,6 @@ func CreateView(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	q := builder.Create()
-	log.Print("[DEBUG] xxx ", q)
 	err := snowflake.Exec(db, q)
 	if err != nil {
 		return errors.Wrapf(err, "error creating view %v", name)

--- a/pkg/resources/view_acceptance_test.go
+++ b/pkg/resources/view_acceptance_test.go
@@ -57,6 +57,7 @@ resource "snowflake_view" "test" {
 	name      = "%v"
 	comment   = "Terraform test resource"
 	database  = snowflake_database.test.name
+	schema    = "PUBLIC"
 	is_secure = true
 	or_replace = false
 	statement = "%s"

--- a/pkg/snowflake/view.go
+++ b/pkg/snowflake/view.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -20,13 +21,12 @@ type ViewBuilder struct {
 }
 
 // QualifiedName prepends the db and schema if set and escapes everything nicely
-func (vb *ViewBuilder) QualifiedName() string {
-	// should not happen since this is enforced by view resource schema
+func (vb *ViewBuilder) QualifiedName() (string, error) {
 	if vb.db == "" || vb.schema == "" {
-		panic("Views must specify a database and a schema") //nolint
+		return "", errors.New("Views must specify a database and a schema")
 	}
 
-	return fmt.Sprintf(`"%v"."%v"."%v"`, vb.db, vb.schema, vb.name)
+	return fmt.Sprintf(`"%v"."%v"."%v"`, vb.db, vb.schema, vb.name), nil
 }
 
 // WithComment adds a comment to the ViewBuilder
@@ -83,7 +83,7 @@ func View(name string) *ViewBuilder {
 }
 
 // Create returns the SQL query that will create a new view.
-func (vb *ViewBuilder) Create() string {
+func (vb *ViewBuilder) Create() (string, error) {
 	var q strings.Builder
 
 	q.WriteString("CREATE")
@@ -96,7 +96,12 @@ func (vb *ViewBuilder) Create() string {
 		q.WriteString(" SECURE")
 	}
 
-	q.WriteString(fmt.Sprintf(` VIEW %v`, vb.QualifiedName()))
+	qn, err := vb.QualifiedName()
+	if err != nil {
+		return "", err
+	}
+
+	q.WriteString(fmt.Sprintf(` VIEW %v`, qn))
 
 	if vb.comment != "" {
 		q.WriteString(fmt.Sprintf(" COMMENT = '%v'", EscapeString(vb.comment)))
@@ -104,38 +109,63 @@ func (vb *ViewBuilder) Create() string {
 
 	q.WriteString(fmt.Sprintf(" AS %v", vb.statement))
 
-	return q.String()
+	return q.String(), nil
 }
 
 // Rename returns the SQL query that will rename the view.
-func (vb *ViewBuilder) Rename(newName string) string {
-	oldName := vb.QualifiedName()
+func (vb *ViewBuilder) Rename(newName string) (string, error) {
+	oldName, err := vb.QualifiedName()
+	if err != nil {
+		return "", err
+	}
 	vb.name = newName
-	return fmt.Sprintf(`ALTER VIEW %v RENAME TO %v`, oldName, vb.QualifiedName())
+
+	qn, err := vb.QualifiedName()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`ALTER VIEW %v RENAME TO %v`, oldName, qn), nil
 }
 
 // Secure returns the SQL query that will change the view to a secure view.
-func (vb *ViewBuilder) Secure() string {
-	return fmt.Sprintf(`ALTER VIEW %v SET SECURE`, vb.QualifiedName())
+func (vb *ViewBuilder) Secure() (string, error) {
+	qn, err := vb.QualifiedName()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`ALTER VIEW %v SET SECURE`, qn), nil
 }
 
 // Unsecure returns the SQL query that will change the view to a normal (unsecured) view.
-func (vb *ViewBuilder) Unsecure() string {
-	return fmt.Sprintf(`ALTER VIEW %v UNSET SECURE`, vb.QualifiedName())
+func (vb *ViewBuilder) Unsecure() (string, error) {
+	qn, err := vb.QualifiedName()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`ALTER VIEW %v UNSET SECURE`, qn), nil
 }
 
 // ChangeComment returns the SQL query that will update the comment on the view.
 // Note that comment is the only parameter, if more are released this should be
 // abstracted as per the generic builder.
-func (vb *ViewBuilder) ChangeComment(c string) string {
-	return fmt.Sprintf(`ALTER VIEW %v SET COMMENT = '%v'`, vb.QualifiedName(), EscapeString(c))
+func (vb *ViewBuilder) ChangeComment(c string) (string, error) {
+	qn, err := vb.QualifiedName()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`ALTER VIEW %v SET COMMENT = '%v'`, qn, EscapeString(c)), nil
 }
 
 // RemoveComment returns the SQL query that will remove the comment on the view.
 // Note that comment is the only parameter, if more are released this should be
 // abstracted as per the generic builder.
-func (vb *ViewBuilder) RemoveComment() string {
-	return fmt.Sprintf(`ALTER VIEW %v UNSET COMMENT`, vb.QualifiedName())
+func (vb *ViewBuilder) RemoveComment() (string, error) {
+	qn, err := vb.QualifiedName()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`ALTER VIEW %v UNSET COMMENT`, qn), nil
 }
 
 // Show returns the SQL query that will show the row representing this view.
@@ -144,8 +174,12 @@ func (vb *ViewBuilder) Show() string {
 }
 
 // Drop returns the SQL query that will drop the row representing this view.
-func (vb *ViewBuilder) Drop() string {
-	return fmt.Sprintf(`DROP VIEW %v`, vb.QualifiedName())
+func (vb *ViewBuilder) Drop() (string, error) {
+	qn, err := vb.QualifiedName()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`DROP VIEW %v`, qn), nil
 }
 
 type view struct {

--- a/pkg/snowflake/view.go
+++ b/pkg/snowflake/view.go
@@ -21,23 +21,12 @@ type ViewBuilder struct {
 
 // QualifiedName prepends the db and schema if set and escapes everything nicely
 func (vb *ViewBuilder) QualifiedName() string {
-	var n strings.Builder
-
-	if vb.db != "" && vb.schema != "" {
-		n.WriteString(fmt.Sprintf(`"%v"."%v".`, vb.db, vb.schema))
+	// should not happen since this is enforced by view resource schema
+	if vb.db == "" || vb.schema == "" {
+		panic("Views must specify a database and a schema")
 	}
 
-	if vb.db != "" && vb.schema == "" {
-		n.WriteString(fmt.Sprintf(`"%v"..`, vb.db))
-	}
-
-	if vb.db == "" && vb.schema != "" {
-		n.WriteString(fmt.Sprintf(`"%v".`, vb.schema))
-	}
-
-	n.WriteString(fmt.Sprintf(`"%v"`, vb.name))
-
-	return n.String()
+	return fmt.Sprintf(`"%v"."%v"."%v"`, vb.db, vb.schema, vb.name)
 }
 
 // WithComment adds a comment to the ViewBuilder
@@ -151,10 +140,7 @@ func (vb *ViewBuilder) RemoveComment() string {
 
 // Show returns the SQL query that will show the row representing this view.
 func (vb *ViewBuilder) Show() string {
-	if vb.db == "" {
-		return fmt.Sprintf(`SHOW VIEWS LIKE '%v'`, vb.name)
-	}
-	return fmt.Sprintf(`SHOW VIEWS LIKE '%v' IN DATABASE "%v"`, vb.name, vb.db)
+	return fmt.Sprintf(`SHOW VIEWS LIKE '%v' IN SCHEMA "%v"."%v"`, vb.name, vb.db, vb.schema)
 }
 
 // Drop returns the SQL query that will drop the row representing this view.

--- a/pkg/snowflake/view.go
+++ b/pkg/snowflake/view.go
@@ -23,7 +23,7 @@ type ViewBuilder struct {
 func (vb *ViewBuilder) QualifiedName() string {
 	// should not happen since this is enforced by view resource schema
 	if vb.db == "" || vb.schema == "" {
-		panic("Views must specify a database and a schema")
+		panic("Views must specify a database and a schema") //nolint
 	}
 
 	return fmt.Sprintf(`"%v"."%v"."%v"`, vb.db, vb.schema, vb.name)

--- a/pkg/snowflake/view_test.go
+++ b/pkg/snowflake/view_test.go
@@ -16,7 +16,9 @@ func TestView(t *testing.T) {
 	v := View(view).WithDB(db).WithSchema(schema)
 	r.NotNil(v)
 	r.False(v.secure)
-	r.Equal(v.QualifiedName(), fmt.Sprintf(`"%v"."%v"."%v"`, db, schema, view))
+	qn, err := v.QualifiedName()
+	r.NoError(err)
+	r.Equal(qn, fmt.Sprintf(`"%v"."%v"."%v"`, db, schema, view))
 
 	v.WithSecure()
 	r.True(v.secure)
@@ -27,61 +29,77 @@ func TestView(t *testing.T) {
 
 	v.WithStatement("SELECT * FROM DUMMY WHERE blah = 'blahblah' LIMIT 1")
 
-	q := v.Create()
+	q, err := v.Create()
+	r.NoError(err)
 	r.Equal(`CREATE SECURE VIEW "some_database"."some_schema"."test" COMMENT = 'great\' comment' AS SELECT * FROM DUMMY WHERE blah = 'blahblah' LIMIT 1`, q)
 
-	q = v.Secure()
+	q, err = v.Secure()
+	r.NoError(err)
 	r.Equal(`ALTER VIEW "some_database"."some_schema"."test" SET SECURE`, q)
 
-	q = v.Unsecure()
+	q, err = v.Unsecure()
+	r.NoError(err)
 	r.Equal(`ALTER VIEW "some_database"."some_schema"."test" UNSET SECURE`, q)
 
-	q = v.ChangeComment("bad' comment")
+	q, err = v.ChangeComment("bad' comment")
+	r.NoError(err)
 	r.Equal(`ALTER VIEW "some_database"."some_schema"."test" SET COMMENT = 'bad\' comment'`, q)
 
-	q = v.RemoveComment()
+	q, err = v.RemoveComment()
+	r.NoError(err)
 	r.Equal(`ALTER VIEW "some_database"."some_schema"."test" UNSET COMMENT`, q)
 
-	q = v.Drop()
+	q, err = v.Drop()
+	r.NoError(err)
 	r.Equal(`DROP VIEW "some_database"."some_schema"."test"`, q)
 
 	q = v.Show()
 	r.Equal(`SHOW VIEWS LIKE 'test' IN SCHEMA "some_database"."some_schema"`, q)
 
 	v.WithDB("mydb")
-	r.Equal(v.QualifiedName(), `"mydb"."some_schema"."test"`)
+	qn, err = v.QualifiedName()
+	r.NoError(err)
+	r.Equal(qn, `"mydb"."some_schema"."test"`)
 
-	q = v.Create()
+	q, err = v.Create()
+	r.NoError(err)
 	r.Equal(`CREATE SECURE VIEW "mydb"."some_schema"."test" COMMENT = 'great\' comment' AS SELECT * FROM DUMMY WHERE blah = 'blahblah' LIMIT 1`, q)
 
-	q = v.Secure()
+	q, err = v.Secure()
+	r.NoError(err)
 	r.Equal(`ALTER VIEW "mydb"."some_schema"."test" SET SECURE`, q)
 
 	q = v.Show()
 	r.Equal(`SHOW VIEWS LIKE 'test' IN SCHEMA "mydb"."some_schema"`, q)
 
-	q = v.Drop()
+	q, err = v.Drop()
+	r.NoError(err)
 	r.Equal(`DROP VIEW "mydb"."some_schema"."test"`, q)
 }
 
 func TestQualifiedName(t *testing.T) {
 	r := require.New(t)
 	v := View("view").WithDB("db").WithSchema("schema")
-	r.Equal(v.QualifiedName(), `"db"."schema"."view"`)
+	qn, err := v.QualifiedName()
+	r.NoError(err)
+	r.Equal(qn, `"db"."schema"."view"`)
 }
 
 func TestRename(t *testing.T) {
 	r := require.New(t)
 	v := View("test").WithDB("db").WithSchema("schema")
 
-	q := v.Rename("test2")
+	q, err := v.Rename("test2")
+	r.NoError(err)
 	r.Equal(`ALTER VIEW "db"."schema"."test" RENAME TO "db"."schema"."test2"`, q)
 
 	v.WithDB("testDB")
-	q = v.Rename("test3")
+	q, err = v.Rename("test3")
+	r.NoError(err)
 	r.Equal(`ALTER VIEW "testDB"."schema"."test2" RENAME TO "testDB"."schema"."test3"`, q)
 
 	v = View("test4").WithDB("db").WithSchema("testSchema")
-	q = v.Rename("test5")
+	q, err = v.Rename("test5")
+	r.NoError(err)
 	r.Equal(`ALTER VIEW "db"."testSchema"."test4" RENAME TO "db"."testSchema"."test5"`, q)
 }


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
If I had a view `foo.bar.view` and another view `foo.baz.view`, the provider was not able to distinguish between them. This caused all sort of issues such as modifying the wrong view, reassigning grants, etc.

NOTE: It seems to me that we should require a DB and a SCHEMA to be specified in the resource. The lack of one or the other makes it so that the queries are "context dependent", under-specified, and somewhat dangerous. I decided to make both db and schema required fields and simplify the code accordingly. LMK what your thoughts are.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [X] acceptance tests
<!-- add more below if you think they are relevant -->
* [X] Unit tests

## References
<!-- issues documentation links, etc  -->

* https://docs.snowflake.com/en/sql-reference/sql/alter-view.html
* https://docs.snowflake.com/en/sql-reference/sql/show-views.html