### PR TITLE
docs: fix import format for snowflake_account_grant

### DIFF
--- a/docs/resources/account_grant.md
+++ b/docs/resources/account_grant.md
@@ -35,6 +35,6 @@ resource snowflake_account_grant grant {
 Import is supported using the following syntax:
 
 ```shell
-# format is account name | privilege | true/false for with_grant_option
-terraform import snowflake_account_grant.example 'accountName|USAGE|true'
+# format is account name | | | privilege | true/false for with_grant_option
+terraform import snowflake_account_grant.example 'accountName|||USAGE|true'
 ```

--- a/examples/resources/snowflake_account_grant/import.sh
+++ b/examples/resources/snowflake_account_grant/import.sh
@@ -1,2 +1,2 @@
-# format is account name | privilege | true/false for with_grant_option
-terraform import snowflake_account_grant.example 'accountName|USAGE|true'
+# format is account name | | | privilege | true/false for with_grant_option
+terraform import snowflake_account_grant.example 'accountName|||USAGE|true'


### PR DESCRIPTION
Same problem as #429.
The argument of `grantIDFromString` named `stringID` expects 4 or 5 fields delimitered by "|".