### PR TITLE
feat: Added support for X5LARGE and X6LARGE warehouses

### DIFF
--- a/docs/resources/warehouse.md
+++ b/docs/resources/warehouse.md
@@ -25,7 +25,7 @@ resource snowflake_warehouse w {
 
 ### Required
 
-- **name** (String)
+- **name** (String) Identifier for the virtual warehouse; must be unique for your account.
 
 ### Optional
 
@@ -42,7 +42,7 @@ resource snowflake_warehouse w {
 - **statement_queued_timeout_in_seconds** (Number) Object parameter that specifies the time, in seconds, a SQL statement (query, DDL, DML, etc.) can be queued on a warehouse before it is canceled by the system.
 - **statement_timeout_in_seconds** (Number) Specifies the time, in seconds, after which a running SQL statement (query, DDL, DML, etc.) is canceled by the system
 - **wait_for_provisioning** (Boolean) Specifies whether the warehouse, after being resized, waits for all the servers to provision before executing any queued or new queries.
-- **warehouse_size** (String)
+- **warehouse_size** (String) Specifies the size of the virtual warehouse. Larger warehouse sizes 5X-Large and 6X-Large are currently in preview and only available on Amazon Web Services (AWS).
 
 ## Import
 

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -22,8 +22,9 @@ var warehouseProperties = []string{
 
 var warehouseSchema = map[string]*schema.Schema{
 	"name": {
-		Type:     schema.TypeString,
-		Required: true,
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Identifier for the virtual warehouse; must be unique for your account.",
 	},
 	"comment": {
 		Type:     schema.TypeString,
@@ -37,7 +38,8 @@ var warehouseSchema = map[string]*schema.Schema{
 		ValidateFunc: validation.StringInSlice([]string{
 			"XSMALL", "X-SMALL", "SMALL", "MEDIUM", "LARGE", "XLARGE",
 			"X-LARGE", "XXLARGE", "X2LARGE", "2X-LARGE", "XXXLARGE", "X3LARGE",
-			"3X-LARGE", "X4LARGE", "4X-LARGE",
+			"3X-LARGE", "X4LARGE", "4X-LARGE", "X5LARGE", "5X-LARGE", "X6LARGE",
+			"6X-LARGE",
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {
@@ -45,6 +47,7 @@ var warehouseSchema = map[string]*schema.Schema{
 			}
 			return normalize(old) == normalize(new)
 		},
+		Description: "Specifies the size of the virtual warehouse. Larger warehouse sizes 5X-Large and 6X-Large are currently in preview and only available on Amazon Web Services (AWS).",
 	},
 	"max_cluster_count": {
 		Type:         schema.TypeInt,


### PR DESCRIPTION
Snowflake on AWS supports X5Large and X6Large warehouses, this modifies the validation func to allow these and the synonyms to be supplied

## Test Plan
* [x] acceptance tests
* [x] ran `make docs`

## References

* https://docs.snowflake.com/en/sql-reference/sql/create-warehouse.html#optional-properties-objectproperties