### PR TITLE
Lower limit on warehouse auto-suspend setting

### DIFF
--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -71,7 +71,7 @@ var warehouseSchema = map[string]*schema.Schema{
 		Description:  "Specifies the number of seconds of inactivity after which a warehouse is automatically suspended.",
 		Optional:     true,
 		Computed:     true,
-		ValidateFunc: validation.IntAtLeast(60),
+		ValidateFunc: validation.IntAtLeast(1),
 	},
 	// @TODO add a disable_auto_suspend property that sets the value of auto_suspend to NULL
 	"auto_resume": {


### PR DESCRIPTION
The warehouse auto-suspend setting can actually be an arbitrary integer (you can test this with `alter warehouse reporting set auto_suspend = <x>`). The current check for 60 seconds imposes an arbitrary restriction on the provider that's not present in the service.

Negative values are just interpreted as "never". Based on the intent of the provider surface it looks like the "never" case should be handled by removing the auto-suspend setting, so a 1-second minimum seemed reasonable.