### PR TITLE
Differentiating between external and internal stage in testing

### DIFF
--- a/pkg/resources/external_stage_acceptance_test.go
+++ b/pkg/resources/external_stage_acceptance_test.go
@@ -28,7 +28,6 @@ func TestAcc_ExternalStage(t *testing.T) {
 	})
 }
 
-// The defining feature of an external stage is the url that you provide when creating the stage
 func externalStageConfig(n string) string {
 	return fmt.Sprintf(`
 resource "snowflake_database" "test" {

--- a/pkg/resources/external_stage_acceptance_test.go
+++ b/pkg/resources/external_stage_acceptance_test.go
@@ -1,0 +1,53 @@
+package resources_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAcc_ExternalStage(t *testing.T) {
+	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: providers(),
+		Steps: []resource.TestStep{
+			{
+				Config: externalStageConfig(accName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_stage.test", "name", accName),
+					resource.TestCheckResourceAttr("snowflake_stage.test", "database", accName),
+					resource.TestCheckResourceAttr("snowflake_stage.test", "schema", accName),
+					resource.TestCheckResourceAttr("snowflake_stage.test", "comment", "Terraform acceptance test"),
+				),
+			},
+		},
+	})
+}
+
+// The defining feature of an external stage is the url that you provide when creating the stage
+func externalStageConfig(n string) string {
+	return fmt.Sprintf(`
+resource "snowflake_database" "test" {
+	name = "%v"
+	comment = "Terraform acceptance test"
+}
+
+resource "snowflake_schema" "test" {
+	name = "%v"
+	database = snowflake_database.test.name
+	comment = "Terraform acceptance test"
+}
+
+resource "snowflake_stage" "test" {
+	name = "%v"
+	url = "s3://com.example.bucket/prefix"
+	database = snowflake_database.test.name
+	schema = snowflake_schema.test.name
+	comment = "Terraform acceptance test"
+}
+`, n, n, n)
+}

--- a/pkg/resources/internal_stage_acceptance_test.go
+++ b/pkg/resources/internal_stage_acceptance_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAcc_Stage(t *testing.T) {
+func TestAcc_InteralStage(t *testing.T) {
 	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
 		Providers: providers(),
 		Steps: []resource.TestStep{
 			{
-				Config: stageConfig(accName),
+				Config: internalStageConfig(accName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_stage.test", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_stage.test", "database", accName),
@@ -28,7 +28,7 @@ func TestAcc_Stage(t *testing.T) {
 	})
 }
 
-func stageConfig(n string) string {
+func internalStageConfig(n string) string {
 	return fmt.Sprintf(`
 resource "snowflake_database" "test" {
 	name = "%v"

--- a/pkg/resources/internal_stage_acceptance_test.go
+++ b/pkg/resources/internal_stage_acceptance_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAcc_InteralStage(t *testing.T) {
+func TestAcc_InternalStage(t *testing.T) {
 	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
When working on this PR: https://github.com/chanzuckerberg/terraform-provider-snowflake/pull/426
I found that external stage and internal stage are slightly different, and should be tested.

Tests fail until the referenced PR is merged.