### PR TITLE
gjv9491/oauth refresh token

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,8 @@ export SNOWFLAKE_OAUTH_ENDPOINT='...'
 export SNOWFLAKE_OAUTH_REDIRECT_URL='https://localhost.com'
 ```
 
+Note because access token have a short life; typically 10 minutes, by passing refresh token new access token will be generated.
+
 ### Username and Password Environment Variables
 
 If you choose to use Username and Password Authentication, export these credentials:
@@ -156,4 +158,4 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.
 * `role` - (optional) Snowflake role to use for operations. If left unset, default role for user
   will be used. Can come from the `SNOWFLAKE_ROLE` environment variable.
-  
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ provider snowflake {
   password              = "..."
   oauth_access_token    = "..."
   private_key_path      = "..."
+  private_key           = "..."
   oauth_refresh_token   = "..."
   oauth_client_id       = "..."
   oauth_client_secret   = "..."

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,7 @@ The Snowflake provider support multiple ways to authenticate:
 
 * Password
 * OAuth Access Token
+* OAuth Refresh Token
 * Browser Auth
 * Private Key
 
@@ -109,7 +110,7 @@ export SNOWFLAKE_OAUTH_ACCESS_TOKEN='...'
 
 Note that once this access token expires, you'll need to request a new one through an external application.
 
-If you have an OAuth Refresh token, export these credentials as environment variables:
+If you have an OAuth refresh token, export these credentials as environment variables:
 
 ```shell
 export SNOWFLAKE_OAUTH_REFRESH_TOKEN='...'

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,27 +47,18 @@ provider snowflake {
 
 ### Optional
 
-<<<<<<< HEAD
 - **browser_auth** (Boolean)
 - **oauth_access_token** (String, Sensitive)
+- **oauth_client_id** (String, Sensitive)
+- **oauth_client_secret** (String, Sensitive)
+- **oauth_endpoint** (String, Sensitive)
+- **oauth_redirect_url** (String, Sensitive)
+- **oauth_refresh_token** (String, Sensitive)
 - **password** (String, Sensitive)
 - **private_key** (String, Sensitive)
 - **private_key_path** (String, Sensitive)
 - **region** (String)
 - **role** (String)
-=======
-- **browser_auth** (Boolean, Optional)
-- **oauth_access_token** (String, Optional)
-- **password** (String, Optional)
-- **private_key_path** (String, Optional)
-- **oauth_refresh_token** (String, Optional)
-- **oauth_client_id** (String, Optional)
-- **oauth_client_secret** (String, Optional)
-- **oauth_endpoint** (String, Optional)
-- **oauth_redirect_url** (String, Optional)
-- **region** (String, Optional)
-- **role** (String, Optional)
->>>>>>> 08049f0 (Updated documentation, to show how to utlize refresh token)
 
 ## Authentication
 
@@ -110,7 +101,9 @@ export SNOWFLAKE_OAUTH_ACCESS_TOKEN='...'
 
 Note that once this access token expires, you'll need to request a new one through an external application.
 
-If you have an OAuth refresh token, export these credentials as environment variables:
+### OAuth Refresh Token
+
+If you have an OAuth Refresh token, export these credentials as environment variables:
 
 ```shell
 export SNOWFLAKE_OAUTH_REFRESH_TOKEN='...'
@@ -119,8 +112,6 @@ export SNOWFLAKE_OAUTH_CLIENT_SECRET='...'
 export SNOWFLAKE_OAUTH_ENDPOINT='...'
 export SNOWFLAKE_OAUTH_REDIRECT_URL='https://localhost.com'
 ```
-
-Note because access token have a short life; typically 10 minutes, by passing refresh token new access token will be generated.
 
 ### Username and Password Environment Variables
 
@@ -165,3 +156,4 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.
 * `role` - (optional) Snowflake role to use for operations. If left unset, default role for user
   will be used. Can come from the `SNOWFLAKE_ROLE` environment variable.
+  

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,14 @@ provider snowflake {
   region   = "..."
 
   // optional, at exactly one must be set
-  password           = "..."
-  oauth_access_token = "..."
-  private_key_path   = "..."
+  password              = "..."
+  oauth_access_token    = "..."
+  private_key_path      = "..."
+  oauth_refresh_token   = "..."
+  oauth_client_id       = "..."
+  oauth_client_secret   = "..."
+  oauth_endpoint        = "..."
+  oauth_redirect_url    = "..."
 
   // optional
   role = "..."
@@ -42,6 +47,7 @@ provider snowflake {
 
 ### Optional
 
+<<<<<<< HEAD
 - **browser_auth** (Boolean)
 - **oauth_access_token** (String, Sensitive)
 - **password** (String, Sensitive)
@@ -49,6 +55,19 @@ provider snowflake {
 - **private_key_path** (String, Sensitive)
 - **region** (String)
 - **role** (String)
+=======
+- **browser_auth** (Boolean, Optional)
+- **oauth_access_token** (String, Optional)
+- **password** (String, Optional)
+- **private_key_path** (String, Optional)
+- **oauth_refresh_token** (String, Optional)
+- **oauth_client_id** (String, Optional)
+- **oauth_client_secret** (String, Optional)
+- **oauth_endpoint** (String, Optional)
+- **oauth_redirect_url** (String, Optional)
+- **region** (String, Optional)
+- **role** (String, Optional)
+>>>>>>> 08049f0 (Updated documentation, to show how to utlize refresh token)
 
 ## Authentication
 
@@ -90,6 +109,18 @@ export SNOWFLAKE_OAUTH_ACCESS_TOKEN='...'
 
 Note that once this access token expires, you'll need to request a new one through an external application.
 
+If you have an OAuth Refresh token, export these credentials as environment variables:
+
+```shell
+export SNOWFLAKE_OAUTH_REFRESH_TOKEN='...'
+export SNOWFLAKE_OAUTH_CLIENT_ID='...'
+export SNOWFLAKE_OAUTH_CLIENT_SECRET='...'
+export SNOWFLAKE_OAUTH_ENDPOINT='...'
+export SNOWFLAKE_OAUTH_REDIRECT_URL='https://localhost.com'
+```
+
+Note because access token have a short life; typically 10 minutes, by passing refresh token new access token will be generated.
+
 ### Username and Password Environment Variables
 
 If you choose to use Username and Password Authentication, export these credentials:
@@ -113,8 +144,21 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `password` - (optional) Password for username+password auth. Cannot be used with `browser_auth` or
   `private_key_path`. Can be source from `SNOWFLAKE_PASSWORD` environment variable.
 * `oauth_access_token` - (optional) Token for use with OAuth. Generating the token is left to other
-  tools. Cannot be used with `browser_auth`, `private_key_path` or `password`. Can be source from
-  `SNOWFLAKE_OAUTH_ACCESS_TOKEN` environment variable.
+  tools. Cannot be used with `browser_auth`, `private_key_path`, `oauth_refresh_token` or `password`. 
+  Can be sourced from `SNOWFLAKE_OAUTH_ACCESS_TOKEN` environment variable.
+* `oauth_refresh_token` - (optional) Token for use with OAuth. Setup and generation of the token is 
+  left to other tools. Should be used in conjunction with `oauth_client_id`, `oauth_client_secret`, 
+  `oauth_endpoint`, `oauth_redirect_url`. Cannot be used with `browser_auth`, `private_key_path`, 
+  `oauth_access_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_REFRESH_TOKEN` environment 
+  variable.
+* `oauth_client_id` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from 
+  `SNOWFLAKE_OAUTH_CLIENT_ID` environment variable.
+* `oauth_client_secret` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from 
+  `SNOWFLAKE_OAUTH_CLIENT_SECRET` environment variable.
+* `oauth_endpoint` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from 
+  `SNOWFLAKE_OAUTH_ENDPOINT` environment variable.
+* `oauth_redirect_url` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from 
+  `SNOWFLAKE_OAUTH_REDIRECT_URL` environment variable. 
 * `private_key_path` - (optional) Path to a private key for using keypair authentication.. Cannot be
   used with `browser_auth`, `oauth_access_token` or `password`. Can be source from
   `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,6 +8,7 @@ provider snowflake {
   password              = "..."
   oauth_access_token    = "..."
   private_key_path      = "..."
+  private_key           = "..."
   oauth_refresh_token   = "..."
   oauth_client_id       = "..."
   oauth_client_secret   = "..."

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -5,9 +5,14 @@ provider snowflake {
   region   = "..."
 
   // optional, at exactly one must be set
-  password           = "..."
-  oauth_access_token = "..."
-  private_key_path   = "..."
+  password              = "..."
+  oauth_access_token    = "..."
+  private_key_path      = "..."
+  oauth_refresh_token   = "..."
+  oauth_client_id       = "..."
+  oauth_client_secret   = "..."
+  oauth_endpoint        = "..."
+  oauth_redirect_url    = "..."
 
   // optional
   role = "..."

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -364,7 +364,7 @@ func GetOauthAccessToken(
 		return "", errors.Wrap(err, "Response status returned an error:")
 	}
 	if response.StatusCode != 200 {
-		errors.New(fmt.Sprintf("Response status code: %s: %s", strconv.Itoa(response.StatusCode), http.StatusText(response.StatusCode)))
+		return "", errors.New(fmt.Sprintf("Response status code: %s: %s", strconv.Itoa(response.StatusCode), http.StatusText(response.StatusCode)))
 	}
 	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -373,7 +373,7 @@ func GetOauthAccessToken(
 	}
 	err = json.Unmarshal(body, &result)
 	if err != nil {
-		errors.Wrap(err, "Error parsing JSON from Snowflake")
+		return "", errors.Wrap(err, "Error parsing JSON from Snowflake")
 	}
 	return result.AccessToken, nil
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"crypto/rsa"
+	"encoding/json"
 	"io/ioutil"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/datasources"
@@ -12,6 +13,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/snowflakedb/gosnowflake"
 	"golang.org/x/crypto/ssh"
+
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 )
 
 // Provider is a provider
@@ -33,21 +40,61 @@ func Provider() *schema.Provider {
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_PASSWORD", nil),
 				Sensitive:     true,
-				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "oauth_access_token"},
+				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "oauth_access_token", "oauth_refresh_token"},
 			},
 			"oauth_access_token": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_ACCESS_TOKEN", nil),
 				Sensitive:     true,
-				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "password"},
+				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "password", "oauth_refresh_token"},
+			},
+			"oauth_refresh_token": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_REFRESH_TOKEN", nil),
+				Sensitive:     true,
+				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "password", "oauth_access_token"},
+				RequiredWith:  []string{"oauth_client_id", "oauth_client_secret", "oauth_endpoint", "oauth_redirect_url"},
+			},
+			"oauth_client_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_CLIENT_ID", nil),
+				Sensitive:     true,
+				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "password", "oauth_access_token"},
+				RequiredWith:  []string{"oauth_refresh_token", "oauth_client_secret", "oauth_endpoint", "oauth_redirect_url"},
+			},
+			"oauth_client_secret": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_CLIENT_SECRET", nil),
+				Sensitive:     true,
+				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "password", "oauth_access_token"},
+				RequiredWith:  []string{"oauth_client_id", "oauth_refresh_token", "oauth_endpoint", "oauth_redirect_url"},
+			},
+			"oauth_endpoint": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_ENDPOINT", nil),
+				Sensitive:     true,
+				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "password", "oauth_access_token"},
+				RequiredWith:  []string{"oauth_client_id", "oauth_client_secret", "oauth_refresh_token", "oauth_redirect_url"},
+			},
+			"oauth_redirect_url": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_REDIRECT_URL", nil),
+				Sensitive:     true,
+				ConflictsWith: []string{"browser_auth", "private_key_path", "private_key", "password", "oauth_access_token"},
+				RequiredWith:  []string{"oauth_client_id", "oauth_client_secret", "oauth_endpoint", "oauth_refresh_token"},
 			},
 			"browser_auth": {
 				Type:          schema.TypeBool,
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_USE_BROWSER_AUTH", nil),
 				Sensitive:     false,
-				ConflictsWith: []string{"password", "private_key_path", "private_key", "oauth_access_token"},
+				ConflictsWith: []string{"password", "private_key_path", "private_key", "oauth_access_token", "oauth_refresh_token"},
 			},
 			"private_key_path": {
 				Type:          schema.TypeString,
@@ -61,7 +108,7 @@ func Provider() *schema.Provider {
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_PRIVATE_KEY", nil),
 				Sensitive:     true,
-				ConflictsWith: []string{"browser_auth", "password", "oauth_access_token", "private_key_path"},
+				ConflictsWith: []string{"browser_auth", "password", "oauth_access_token", "private_key_path", "oauth_refresh_token"},
 			},
 			"role": {
 				Type:        schema.TypeString,
@@ -148,6 +195,19 @@ func ConfigureProvider(s *schema.ResourceData) (interface{}, error) {
 	oauthAccessToken := s.Get("oauth_access_token").(string)
 	region := s.Get("region").(string)
 	role := s.Get("role").(string)
+	oauthRefreshToken := s.Get("oauth_refresh_token").(string)
+	oauthClientID := s.Get("oauth_client_id").(string)
+	oauthClientSecret := s.Get("oauth_client_secret").(string)
+	oauthEndpoint := s.Get("oauth_endpoint").(string)
+	oauthRedirectURL := s.Get("oauth_redirect_url").(string)
+
+	if oauthRefreshToken != "" {
+		accessToken, err := GetOauthAccessToken(oauthEndpoint, oauthClientID, oauthClientSecret, GetOauthData(oauthRefreshToken, oauthRedirectURL))
+		if err != nil {
+			errors.Wrap(err, "could not retreive access token from refresh token")
+		}
+		oauthAccessToken = accessToken
+	}
 
 	dsn, err := DSN(
 		account,
@@ -160,7 +220,6 @@ func ConfigureProvider(s *schema.ResourceData) (interface{}, error) {
 		region,
 		role,
 	)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build dsn for snowflake connection")
 	}
@@ -258,4 +317,56 @@ func ParsePrivateKey(privateKeyBytes []byte) (*rsa.PrivateKey, error) {
 		return nil, errors.New("privateKey not of type RSA")
 	}
 	return rsaPrivateKey, nil
+}
+
+type Result struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+func GetOauthData(refreshToken, redirectUrl string) url.Values {
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("refresh_token", refreshToken)
+	data.Set("redirect_uri", redirectUrl)
+	return data
+}
+
+func GetOauthRequest(dataContent *strings.Reader, endPoint, clientId, clientSecret string) *http.Request {
+	request, err := http.NewRequest("POST", endPoint, dataContent)
+	if err != nil {
+		errors.Wrap(err, "Request to the endpoint could not be completed")
+	}
+	request.SetBasicAuth(clientId, clientSecret)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+	return request
+
+}
+
+func GetOauthAccessToken(
+	endPoint,
+	client_id,
+	client_secret string,
+	data url.Values) (string, error) {
+
+	client := &http.Client{}
+	request := GetOauthRequest(strings.NewReader(data.Encode()), endPoint, client_id, client_secret)
+
+	var result Result
+
+	response, err := client.Do(request)
+	if err != nil {
+		errors.Wrap(err, "Response status returned an error:")
+	}
+	if response.StatusCode != 200 {
+		errors.New(fmt.Sprintf("Response status code: %s: %s", strconv.Itoa(response.StatusCode), http.StatusText(response.StatusCode)))
+	}
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		errors.Wrap(err, "Response body was not able to be parsed")
+	}
+	json.Unmarshal([]byte(body), &result)
+	return result.AccessToken, nil
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -72,6 +72,8 @@ export SNOWFLAKE_OAUTH_ENDPOINT='...'
 export SNOWFLAKE_OAUTH_REDIRECT_URL='https://localhost.com'
 ```
 
+Note because access token have a short life; typically 10 minutes, by passing refresh token new access token will be generated.
+
 ### Username and Password Environment Variables
 
 If you choose to use Username and Password Authentication, export these credentials:
@@ -115,4 +117,4 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.
 * `role` - (optional) Snowflake role to use for operations. If left unset, default role for user
   will be used. Can come from the `SNOWFLAKE_ROLE` environment variable.
-  
+

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -25,6 +25,7 @@ The Snowflake provider support multiple ways to authenticate:
 
 * Password
 * OAuth Access Token
+* OAuth Refresh Token
 * Browser Auth
 * Private Key
 
@@ -59,6 +60,18 @@ export SNOWFLAKE_OAUTH_ACCESS_TOKEN='...'
 
 Note that once this access token expires, you'll need to request a new one through an external application.
 
+### OAuth Refresh Token
+
+If you have an OAuth Refresh token, export these credentials as environment variables:
+
+```shell
+export SNOWFLAKE_OAUTH_REFRESH_TOKEN='...'
+export SNOWFLAKE_OAUTH_CLIENT_ID='...'
+export SNOWFLAKE_OAUTH_CLIENT_SECRET='...'
+export SNOWFLAKE_OAUTH_ENDPOINT='...'
+export SNOWFLAKE_OAUTH_REDIRECT_URL='https://localhost.com'
+```
+
 ### Username and Password Environment Variables
 
 If you choose to use Username and Password Authentication, export these credentials:
@@ -82,10 +95,24 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `password` - (optional) Password for username+password auth. Cannot be used with `browser_auth` or
   `private_key_path`. Can be source from `SNOWFLAKE_PASSWORD` environment variable.
 * `oauth_access_token` - (optional) Token for use with OAuth. Generating the token is left to other
-  tools. Cannot be used with `browser_auth`, `private_key_path` or `password`. Can be source from
-  `SNOWFLAKE_OAUTH_ACCESS_TOKEN` environment variable.
+  tools. Cannot be used with `browser_auth`, `private_key_path`, `oauth_refresh_token` or `password`. 
+  Can be sourced from `SNOWFLAKE_OAUTH_ACCESS_TOKEN` environment variable.
+* `oauth_refresh_token` - (optional) Token for use with OAuth. Setup and generation of the token is 
+  left to other tools. Should be used in conjunction with `oauth_client_id`, `oauth_client_secret`, 
+  `oauth_endpoint`, `oauth_redirect_url`. Cannot be used with `browser_auth`, `private_key_path`, 
+  `oauth_access_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_REFRESH_TOKEN` environment 
+  variable.
+* `oauth_client_id` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from 
+  `SNOWFLAKE_OAUTH_CLIENT_ID` environment variable.
+* `oauth_client_secret` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from 
+  `SNOWFLAKE_OAUTH_CLIENT_SECRET` environment variable.
+* `oauth_endpoint` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from 
+  `SNOWFLAKE_OAUTH_ENDPOINT` environment variable.
+* `oauth_redirect_url` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from 
+  `SNOWFLAKE_OAUTH_REDIRECT_URL` environment variable. 
 * `private_key_path` - (optional) Path to a private key for using keypair authentication.. Cannot be
   used with `browser_auth`, `oauth_access_token` or `password`. Can be source from
   `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.
 * `role` - (optional) Snowflake role to use for operations. If left unset, default role for user
   will be used. Can come from the `SNOWFLAKE_ROLE` environment variable.
+  


### PR DESCRIPTION
## Retrieving Access Token Using Refresh Token

##### Including functionality to retrieve access token by passing the following parameters refresh token, client id, client secret, endpoint and redirect_url. This access token is then passed to function DSN to perform authentication      

## Test Plan
New changes have been compiled and tested successfully (including acceptance tests)

 *  [x] unit tests
 *  [x] acceptance tests

##### The following test cases has been added 
* TestGetOauthDATA.      
* TestGetOauthResponse.      
* TestGetOauthAccessToken.      

## Addressing Issue
* https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/37  

## References
#### Setting up Refresh Token
* https://community.snowflake.com/s/article/HOW-TO-OAUTH-TOKEN-GENERATION-USING-SNOWFLAKE-CUSTOM-OAUTH

The link above provides guidance on to how to setup a refresh token