### PR TITLE
fix: OSCP -> OCSP misspelling

### DIFF
--- a/docs/data-sources/system_get_privatelink_config.md
+++ b/docs/data-sources/system_get_privatelink_config.md
@@ -58,9 +58,9 @@ resource "aws_route53_record" "snowflake_private_link_url" {
   records = [aws_vpc_endpoint.snowflake_private_link.dns_entry[0]["dns_name"]]
 }
 
-resource "aws_route53_record" "snowflake_private_link_oscp_url" {
+resource "aws_route53_record" "snowflake_private_link_ocsp_url" {
   zone_id = aws_route53_zone.snowflake_private_link_url.zone_id
-  name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.oscp_url
+  name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.ocsp_url
   type    = "CNAME"
   ttl     = "300"
   records = [aws_vpc_endpoint.snowflake_private_link.dns_entry[0]["dns_name"]]
@@ -80,6 +80,6 @@ resource "aws_route53_record" "snowflake_private_link_oscp_url" {
 - **account_url** (String) The URL used to connect to Snowflake through AWS PrivateLink or Azure Private Link.
 - **aws_vpce_id** (String) The AWS VPCE ID for your account.
 - **azure_pls_id** (String) The Azure Private Link Service ID for your account.
-- **oscp_url** (String) The OCSP URL corresponding to your Snowflake account that uses AWS PrivateLink or Azure Private Link.
+- **ocsp_url** (String) The OCSP URL corresponding to your Snowflake account that uses AWS PrivateLink or Azure Private Link.
 
 

--- a/examples/data-sources/snowflake_system_get_privatelink_config/data-source.tf
+++ b/examples/data-sources/snowflake_system_get_privatelink_config/data-source.tf
@@ -43,9 +43,9 @@ resource "aws_route53_record" "snowflake_private_link_url" {
   records = [aws_vpc_endpoint.snowflake_private_link.dns_entry[0]["dns_name"]]
 }
 
-resource "aws_route53_record" "snowflake_private_link_oscp_url" {
+resource "aws_route53_record" "snowflake_private_link_ocsp_url" {
   zone_id = aws_route53_zone.snowflake_private_link_url.zone_id
-  name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.oscp_url
+  name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.ocsp_url
   type    = "CNAME"
   ttl     = "300"
   records = [aws_vpc_endpoint.snowflake_private_link.dns_entry[0]["dns_name"]]

--- a/pkg/datasources/system_get_privatelink_config.go
+++ b/pkg/datasources/system_get_privatelink_config.go
@@ -21,7 +21,7 @@ var systemGetPrivateLinkConfigSchema = map[string]*schema.Schema{
 		Description: "The URL used to connect to Snowflake through AWS PrivateLink or Azure Private Link.",
 	},
 
-	"oscp_url": {
+	"ocsp_url": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "The OCSP URL corresponding to your Snowflake account that uses AWS PrivateLink or Azure Private Link.",
@@ -72,7 +72,7 @@ func ReadSystemGetPrivateLinkConfig(d *schema.ResourceData, meta interface{}) er
 	d.SetId(config.AccountName)
 	d.Set("account_name", config.AccountName)
 	d.Set("account_url", config.AccountURL)
-	d.Set("oscp_url", config.OSCPURL)
+	d.Set("ocsp_url", config.OCSPURL)
 
 	if config.AwsVpceID != "" {
 		d.Set("aws_vpce_id", config.AwsVpceID)

--- a/pkg/datasources/system_get_privatelink_config_acceptance_test.go
+++ b/pkg/datasources/system_get_privatelink_config_acceptance_test.go
@@ -15,7 +15,7 @@ func TestAccSystemGetPrivateLinkConfig_aws(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.snowflake_system_get_privatelink_config.p", "account_name"),
 					resource.TestCheckResourceAttrSet("data.snowflake_system_get_privatelink_config.p", "account_url"),
-					resource.TestCheckResourceAttrSet("data.snowflake_system_get_privatelink_config.p", "oscp_url"),
+					resource.TestCheckResourceAttrSet("data.snowflake_system_get_privatelink_config.p", "ocsp_url"),
 					resource.TestCheckResourceAttrSet("data.snowflake_system_get_privatelink_config.p", "aws_vpce_id"),
 				),
 			},

--- a/pkg/snowflake/system_get_privatelink_config.go
+++ b/pkg/snowflake/system_get_privatelink_config.go
@@ -19,8 +19,8 @@ type privateLinkConfigInternal struct {
 	AwsVpceID                 string `json:"privatelink-vpce-id,omitempty"`
 	AzurePrivateLinkServiceID string `json:"privatelink-pls-id,omitempty"`
 	AccountURL                string `json:"privatelink-account-url"`
-	OSCPURL                   string `json:"privatelink-ocsp-url,omitempty"`
-	TypodOSCPURL              string `json:"privatelink_ocsp-url,omitempty"` // because snowflake returns this for AWS, but don't have an Azure account to verify against
+	OCSPURL                   string `json:"privatelink-ocsp-url,omitempty"`
+	TypodOCSPURL              string `json:"privatelink_ocsp-url,omitempty"` // because snowflake returns this for AWS, but don't have an Azure account to verify against
 }
 
 type PrivateLinkConfig struct {
@@ -28,7 +28,7 @@ type PrivateLinkConfig struct {
 	AwsVpceID                 string
 	AzurePrivateLinkServiceID string
 	AccountURL                string
-	OSCPURL                   string
+	OCSPURL                   string
 }
 
 func ScanPrivateLinkConfig(row *sqlx.Row) (*RawPrivateLinkConfig, error) {
@@ -53,11 +53,11 @@ func (i *privateLinkConfigInternal) getPrivateLinkConfig() (*PrivateLinkConfig, 
 		i.AwsVpceID,
 		i.AzurePrivateLinkServiceID,
 		i.AccountURL,
-		i.OSCPURL,
+		i.OCSPURL,
 	}
 
-	if i.TypodOSCPURL != "" {
-		config.OSCPURL = i.TypodOSCPURL
+	if i.TypodOCSPURL != "" {
+		config.OCSPURL = i.TypodOCSPURL
 	}
 
 	return config, nil

--- a/pkg/snowflake/system_get_privatelink_config_test.go
+++ b/pkg/snowflake/system_get_privatelink_config_test.go
@@ -27,7 +27,7 @@ func TestSystemGetPrivateLinkGetStructuredConfigAws(t *testing.T) {
 	r.Equal("com.amazonaws.vpce.eu-west-1.vpce-svc-123456789abcdef12", c.AwsVpceID)
 	r.Equal("", c.AzurePrivateLinkServiceID)
 	r.Equal("ab1234.eu-west-1.privatelink.snowflakecomputing.com", c.AccountURL)
-	r.Equal("ocsp.ab1234.eu-west-1.privatelink.snowflakecomputing.com", c.OSCPURL)
+	r.Equal("ocsp.ab1234.eu-west-1.privatelink.snowflakecomputing.com", c.OCSPURL)
 }
 
 func TestSystemGetPrivateLinkGetStructuredConfigAwsAsPerDocumentation(t *testing.T) {
@@ -44,7 +44,7 @@ func TestSystemGetPrivateLinkGetStructuredConfigAwsAsPerDocumentation(t *testing
 	r.Equal("com.amazonaws.vpce.eu-west-1.vpce-svc-123456789abcdef12", c.AwsVpceID)
 	r.Equal("", c.AzurePrivateLinkServiceID)
 	r.Equal("ab1234.eu-west-1.privatelink.snowflakecomputing.com", c.AccountURL)
-	r.Equal("ocsp.ab1234.eu-west-1.privatelink.snowflakecomputing.com", c.OSCPURL)
+	r.Equal("ocsp.ab1234.eu-west-1.privatelink.snowflakecomputing.com", c.OCSPURL)
 }
 
 func TestSystemGetPrivateLinkGetStructuredConfigAzure(t *testing.T) {
@@ -61,5 +61,5 @@ func TestSystemGetPrivateLinkGetStructuredConfigAzure(t *testing.T) {
 	r.Equal("", c.AwsVpceID)
 	r.Equal("sf-pvlinksvc-azeastus2.east-us-2.azure.something", c.AzurePrivateLinkServiceID)
 	r.Equal("ab1234.east-us-2.azure.privatelink.snowflakecomputing.com", c.AccountURL)
-	r.Equal("ocsp.ab1234.east-us-2.azure.privatelink.snowflakecomputing.com", c.OSCPURL)
+	r.Equal("ocsp.ab1234.east-us-2.azure.privatelink.snowflakecomputing.com", c.OCSPURL)
 }


### PR DESCRIPTION
Fix typo of `OSCP` and `oscp` references to `OCSP` and `ocsp` respectively.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
* [x] unit tests