### PR TITLE
Remove snowflake_role_grants name example

### DIFF
--- a/docs/resources/role_grants.md
+++ b/docs/resources/role_grants.md
@@ -33,8 +33,6 @@ resource "snowflake_role" "other_role" {
 }
 
 resource "snowflake_role_grants" "grants" {
-  name = "foo"
-
   role_name = "${snowflake_role.role.name}"
 
   roles = [

--- a/examples/resources/snowflake_role_grants/resource.tf
+++ b/examples/resources/snowflake_role_grants/resource.tf
@@ -18,8 +18,6 @@ resource "snowflake_role" "other_role" {
 }
 
 resource "snowflake_role_grants" "grants" {
-  name = "foo"
-
   role_name = "${snowflake_role.role.name}"
 
   roles = [


### PR DESCRIPTION
`name` is not a field on the snowflake_role_grants resource making the example invalid if copied exactly.

## Test Plan
This is just an example change and does not not currently have any tests other than manually checking the terraform.

## References
