### PR TITLE
feat: adding support for create tag to schema grants

### DIFF
--- a/pkg/resources/privileges.go
+++ b/pkg/resources/privileges.go
@@ -25,6 +25,7 @@ const (
 	privilegeUsage                     Privilege = "USAGE"
 	privilegeWrite                     Privilege = "WRITE"
 	privilegeCreateTable               Privilege = "CREATE TABLE"
+	privilegeCreateTag                 Privilege = "CREATE TAG"
 	privilegeCreateView                Privilege = "CREATE VIEW"
 	privilegeCreateFileFormat          Privilege = "CREATE FILE FORMAT"
 	privilegeCreateStage               Privilege = "CREATE STAGE"

--- a/pkg/resources/schema_grant.go
+++ b/pkg/resources/schema_grant.go
@@ -13,6 +13,7 @@ var validSchemaPrivileges = NewPrivilegeSet(
 	privilegeOwnership,
 	privilegeUsage,
 	privilegeCreateTable,
+	privilegeCreateTag,
 	privilegeCreateView,
 	privilegeCreateFileFormat,
 	privilegeCreateStage,

--- a/pkg/resources/schema_grant_test.go
+++ b/pkg/resources/schema_grant_test.go
@@ -23,7 +23,7 @@ func TestSchemaGrant(t *testing.T) {
 func TestSchemaGrantCreate(t *testing.T) {
 	r := require.New(t)
 
-	for _, test_priv := range []string{"USAGE", "MODIFY"} {
+	for _, test_priv := range []string{"USAGE", "MODIFY", "CREATE TAG"} {
 		in := map[string]interface{}{
 			"schema_name":       "test-schema",
 			"database_name":     "test-db",


### PR DESCRIPTION
This PR addresses #734 and adds CREATE TAG as a valid privilege to schema grants.

## Test Plan
Added CREATE TAG to the schema grant test

## References
#734 