### PR TITLE
role_grants: update read to only use grants specific to the tf resource

### DIFF
--- a/pkg/resources/role_grants.go
+++ b/pkg/resources/role_grants.go
@@ -98,6 +98,9 @@ func ReadRoleGrants(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	roleName := d.Id()
 
+	tfRoles := expandStringList(d.Get("roles").(*schema.Set).List())
+	tfUsers := expandStringList(d.Get("users").(*schema.Set).List())
+
 	roles := make([]string, 0)
 	users := make([]string, 0)
 
@@ -109,9 +112,17 @@ func ReadRoleGrants(d *schema.ResourceData, meta interface{}) error {
 	for _, grant := range grants {
 		switch grant.GrantedTo.String {
 		case "ROLE":
-			roles = append(roles, grant.GranteeName.String)
+			for _, tfRole := range tfRoles {
+				if tfRole == grant.GranteeName.String {
+					roles = append(roles, grant.GranteeName.String)
+				}
+			}
 		case "USER":
-			users = append(users, grant.GranteeName.String)
+			for _, tfUser := range tfUsers {
+				if tfUser == grant.GranteeName.String {
+					users = append(users, grant.GranteeName.String)
+				}
+			}
 		default:
 			return fmt.Errorf("unknown grant type %s", grant.GrantedTo.String)
 		}

--- a/pkg/resources/role_grants_acceptance_test.go
+++ b/pkg/resources/role_grants_acceptance_test.go
@@ -150,9 +150,10 @@ func TestAcc_GrantRole(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:      "snowflake_role_grants.w",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "snowflake_role_grants.w",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"roles", "users"},
 			},
 		},
 	})
@@ -181,42 +182,44 @@ resource "snowflake_user" "u2" {
 
 func rgConfig(role1, role2, role3, user1, user2 string) string {
 	s := `
-%s
+	%s
 
-resource "snowflake_role_grants" "w" {
-	role_name = "${snowflake_role.r.name}"
-	roles = ["${snowflake_role.r2.name}", "${snowflake_role.r3.name}"]
-	users = ["${snowflake_user.u.name}", "${snowflake_user.u2.name}"]
-}
-`
+	resource "snowflake_role_grants" "w" {
+		role_name = "${snowflake_role.r.name}"
+		roles = ["${snowflake_role.r2.name}", "${snowflake_role.r3.name}"]
+		users = ["${snowflake_user.u.name}", "${snowflake_user.u2.name}"]
+	}
+	`
 	return fmt.Sprintf(s, rolesAndUser(role1, role2, role3, user1, user2))
 }
 
 func rgConfig2(role1, role2, role3, user1, user2 string) string {
 	s := `
 
-%s
+	%s
 
-resource "snowflake_role_grants" "w" {
-	role_name = "${snowflake_role.r.name}"
-	roles = ["${snowflake_role.r2.name}"]
-	users = ["${snowflake_user.u.name}", "${snowflake_user.u2.name}"]
-}
-`
+	resource "snowflake_role_grants" "w" {
+		role_name = "${snowflake_role.r.name}"
+		roles = ["${snowflake_role.r2.name}"]
+		users = ["${snowflake_user.u.name}", "${snowflake_user.u2.name}"]
+	}
+	`
+
 	return fmt.Sprintf(s, rolesAndUser(role1, role2, role3, user1, user2))
 }
 
 func rgConfig3(role1, role2, role3, user1, user2 string) string {
 	s := `
 
-%s
+	%s
 
-resource "snowflake_role_grants" "w" {
-	role_name = "${snowflake_role.r.name}"
-	roles = ["${snowflake_role.r2.name}", "${snowflake_role.r3.name}"]
-	users = ["${snowflake_user.u.name}"]
-}
-`
+	resource "snowflake_role_grants" "w" {
+		role_name = "${snowflake_role.r.name}"
+		roles = ["${snowflake_role.r2.name}", "${snowflake_role.r3.name}"]
+		users = ["${snowflake_user.u.name}"]
+	}
+	`
+
 	return fmt.Sprintf(s, rolesAndUser(role1, role2, role3, user1, user2))
 }
 


### PR DESCRIPTION
The current behavior is to query Snowflake for all grants to the specified role when a role grant is read, updated, or deleted. This means the update or delete to applies to _all_ grants to the specified role rather than just the grants that are part of the terraform resource. This causes issues when there are multiple resources handling grants to the same role, as well as when there is a role hierarchy (see issues linked below for more info).

These changes modify the role grant read to look at only the grants that are part of the specified terraform resource. This allows for more flexible use of terraform modules and eliminates issues with role hierarchies.

## Test Plan
* [x] acceptance tests
* [x] unit tests

## References
[189](https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/189)
[512](https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/512)