### PR TITLE
fix: partition_by error in external table

### DIFF
--- a/pkg/resources/external_table.go
+++ b/pkg/resources/external_table.go
@@ -212,8 +212,8 @@ func CreateExternalTable(data *schema.ResourceData, meta interface{}) error {
 
 	// Set optionals
 	if v, ok := data.GetOk("partition_by"); ok {
-		partiionBys := expandStringList(v.(*schema.Set).List())
-		builder.WithPartitionBys(partiionBys)
+		partitionBys := expandStringList(v.([]interface{}))
+		builder.WithPartitionBys(partitionBys)
 	}
 
 	if v, ok := data.GetOk("pattern"); ok {

--- a/pkg/snowflake/external_table.go
+++ b/pkg/snowflake/external_table.go
@@ -118,9 +118,10 @@ func (tb *ExternalTableBuilder) Create() string {
 	q.WriteString(strings.Join(columnDefinitions, ", "))
 	q.WriteString(fmt.Sprintf(`)`))
 
-	if len(tb.partitionBys) > 1 {
-		q.WriteString(` PARTIION BY `)
+	if len(tb.partitionBys) > 0 {
+		q.WriteString(` PARTITION BY ( `)
 		q.WriteString(EscapeString(strings.Join(tb.partitionBys, ", ")))
+		q.WriteString(` )`)
 	}
 
 	q.WriteString(` WITH LOCATION = ` + EscapeString(tb.location))


### PR DESCRIPTION
This PR does the following:

- Fixed partition_by from set to interface.
- Renamed from partiion to partition.
- Changed the length condition of the partition from >1 to >0.

Adresses: #448

## Test Plan
- [ ] acceptaces test