### PR TITLE
Add make setup step to release instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifndef KEYBASE_KEY_ID
 endif
 .PHONY: check-release-prereqs
 
-release: check-release-prereqs setup ## run a release
+release: setup check-release-prereqs ## run a release
 	./bin/bff bump
 	git push
 	goreleaser release --debug --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifndef KEYBASE_KEY_ID
 endif
 .PHONY: check-release-prereqs
 
-release: check-release-prereqs ## run a release
+release: check-release-prereqs setup ## run a release
 	./bin/bff bump
 	git push
 	goreleaser release --debug --rm-dist

--- a/README.md
+++ b/README.md
@@ -129,6 +129,5 @@ To set up a new person for releasing, there are a few steps–
 4. github admin for chanzuckerberg: take public key exported above and add it [in the registry](https://registry.terraform.io/settings/gpg-keys)
 5. releaser: set `KEYBASE_KEY_ID` environment variable. Note that this is different from the previous id. Get this one from `keybase pgp list`. It should be like ~70 characters long.
 6. set `GITHUB_TOKEN` environment variable with a personal access token
-7. releaser: run `make setup` to prepare environment with updated tags
-8. releaser: run `make release-prerelease` to test that releases are working correctly
-9. releaser: run `make release` to release for real
+7. releaser: run `make release-prerelease` to test that releases are working correctly
+8. releaser: run `make release` to release for real

--- a/README.md
+++ b/README.md
@@ -129,5 +129,6 @@ To set up a new person for releasing, there are a few steps–
 4. github admin for chanzuckerberg: take public key exported above and add it [in the registry](https://registry.terraform.io/settings/gpg-keys)
 5. releaser: set `KEYBASE_KEY_ID` environment variable. Note that this is different from the previous id. Get this one from `keybase pgp list`. It should be like ~70 characters long.
 6. set `GITHUB_TOKEN` environment variable with a personal access token
-7. releaser: run `make release-prerelease` to test that releases are working correctly
-8. releaser: run `make release` to release for real
+7. releaser: run `make setup` to prepare environment with updated tags
+8. releaser: run `make release-prerelease` to test that releases are working correctly
+9. releaser: run `make release` to release for real


### PR DESCRIPTION
Was getting this problem:
```
latestVersionTag "0.23.2"
fileversion "0.23.3"
Error: tag does not match VERSION file
Usage:
  bff bump [flags]

Flags:
  -h, --help   help for bump

tag does not match VERSION file
```

Running `make setup` fixed it, so adding it as substep to release.