### PR TITLE
[feature] CREATE SHARE, IMPORT SHARE privileges for account grants

### DIFF
--- a/pkg/resources/account_grant.go
+++ b/pkg/resources/account_grant.go
@@ -17,6 +17,8 @@ var validAccountPrivileges = NewPrivilegeSet(
 	privilegeMonitorExecution,
 	privilegeExecuteTask,
 	privilegeApplyMaskingPolicy,
+	privilegeCreateShare,
+	privilegeImportShare,
 )
 
 var accountGrantSchema = map[string]*schema.Schema{

--- a/pkg/resources/privileges.go
+++ b/pkg/resources/privileges.go
@@ -37,6 +37,8 @@ const (
 	privilegeCreateMaterializedView Privilege = "CREATE MATERIALIZED VIEW"
 	privilegeCreateTemporaryTable   Privilege = "CREATE TEMPORARY TABLE"
 	privilegeCreateMaskingPolicy    Privilege = "CREATE MASKING POLICY"
+	privilegeCreateShare            Privilege = "CREATE SHARE"
+	privilegeImportShare            Privilege = "IMPORT SHARE"
 	privilegeAddSearchOptimization  Privilege = "ADD SEARCH OPTIMIZATION"
 	privilegeApplyMaskingPolicy     Privilege = "APPLY MASKING POLICY"
 


### PR DESCRIPTION
These privileges allow non-ACCOUNTADMIN roles to manage shares.

## Test Plan
This is a non-functional change, and privileges are not exhaustively tested, so none needed(?)

## References
https://docs.snowflake.com/en/user-guide/security-access-control-privileges.html#global-privileges