### PR TITLE
[fix] Generic Grant revoke OWNERSHIP multiple statements not allowed

### DIFF
--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -364,14 +364,14 @@ func deleteGenericGrantRolesAndShares(
 	db := meta.(*sql.DB)
 
 	for _, role := range roles {
-		err := snowflake.Exec(db, builder.Role(role).Revoke(priv))
+		err := snowflake.ExecMulti(db, builder.Role(role).Revoke(priv))
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, share := range shares {
-		err := snowflake.Exec(db, builder.Share(share).Revoke(priv))
+		err := snowflake.ExecMulti(db, builder.Share(share).Revoke(priv))
 		if err != nil {
 			return err
 		}

--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -110,7 +110,7 @@ func setAccounts(d *schema.ResourceData, meta interface{}) error {
 			return errors.Wrapf(err, "error adding accounts to share %v", name)
 		}
 		// 4. Revoke temporary DB grant to the share
-		err = snowflake.Exec(db, tempDBGrant.Share(name).Revoke("USAGE"))
+		err = snowflake.ExecMulti(db, tempDBGrant.Share(name).Revoke("USAGE"))
 		if err != nil {
 			return errors.Wrapf(err, "error revoking temporary DB grant %v", tempName)
 		}

--- a/pkg/resources/share_test.go
+++ b/pkg/resources/share_test.go
@@ -36,7 +36,11 @@ func TestShareCreate(t *testing.T) {
 		mock.ExpectExec(`^CREATE DATABASE "TEMP_test-share_\d*"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^GRANT USAGE ON DATABASE "TEMP_test-share_\d*" TO SHARE "test-share"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^ALTER SHARE "test-share" SET ACCOUNTS=bob123,sue456$`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		mock.ExpectBegin()
 		mock.ExpectExec(`^REVOKE USAGE ON DATABASE "TEMP_test-share_\d*" FROM SHARE "test-share"$`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
 		mock.ExpectExec(`^DROP DATABASE "TEMP_test-share_\d*"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadShare(mock)
 		err := resources.CreateShare(d, db)

--- a/pkg/snowflake/exec.go
+++ b/pkg/snowflake/exec.go
@@ -14,6 +14,23 @@ func Exec(db *sql.DB, query string) error {
 	return err
 }
 
+func ExecMulti(db *sql.DB, queries []string) error {
+	log.Print("[DEBUG] exec stmts ", queries)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	for _, query := range queries {
+		_, err = tx.Exec(query)
+		if err != nil {
+			return tx.Rollback()
+		}
+	}
+	return tx.Commit()
+}
+
 // QueryRow will run stmt against the db and return the row. We use
 // [DB.Unsafe](https://godoc.org/github.com/jmoiron/sqlx#DB.Unsafe) so that we can scan to structs
 // without worrying about newly introduced columns

--- a/pkg/snowflake/future_grant.go
+++ b/pkg/snowflake/future_grant.go
@@ -219,9 +219,11 @@ func (fge *FutureGrantExecutable) Grant(p string, w bool) string {
 }
 
 // Revoke returns the SQL that will revoke future privileges on the grant from the grantee
-func (fge *FutureGrantExecutable) Revoke(p string) string {
-	return fmt.Sprintf(`REVOKE %v ON FUTURE %vS IN %v %v FROM ROLE "%v"`,
-		p, fge.futureGrantType, fge.futureGrantTarget, fge.grantName, fge.granteeName)
+func (fge *FutureGrantExecutable) Revoke(p string) []string {
+	return []string{
+		fmt.Sprintf(`REVOKE %v ON FUTURE %vS IN %v %v FROM ROLE "%v"`,
+			p, fge.futureGrantType, fge.futureGrantTarget, fge.grantName, fge.granteeName),
+	}
 }
 
 // Show returns the SQL that will show all future grants on the schema

--- a/pkg/snowflake/future_grant_test.go
+++ b/pkg/snowflake/future_grant_test.go
@@ -18,8 +18,8 @@ func TestFutureSchemaGrant(t *testing.T) {
 	s = fvg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" TO ROLE "bob"`, s)
 
-	s = fvg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" FROM ROLE "bob"`, s)
+	revoke := fvg.Role("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON FUTURE SCHEMAS IN DATABASE "test_db" FROM ROLE "bob"`}, revoke)
 }
 
 func TestFutureTableGrant(t *testing.T) {
@@ -33,8 +33,8 @@ func TestFutureTableGrant(t *testing.T) {
 	s = fvg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
-	s = fvg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
+	revoke := fvg.Role("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON FUTURE TABLES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`}, revoke)
 
 	b := require.New(t)
 	fvgd := snowflake.FutureTableGrant("test_db", "")
@@ -46,8 +46,8 @@ func TestFutureTableGrant(t *testing.T) {
 	s = fvgd.Role("bob").Grant("USAGE", false)
 	b.Equal(`GRANT USAGE ON FUTURE TABLES IN DATABASE "test_db" TO ROLE "bob"`, s)
 
-	s = fvgd.Role("bob").Revoke("USAGE")
-	b.Equal(`REVOKE USAGE ON FUTURE TABLES IN DATABASE "test_db" FROM ROLE "bob"`, s)
+	revoke = fvgd.Role("bob").Revoke("USAGE")
+	b.Equal([]string{`REVOKE USAGE ON FUTURE TABLES IN DATABASE "test_db" FROM ROLE "bob"`}, revoke)
 }
 
 func TestFutureMaterializedViewGrant(t *testing.T) {
@@ -61,8 +61,8 @@ func TestFutureMaterializedViewGrant(t *testing.T) {
 	s = fvg.Role("bob").Grant("SELECT", false)
 	r.Equal(`GRANT SELECT ON FUTURE MATERIALIZED VIEWS IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
-	s = fvg.Role("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON FUTURE MATERIALIZED VIEWS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
+	revoke := fvg.Role("bob").Revoke("SELECT")
+	r.Equal([]string{`REVOKE SELECT ON FUTURE MATERIALIZED VIEWS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`}, revoke)
 
 	b := require.New(t)
 	fvgd := snowflake.FutureMaterializedViewGrant("test_db", "")
@@ -74,8 +74,8 @@ func TestFutureMaterializedViewGrant(t *testing.T) {
 	s = fvgd.Role("bob").Grant("SELECT", false)
 	b.Equal(`GRANT SELECT ON FUTURE MATERIALIZED VIEWS IN DATABASE "test_db" TO ROLE "bob"`, s)
 
-	s = fvgd.Role("bob").Revoke("SELECT")
-	b.Equal(`REVOKE SELECT ON FUTURE MATERIALIZED VIEWS IN DATABASE "test_db" FROM ROLE "bob"`, s)
+	revoke = fvgd.Role("bob").Revoke("SELECT")
+	b.Equal([]string{`REVOKE SELECT ON FUTURE MATERIALIZED VIEWS IN DATABASE "test_db" FROM ROLE "bob"`}, revoke)
 }
 
 func TestFutureViewGrant(t *testing.T) {
@@ -89,8 +89,8 @@ func TestFutureViewGrant(t *testing.T) {
 	s = fvg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
-	s = fvg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
+	revoke := fvg.Role("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON FUTURE VIEWS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`}, revoke)
 
 	b := require.New(t)
 	fvgd := snowflake.FutureViewGrant("test_db", "")
@@ -102,8 +102,8 @@ func TestFutureViewGrant(t *testing.T) {
 	s = fvgd.Role("bob").Grant("USAGE", false)
 	b.Equal(`GRANT USAGE ON FUTURE VIEWS IN DATABASE "test_db" TO ROLE "bob"`, s)
 
-	s = fvgd.Role("bob").Revoke("USAGE")
-	b.Equal(`REVOKE USAGE ON FUTURE VIEWS IN DATABASE "test_db" FROM ROLE "bob"`, s)
+	revoke = fvgd.Role("bob").Revoke("USAGE")
+	b.Equal([]string{`REVOKE USAGE ON FUTURE VIEWS IN DATABASE "test_db" FROM ROLE "bob"`}, revoke)
 }
 
 func TestFutureStageGrant(t *testing.T) {
@@ -117,8 +117,8 @@ func TestFutureStageGrant(t *testing.T) {
 	s = fvg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FUTURE STAGES IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
-	s = fvg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUTURE STAGES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
+	revoke := fvg.Role("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON FUTURE STAGES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`}, revoke)
 
 	b := require.New(t)
 	fvgd := snowflake.FutureStageGrant("test_db", "")
@@ -130,8 +130,8 @@ func TestFutureStageGrant(t *testing.T) {
 	s = fvgd.Role("bob").Grant("USAGE", false)
 	b.Equal(`GRANT USAGE ON FUTURE STAGES IN DATABASE "test_db" TO ROLE "bob"`, s)
 
-	s = fvgd.Role("bob").Revoke("USAGE")
-	b.Equal(`REVOKE USAGE ON FUTURE STAGES IN DATABASE "test_db" FROM ROLE "bob"`, s)
+	revoke = fvgd.Role("bob").Revoke("USAGE")
+	b.Equal([]string{`REVOKE USAGE ON FUTURE STAGES IN DATABASE "test_db" FROM ROLE "bob"`}, revoke)
 }
 
 func TestShowFutureGrantsInSchema(t *testing.T) {
@@ -160,8 +160,8 @@ func TestFutureExternalTableGrant(t *testing.T) {
 	s = fvg.Role("bob").Grant("SELECT", false)
 	r.Equal(`GRANT SELECT ON FUTURE EXTERNAL TABLES IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
-	s = fvg.Role("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON FUTURE EXTERNAL TABLES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
+	revoke := fvg.Role("bob").Revoke("SELECT")
+	r.Equal([]string{`REVOKE SELECT ON FUTURE EXTERNAL TABLES IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`}, revoke)
 
 	b := require.New(t)
 	fvgd := snowflake.FutureExternalTableGrant("test_db", "")
@@ -173,8 +173,8 @@ func TestFutureExternalTableGrant(t *testing.T) {
 	s = fvgd.Role("bob").Grant("SELECT", false)
 	b.Equal(`GRANT SELECT ON FUTURE EXTERNAL TABLES IN DATABASE "test_db" TO ROLE "bob"`, s)
 
-	s = fvgd.Role("bob").Revoke("SELECT")
-	b.Equal(`REVOKE SELECT ON FUTURE EXTERNAL TABLES IN DATABASE "test_db" FROM ROLE "bob"`, s)
+	revoke = fvgd.Role("bob").Revoke("SELECT")
+	b.Equal([]string{`REVOKE SELECT ON FUTURE EXTERNAL TABLES IN DATABASE "test_db" FROM ROLE "bob"`}, revoke)
 }
 
 func TestFutureFileFormatGrant(t *testing.T) {
@@ -188,8 +188,8 @@ func TestFutureFileFormatGrant(t *testing.T) {
 	s = fvg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FUTURE FILE FORMATS IN SCHEMA "test_db"."PUBLIC" TO ROLE "bob"`, s)
 
-	s = fvg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUTURE FILE FORMATS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`, s)
+	revoke := fvg.Role("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON FUTURE FILE FORMATS IN SCHEMA "test_db"."PUBLIC" FROM ROLE "bob"`}, revoke)
 
 	b := require.New(t)
 	fvgd := snowflake.FutureFileFormatGrant("test_db", "")
@@ -201,6 +201,6 @@ func TestFutureFileFormatGrant(t *testing.T) {
 	s = fvgd.Role("bob").Grant("USAGE", false)
 	b.Equal(`GRANT USAGE ON FUTURE FILE FORMATS IN DATABASE "test_db" TO ROLE "bob"`, s)
 
-	s = fvgd.Role("bob").Revoke("USAGE")
-	b.Equal(`REVOKE USAGE ON FUTURE FILE FORMATS IN DATABASE "test_db" FROM ROLE "bob"`, s)
+	revoke = fvgd.Role("bob").Revoke("USAGE")
+	b.Equal([]string{`REVOKE USAGE ON FUTURE FILE FORMATS IN DATABASE "test_db" FROM ROLE "bob"`}, revoke)
 }

--- a/pkg/snowflake/grant_test.go
+++ b/pkg/snowflake/grant_test.go
@@ -18,20 +18,20 @@ func TestDatabaseGrant(t *testing.T) {
 	s = dg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON DATABASE "testDB" TO ROLE "bob"`, s)
 
-	s = dg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON DATABASE "testDB" FROM ROLE "bob"`, s)
+	revoke := dg.Role("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON DATABASE "testDB" FROM ROLE "bob"`}, revoke)
 
 	s = dg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON DATABASE "testDB" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = dg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON DATABASE "testDB" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = dg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON DATABASE "testDB" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 
 	s = dg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON DATABASE "testDB" TO SHARE "bob"`, s)
 
-	s = dg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON DATABASE "testDB" FROM SHARE "bob"`, s)
+	revoke = dg.Share("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON DATABASE "testDB" FROM SHARE "bob"`}, revoke)
 }
 
 func TestSchemaGrant(t *testing.T) {
@@ -45,20 +45,20 @@ func TestSchemaGrant(t *testing.T) {
 	s = sg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON SCHEMA "test_db"."testSchema" TO ROLE "bob"`, s)
 
-	s = sg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM ROLE "bob"`, s)
+	revoke := sg.Role("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM ROLE "bob"`}, revoke)
 
 	s = sg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON SCHEMA "test_db"."testSchema" TO SHARE "bob"`, s)
 
-	s = sg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM SHARE "bob"`, s)
+	revoke = sg.Share("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON SCHEMA "test_db"."testSchema" FROM SHARE "bob"`}, revoke)
 
 	s = sg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON SCHEMA "test_db"."testSchema" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = sg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON SCHEMA "test_db"."testSchema" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = sg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON SCHEMA "test_db"."testSchema" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestViewGrant(t *testing.T) {
@@ -72,20 +72,20 @@ func TestViewGrant(t *testing.T) {
 	s = vg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob"`, s)
 
-	s = vg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM ROLE "bob"`, s)
+	revoke := vg.Role("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM ROLE "bob"`}, revoke)
 
 	s = vg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON VIEW "test_db"."PUBLIC"."testView" TO SHARE "bob"`, s)
 
-	s = vg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM SHARE "bob"`, s)
+	revoke = vg.Share("bob").Revoke("USAGE")
+	r.Equal([]string{`REVOKE USAGE ON VIEW "test_db"."PUBLIC"."testView" FROM SHARE "bob"`}, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testView" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestMaterializedViewGrant(t *testing.T) {
@@ -99,20 +99,20 @@ func TestMaterializedViewGrant(t *testing.T) {
 	s = vg.Role("bob").Grant("SELECT", false)
 	r.Equal(`GRANT SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE "bob"`, s)
 
-	s = vg.Role("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" FROM ROLE "bob"`, s)
+	revoke := vg.Role("bob").Revoke("SELECT")
+	r.Equal(`REVOKE SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" FROM ROLE "bob"`, revoke)
 
 	s = vg.Share("bob").Grant("SELECT", false)
 	r.Equal(`GRANT SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO SHARE "bob"`, s)
 
-	s = vg.Share("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" FROM SHARE "bob"`, s)
+	revoke = vg.Share("bob").Revoke("SELECT")
+	r.Equal(`REVOKE SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" FROM SHARE "bob"`, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
 }
 
 func TestExternalTableGrant(t *testing.T) {
@@ -126,20 +126,20 @@ func TestExternalTableGrant(t *testing.T) {
 	s = vg.Role("bob").Grant("SELECT", false)
 	r.Equal(`GRANT SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE "bob"`, s)
 
-	s = vg.Role("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" FROM ROLE "bob"`, s)
+	revoke := vg.Role("bob").Revoke("SELECT")
+	r.Equal(`REVOKE SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" FROM ROLE "bob"`, revoke)
 
 	s = vg.Share("bob").Grant("SELECT", false)
 	r.Equal(`GRANT SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO SHARE "bob"`, s)
 
-	s = vg.Share("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" FROM SHARE "bob"`, s)
+	revoke = vg.Share("bob").Revoke("SELECT")
+	r.Equal(`REVOKE SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" FROM SHARE "bob"`, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
 }
 
 func TestFileFormatGrant(t *testing.T) {
@@ -153,20 +153,20 @@ func TestFileFormatGrant(t *testing.T) {
 	s = vg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE "bob"`, s)
 
-	s = vg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" FROM ROLE "bob"`, s)
+	revoke := vg.Role("bob").Revoke("USAGE")
+	r.Equal(`REVOKE USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" FROM ROLE "bob"`, revoke)
 
 	s = vg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO SHARE "bob"`, s)
 
-	s = vg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" FROM SHARE "bob"`, s)
+	revoke = vg.Share("bob").Revoke("USAGE")
+	r.Equal(`REVOKE USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" FROM SHARE "bob"`, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
 }
 
 func TestFunctionGrant(t *testing.T) {
@@ -180,20 +180,20 @@ func TestFunctionGrant(t *testing.T) {
 	s = vg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE "bob"`, s)
 
-	s = vg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) FROM ROLE "bob"`, s)
+	revoke := vg.Role("bob").Revoke("USAGE")
+	r.Equal(`REVOKE USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) FROM ROLE "bob"`, revoke)
 
 	s = vg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO SHARE "bob"`, s)
 
-	s = vg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) FROM SHARE "bob"`, s)
+	revoke = vg.Share("bob").Revoke("USAGE")
+	r.Equal(`REVOKE USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) FROM SHARE "bob"`, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
 }
 
 func TestProcedureGrant(t *testing.T) {
@@ -207,20 +207,20 @@ func TestProcedureGrant(t *testing.T) {
 	s = vg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE "bob"`, s)
 
-	s = vg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) FROM ROLE "bob"`, s)
+	revoke := vg.Role("bob").Revoke("USAGE")
+	r.Equal(`REVOKE USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) FROM ROLE "bob"`, revoke)
 
 	s = vg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO SHARE "bob"`, s)
 
-	s = vg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) FROM SHARE "bob"`, s)
+	revoke = vg.Share("bob").Revoke("USAGE")
+	r.Equal(`REVOKE USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) FROM SHARE "bob"`, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = vg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
 }
 
 func TestWarehouseGrant(t *testing.T) {
@@ -234,14 +234,14 @@ func TestWarehouseGrant(t *testing.T) {
 	s = wg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON WAREHOUSE "test_warehouse" TO ROLE "bob"`, s)
 
-	s = wg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON WAREHOUSE "test_warehouse" FROM ROLE "bob"`, s)
+	revoke := wg.Role("bob").Revoke("USAGE")
+	r.Equal(`REVOKE USAGE ON WAREHOUSE "test_warehouse" FROM ROLE "bob"`, revoke)
 
 	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = wg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = wg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
 
 }
 
@@ -260,8 +260,8 @@ func TestAccountGrant(t *testing.T) {
 	s = wg.Role("bob").Grant("MANAGE GRANTS", false)
 	r.Equal(`GRANT MANAGE GRANTS ON ACCOUNT  TO ROLE "bob"`, s)
 
-	s = wg.Role("bob").Revoke("MONITOR USAGE")
-	r.Equal(`REVOKE MONITOR USAGE ON ACCOUNT  FROM ROLE "bob"`, s)
+	revoke := wg.Role("bob").Revoke("MONITOR USAGE")
+	r.Equal(`REVOKE MONITOR USAGE ON ACCOUNT  FROM ROLE "bob"`, revoke)
 
 	s = wg.Role("bob").Grant("APPLY MASKING POLICY", false)
 	r.Equal(`GRANT APPLY MASKING POLICY ON ACCOUNT  TO ROLE "bob"`, s)
@@ -278,14 +278,14 @@ func TestIntegrationGrant(t *testing.T) {
 	s = wg.Role("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON INTEGRATION "test_integration" TO ROLE "bob"`, s)
 
-	s = wg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON INTEGRATION "test_integration" FROM ROLE "bob"`, s)
+	revoke := wg.Role("bob").Revoke("USAGE")
+	r.Equal(`REVOKE USAGE ON INTEGRATION "test_integration" FROM ROLE "bob"`, revoke)
 
 	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = wg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = wg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
 }
 
 func TestResourceMonitorGrant(t *testing.T) {
@@ -299,14 +299,14 @@ func TestResourceMonitorGrant(t *testing.T) {
 	s = wg.Role("bob").Grant("MONITOR", false)
 	r.Equal(`GRANT MONITOR ON RESOURCE MONITOR "test_monitor" TO ROLE "bob"`, s)
 
-	s = wg.Role("bob").Revoke("MODIFY")
-	r.Equal(`REVOKE MODIFY ON RESOURCE MONITOR "test_monitor" FROM ROLE "bob"`, s)
+	revoke := wg.Role("bob").Revoke("MODIFY")
+	r.Equal(`REVOKE MODIFY ON RESOURCE MONITOR "test_monitor" FROM ROLE "bob"`, revoke)
 
 	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON RESOURCE MONITOR "test_monitor" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
-	s = wg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON RESOURCE MONITOR "test_monitor" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, s)
+	revoke = wg.Role("bob").Revoke("OWNERSHIP")
+	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON RESOURCE MONITOR "test_monitor" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
 }
 
 func TestShowGrantsOf(t *testing.T) {

--- a/pkg/snowflake/grant_test.go
+++ b/pkg/snowflake/grant_test.go
@@ -100,19 +100,19 @@ func TestMaterializedViewGrant(t *testing.T) {
 	r.Equal(`GRANT SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE "bob"`, s)
 
 	revoke := vg.Role("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" FROM ROLE "bob"`}, revoke)
 
 	s = vg.Share("bob").Grant("SELECT", false)
 	r.Equal(`GRANT SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO SHARE "bob"`, s)
 
 	revoke = vg.Share("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" FROM SHARE "bob"`, revoke)
+	r.Equal([]string{`REVOKE SELECT ON VIEW "test_db"."PUBLIC"."testMaterializedView" FROM SHARE "bob"`}, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	revoke = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON VIEW "test_db"."PUBLIC"."testMaterializedView" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestExternalTableGrant(t *testing.T) {
@@ -127,19 +127,19 @@ func TestExternalTableGrant(t *testing.T) {
 	r.Equal(`GRANT SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE "bob"`, s)
 
 	revoke := vg.Role("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" FROM ROLE "bob"`}, revoke)
 
 	s = vg.Share("bob").Grant("SELECT", false)
 	r.Equal(`GRANT SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO SHARE "bob"`, s)
 
 	revoke = vg.Share("bob").Revoke("SELECT")
-	r.Equal(`REVOKE SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" FROM SHARE "bob"`, revoke)
+	r.Equal([]string{`REVOKE SELECT ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" FROM SHARE "bob"`}, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	revoke = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestFileFormatGrant(t *testing.T) {
@@ -154,19 +154,19 @@ func TestFileFormatGrant(t *testing.T) {
 	r.Equal(`GRANT USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE "bob"`, s)
 
 	revoke := vg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" FROM ROLE "bob"`}, revoke)
 
 	s = vg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO SHARE "bob"`, s)
 
 	revoke = vg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" FROM SHARE "bob"`, revoke)
+	r.Equal([]string{`REVOKE USAGE ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" FROM SHARE "bob"`}, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	revoke = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestFunctionGrant(t *testing.T) {
@@ -181,19 +181,19 @@ func TestFunctionGrant(t *testing.T) {
 	r.Equal(`GRANT USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE "bob"`, s)
 
 	revoke := vg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) FROM ROLE "bob"`}, revoke)
 
 	s = vg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO SHARE "bob"`, s)
 
 	revoke = vg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) FROM SHARE "bob"`, revoke)
+	r.Equal([]string{`REVOKE USAGE ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) FROM SHARE "bob"`}, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	revoke = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestProcedureGrant(t *testing.T) {
@@ -208,19 +208,19 @@ func TestProcedureGrant(t *testing.T) {
 	r.Equal(`GRANT USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE "bob"`, s)
 
 	revoke := vg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) FROM ROLE "bob"`}, revoke)
 
 	s = vg.Share("bob").Grant("USAGE", false)
 	r.Equal(`GRANT USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO SHARE "bob"`, s)
 
 	revoke = vg.Share("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) FROM SHARE "bob"`, revoke)
+	r.Equal([]string{`REVOKE USAGE ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) FROM SHARE "bob"`}, revoke)
 
 	s = vg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	revoke = vg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING) TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestWarehouseGrant(t *testing.T) {
@@ -235,13 +235,13 @@ func TestWarehouseGrant(t *testing.T) {
 	r.Equal(`GRANT USAGE ON WAREHOUSE "test_warehouse" TO ROLE "bob"`, s)
 
 	revoke := wg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON WAREHOUSE "test_warehouse" FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE USAGE ON WAREHOUSE "test_warehouse" FROM ROLE "bob"`}, revoke)
 
 	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	revoke = wg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 
 }
 
@@ -261,7 +261,7 @@ func TestAccountGrant(t *testing.T) {
 	r.Equal(`GRANT MANAGE GRANTS ON ACCOUNT  TO ROLE "bob"`, s)
 
 	revoke := wg.Role("bob").Revoke("MONITOR USAGE")
-	r.Equal(`REVOKE MONITOR USAGE ON ACCOUNT  FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE MONITOR USAGE ON ACCOUNT  FROM ROLE "bob"`}, revoke)
 
 	s = wg.Role("bob").Grant("APPLY MASKING POLICY", false)
 	r.Equal(`GRANT APPLY MASKING POLICY ON ACCOUNT  TO ROLE "bob"`, s)
@@ -279,13 +279,13 @@ func TestIntegrationGrant(t *testing.T) {
 	r.Equal(`GRANT USAGE ON INTEGRATION "test_integration" TO ROLE "bob"`, s)
 
 	revoke := wg.Role("bob").Revoke("USAGE")
-	r.Equal(`REVOKE USAGE ON INTEGRATION "test_integration" FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE USAGE ON INTEGRATION "test_integration" FROM ROLE "bob"`}, revoke)
 
 	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	revoke = wg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON INTEGRATION "test_integration" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestResourceMonitorGrant(t *testing.T) {
@@ -300,13 +300,13 @@ func TestResourceMonitorGrant(t *testing.T) {
 	r.Equal(`GRANT MONITOR ON RESOURCE MONITOR "test_monitor" TO ROLE "bob"`, s)
 
 	revoke := wg.Role("bob").Revoke("MODIFY")
-	r.Equal(`REVOKE MODIFY ON RESOURCE MONITOR "test_monitor" FROM ROLE "bob"`, revoke)
+	r.Equal([]string{`REVOKE MODIFY ON RESOURCE MONITOR "test_monitor" FROM ROLE "bob"`}, revoke)
 
 	s = wg.Role("bob").Grant("OWNERSHIP", false)
 	r.Equal(`GRANT OWNERSHIP ON RESOURCE MONITOR "test_monitor" TO ROLE "bob" COPY CURRENT GRANTS`, s)
 
 	revoke = wg.Role("bob").Revoke("OWNERSHIP")
-	r.Equal(`SET currentRole=CURRENT_ROLE(); GRANT OWNERSHIP ON RESOURCE MONITOR "test_monitor" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`, revoke)
+	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON RESOURCE MONITOR "test_monitor" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
 }
 
 func TestShowGrantsOf(t *testing.T) {


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

Snowflake SQL driver does not accept multiple statements like we used to have -- made some tweaks to revoke so that it is a multi statement.

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 