### PR TITLE
add link to getting-started guide from snowflake

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is a terraform provider plugin for managing [Snowflake](https://www.snowfla
 
 If you need help, try the [discussions area](https://github.com/chanzuckerberg/terraform-provider-snowflake/discussions) of this repo.
 
+For an end-to-end guide on how to use this provider, checkout [guides.snowflake.com](https://guides.snowflake.com/guide/terraforming_snowflake/)
+
 ## Install
 
 The easiest way is to run this command:


### PR DESCRIPTION
I've added a link to the main readme to a getting-started guide written by Snowflake for this provider.

https://guides.snowflake.com/guide/terraforming_snowflake/

for the source of the guide (pull requests welcome!) take a look here: 

https://github.com/Snowflake-Labs/sfguides/blob/master/site/devlabs/terraforming_snowflake.md