### PR TITLE
Corrected mistakes within the snowflake_system_get_privatelink_config documentation example

### DIFF
--- a/docs/data-sources/system_get_privatelink_config.md
+++ b/docs/data-sources/system_get_privatelink_config.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-data "system_get_privatelink_config" "snowflake_private_link" {}
+data "snowflake_system_get_privatelink_config" "snowflake_private_link" {}
 
 resource "aws_security_group" "snowflake_private_link" {
   vpc_id = var.vpc_id
@@ -35,9 +35,10 @@ resource "aws_security_group" "snowflake_private_link" {
 
 resource "aws_vpc_endpoint" "snowflake_private_link" {
   vpc_id              = var.vpc_id
-  service_name        = data.system_get_privatelink_config.aws_vpce_id
+  service_name        = data.snowflake_system_get_privatelink_config.snowflake_private_link.aws_vpce_id
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.snowflake_private_link.id]
+  subnet_ids          = var.subnet_ids
   private_dns_enabled = false
 }
 
@@ -51,7 +52,7 @@ resource "aws_route53_zone" "snowflake_private_link" {
 
 resource "aws_route53_record" "snowflake_private_link_url" {
   zone_id = aws_route53_zone.snowflake_private_link.zone_id
-  name    = data.system_get_privatelink_config.snowflake_private_link.account_url
+  name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.account_url
   type    = "CNAME"
   ttl     = "300"
   records = [aws_vpc_endpoint.snowflake_private_link.dns_entry[0]["dns_name"]]
@@ -59,7 +60,7 @@ resource "aws_route53_record" "snowflake_private_link_url" {
 
 resource "aws_route53_record" "snowflake_private_link_oscp_url" {
   zone_id = aws_route53_zone.snowflake_private_link_url.zone_id
-  name    = data.system_get_privatelink_config.snowflake_private_link.oscp_url
+  name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.oscp_url
   type    = "CNAME"
   ttl     = "300"
   records = [aws_vpc_endpoint.snowflake_private_link.dns_entry[0]["dns_name"]]

--- a/examples/data-sources/snowflake_system_get_privatelink_config/data-source.tf
+++ b/examples/data-sources/snowflake_system_get_privatelink_config/data-source.tf
@@ -1,4 +1,4 @@
-data "system_get_privatelink_config" "snowflake_private_link" {}
+data "snowflake_system_get_privatelink_config" "snowflake_private_link" {}
 
 resource "aws_security_group" "snowflake_private_link" {
   vpc_id = var.vpc_id
@@ -20,9 +20,10 @@ resource "aws_security_group" "snowflake_private_link" {
 
 resource "aws_vpc_endpoint" "snowflake_private_link" {
   vpc_id              = var.vpc_id
-  service_name        = data.system_get_privatelink_config.aws_vpce_id
+  service_name        = data.snowflake_system_get_privatelink_config.snowflake_private_link.aws_vpce_id
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.snowflake_private_link.id]
+  subnet_ids          = var.subnet_ids
   private_dns_enabled = false
 }
 
@@ -36,7 +37,7 @@ resource "aws_route53_zone" "snowflake_private_link" {
 
 resource "aws_route53_record" "snowflake_private_link_url" {
   zone_id = aws_route53_zone.snowflake_private_link.zone_id
-  name    = data.system_get_privatelink_config.snowflake_private_link.account_url
+  name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.account_url
   type    = "CNAME"
   ttl     = "300"
   records = [aws_vpc_endpoint.snowflake_private_link.dns_entry[0]["dns_name"]]
@@ -44,7 +45,7 @@ resource "aws_route53_record" "snowflake_private_link_url" {
 
 resource "aws_route53_record" "snowflake_private_link_oscp_url" {
   zone_id = aws_route53_zone.snowflake_private_link_url.zone_id
-  name    = data.system_get_privatelink_config.snowflake_private_link.oscp_url
+  name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.oscp_url
   type    = "CNAME"
   ttl     = "300"
   records = [aws_vpc_endpoint.snowflake_private_link.dns_entry[0]["dns_name"]]


### PR DESCRIPTION
The current example has mistakes, whereby the `snowflake_` prefix was missed in the documentation.

## Test Plan
* N/A

## References
* N/A