### PR TITLE
DOCFIX: Remove misleading attribute from table doc

### DIFF
--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -20,8 +20,6 @@ resource snowflake_table table {
   comment    = "A table."
   cluster_by = ["to_date(DATE)"]
   
-  owner      = "me"
-  
   column {
     name = "id"
     type = "int"

--- a/examples/resources/snowflake_table/resource.tf
+++ b/examples/resources/snowflake_table/resource.tf
@@ -5,8 +5,6 @@ resource snowflake_table table {
   comment    = "A table."
   cluster_by = ["to_date(DATE)"]
   
-  owner      = "me"
-  
   column {
     name = "id"
     type = "int"


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
The resource documentation for [snowflake_table](https://registry.terraform.io/providers/rxrevu/snowflake/latest/docs/resources/table) includes the `owner` attribute in its example code in a way that makes it seem like the attribute is writable. However, the `owner` attribute is read-only, and its value is assigned at resource creation.

This pull request removes the `owner` attribute from the example code.
