### PR TITLE
[doc] Fix typo in network policy document

### DIFF
--- a/docs/resources/network_policy.md
+++ b/docs/resources/network_policy.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_network_poilcy policy {
+resource snowflake_network_policy policy {
   name    = "policy"
   comment = "A policy."
 

--- a/examples/resources/snowflake_network_policy/resource.tf
+++ b/examples/resources/snowflake_network_policy/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_network_poilcy policy {
+resource snowflake_network_policy policy {
   name    = "policy"
   comment = "A policy."
 


### PR DESCRIPTION
Fix #431 which is the typo in network policy doc.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 