### PR TITLE
Filter out account level params

### DIFF
--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -334,7 +334,7 @@ func ReadTask(d *schema.ResourceData, meta interface{}) error {
 		paramMap := map[string]interface{}{}
 		for _, param := range params {
 			log.Printf("[TRACE] %+v\n", param)
-			if param.Value == param.DefaultValue {
+			if param.Value == param.DefaultValue || param.Level == 'ACCOUNT' {
 				continue
 			}
 

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -334,7 +334,7 @@ func ReadTask(d *schema.ResourceData, meta interface{}) error {
 		paramMap := map[string]interface{}{}
 		for _, param := range params {
 			log.Printf("[TRACE] %+v\n", param)
-			if param.Value == param.DefaultValue || param.Level == 'ACCOUNT' {
+			if param.Value == param.DefaultValue || param.Level == "ACCOUNT" {
 				continue
 			}
 


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan

* [ ] acceptance tests

## References
<!-- issues documentation links, etc  -->


*  Hi I am trying to fix the issue documented in https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/474. by filtering out account level params. My first attempt was using env variables, https://github.com/chanzuckerberg/terraform-provider-snowflake/pull/486


## Usage

`terraform plan`
Output:

```
  # snowflake_task.retention_task will be updated in-place
  ~ resource "snowflake_task" "retention_task" {
        comment            = "deletes tables"
        database           = "IDB"
        enabled            = false
        id                 = "IDB|UTIL|RETENTION_TASK"
        name               = "RETENTION_TASK"
        schedule           = "USING CRON 0 23 * * * Europe/London"
        schema             = "UTIL"
      ~ session_parameters = {
          - "QUOTED_IDENTIFIERS_IGNORE_CASE" = "true" -> null
        }
        sql_statement      = "CALL retention(false)"
        warehouse          = "DEMO_XS_WH"
    }
Plan: 0 to add, 1 to change, 0 to destroy.
```

To eliminate the constant recreation of task we can filter out account level params.

`terraform plan`
Output:

```
Plan: 0 to add, 0 to change, 0 to destroy.
```


