### PR TITLE
fix: snowflake_share can't be renamed, ForceNew on name changes

### DIFF
--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -22,6 +22,7 @@ var shareSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Required:    true,
 		Description: "Specifies the identifier for the share; must be unique for the account in which the share is created.",
+		ForceNew:    true,
 	},
 	"comment": {
 		Type:        schema.TypeString,


### PR DESCRIPTION
"Error renaming this does not seem to be used USAGE to foobar"

looks like shares can't be renamed