### PR TITLE
fix: use "DESCRIBE USER" in ReadUser, UserExists

### DIFF
--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -156,7 +156,7 @@ func UserExists(data *schema.ResourceData, meta interface{}) (bool, error) {
 	db := meta.(*sql.DB)
 	id := data.Id()
 
-	stmt := snowflake.User(id).Show()
+	stmt := snowflake.User(id).Describe()
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return false, err
@@ -173,10 +173,10 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.User(id).Show()
-	row := snowflake.QueryRow(db, stmt)
-
-	u, err := snowflake.ScanUser(row)
+	// We use User.Describe instead of User.Show because the "SHOW USERS ..." command
+	// requires the "MANAGE GRANTS" global privilege
+	stmt := snowflake.User(id).Describe()
+	rows, err := snowflake.Query(db, stmt)
 	if err == sql.ErrNoRows {
 		// If not found, mark resource to be removed from statefile during apply or refresh
 		log.Printf("[DEBUG] user (%s) not found", d.Id())
@@ -187,10 +187,16 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	u, err := snowflake.ScanUserDescription(rows)
+	if err != nil {
+		return err
+	}
+
 	err = d.Set("name", u.Name.String)
 	if err != nil {
 		return err
 	}
+
 	err = d.Set("comment", u.Comment.String)
 	if err != nil {
 		return err

--- a/pkg/resources/user_public_keys.go
+++ b/pkg/resources/user_public_keys.go
@@ -61,9 +61,8 @@ func UserPublicKeys() *schema.Resource {
 
 func checkUserExists(db *sql.DB, name string) (bool, error) {
 	// First check if user exists
-	stmt := snowflake.User(name).Show()
-	row := snowflake.QueryRow(db, stmt)
-	_, err := snowflake.ScanUser(row)
+	stmt := snowflake.User(name).Describe()
+	_, err := snowflake.Query(db, stmt)
 	if err == sql.ErrNoRows {
 		log.Printf("[DEBUG] user (%s) not found", name)
 		return false, nil

--- a/pkg/resources/user_test.go
+++ b/pkg/resources/user_test.go
@@ -54,59 +54,41 @@ func TestUserCreate(t *testing.T) {
 }
 
 func expectReadUser(mock sqlmock.Sqlmock, name string) {
+	rowsmap := map[string]string{
+		"NAME":                 name,
+		"CREATED_ON":           "created_on",
+		"LOGIN_NAME":           "myloginname",
+		"DISPLAY_NAME":         "display_name",
+		"FIRST_NAME":           "first_name",
+		"LAST_NAME":            "last_name",
+		"EMAIL":                "email",
+		"MINS_TO_UNLOCK":       "mins_to_unlock",
+		"DAYS_TO_EXPIRY":       "days_to_expiry",
+		"COMMENT":              "mock comment",
+		"DISABLED":             "false",
+		"MUST_CHANGE_PASSWORD": "true",
+		"SNOWFLAKE_LOCK":       "snowflake_lock",
+		"DEFAULT_WAREHOUSE":    "default_warehouse",
+		"DEFAULT_NAMESPACE":    "default_namespace",
+		"DEFAULT_ROLE":         "default_role",
+		"EXT_AUTHN_DUO":        "ext_authn_duo",
+		"EXT_AUTHN_UID":        "ext_authn_uid",
+		"MINS_TO_BYPASS_MFA":   "mins_to_bypass_mfa",
+		"OWNER":                "owner",
+		"LAST_SUCCESS_LOGIN":   "last_success_login",
+		"EXPIRES_AT_TIME":      "expires_at_time",
+		"LOCKED_UNTIL_TIME":    "locked_until_time",
+		"HAS_PASSWORD":         "has_password",
+		"HAS_RSA_PUBLIC_KEY":   "false",
+	}
+
 	rows := sqlmock.NewRows(
 		[]string{"property", "value", "default", "description"},
-	).AddRow(
-		"NAME", name, "", "",
-	).AddRow(
-		"CREATED_ON", "created_on", "", "",
-	).AddRow(
-		"LOGIN_NAME", "myloginname", "", "",
-	).AddRow(
-		"DISPLAY_NAME", "display_name", "", "",
-	).AddRow(
-		"FIRST_NAME", "first_name", "", "",
-	).AddRow(
-		"LAST_NAME", "last_name", "", "",
-	).AddRow(
-		"EMAIL", "email", "", "",
-	).AddRow(
-		"MINS_TO_UNLOCK", "mins_to_unlock", "", "",
-	).AddRow(
-		"DAYS_TO_EXPIRY", "days_to_expiry", "", "",
-	).AddRow(
-		"COMMENT", "mock comment", "", "",
-	).AddRow(
-		"DISABLED", "false", "", "",
-	).AddRow(
-		"MUST_CHANGE_PASSWORD", "true", "", "",
-	).AddRow(
-		"SNOWFLAKE_LOCK", "snowflake_lock", "", "",
-	).AddRow(
-		"DEFAULT_WAREHOUSE", "default_warehouse", "", "",
-	).AddRow(
-		"DEFAULT_NAMESPACE", "default_namespace", "", "",
-	).AddRow(
-		"DEFAULT_ROLE", "default_role", "", "",
-	).AddRow(
-		"EXT_AUTHN_DUO", "ext_authn_duo", "", "",
-	).AddRow(
-		"EXT_AUTHN_UID", "ext_authn_uid", "", "",
-	).AddRow(
-		"MINS_TO_BYPASS_MFA", "mins_to_bypass_mfa", "", "",
-	).AddRow(
-		"OWNER", "owner", "", "",
-	).AddRow(
-		"LAST_SUCCESS_LOGIN", "last_success_login", "", "",
-	).AddRow(
-		"EXPIRES_AT_TIME", "expires_at_time", "", "",
-	).AddRow(
-		"LOCKED_UNTIL_TIME", "locked_until_time", "", "",
-	).AddRow(
-		"HAS_PASSWORD", "has_password", "", "",
-	).AddRow(
-		"HAS_RSA_PUBLIC_KEY", "false", "", "",
 	)
+
+	for k, v := range rowsmap {
+		rows.AddRow(k, v, "", "")
+	}
 
 	q := fmt.Sprintf(`^DESCRIBE USER "%s"$`, name)
 	mock.ExpectQuery(q).WillReturnRows(rows)

--- a/pkg/resources/user_test.go
+++ b/pkg/resources/user_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
@@ -43,30 +44,81 @@ func TestUserCreate(t *testing.T) {
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`^CREATE USER "good_name" COMMENT='great comment' DEFAULT_NAMESPACE='mynamespace' DEFAULT_ROLE='bestrole' DEFAULT_WAREHOUSE='mywarehouse' DISPLAY_NAME='Display Name' EMAIL='fake@email.com' FIRST_NAME='Marcin' LAST_NAME='Zukowski' LOGIN_NAME='gname' PASSWORD='awesomepassword' RSA_PUBLIC_KEY='asdf' RSA_PUBLIC_KEY_2='asdf2' DISABLED=true MUST_CHANGE_PASSWORD=true$`).WillReturnResult(sqlmock.NewResult(1, 1))
-		expectReadUser(mock)
+		name := "good_name"
+		q := fmt.Sprintf(`^CREATE USER "%s" COMMENT='great comment' DEFAULT_NAMESPACE='mynamespace' DEFAULT_ROLE='bestrole' DEFAULT_WAREHOUSE='mywarehouse' DISPLAY_NAME='Display Name' EMAIL='fake@email.com' FIRST_NAME='Marcin' LAST_NAME='Zukowski' LOGIN_NAME='gname' PASSWORD='awesomepassword' RSA_PUBLIC_KEY='asdf' RSA_PUBLIC_KEY_2='asdf2' DISABLED=true MUST_CHANGE_PASSWORD=true$`, name)
+		mock.ExpectExec(q).WillReturnResult(sqlmock.NewResult(1, 1))
+		expectReadUser(mock, name)
 		err := resources.CreateUser(d, db)
 		r.NoError(err)
 	})
 }
 
-func expectReadUser(mock sqlmock.Sqlmock) {
-	rows := sqlmock.NewRows([]string{
-		"name", "created_on", "login_name", "display_name", "first_name", "last_name", "email", "mins_to_unlock",
-		"days_to_expiry", "comment", "disabled", "must_change_password", "snowflake_lock", "default_warehouse",
-		"default_namespace", "default_role", "ext_authn_duo", "ext_authn_uid", "mins_to_bypass_mfa", "owner",
-		"last_success_login", "expires_at_time", "locked_until_time", "has_password", "has_rsa_public_key"},
-	).AddRow("good_name", "created_on", "myloginname", "display_name", "first_name", "last_name", "email", "mins_to_unlock", "days_to_expiry", "mock comment", false, true, "snowflake_lock", "default_warehouse", "default_namespace", "default_role", "ext_authn_duo", "ext_authn_uid", "mins_to_bypass_mfa", "owner", "last_success_login", "expires_at_time", "locked_until_time", "has_password", false)
-	mock.ExpectQuery(`^SHOW USERS LIKE 'good_name'$`).WillReturnRows(rows)
+func expectReadUser(mock sqlmock.Sqlmock, name string) {
+	rows := sqlmock.NewRows(
+		[]string{"property", "value", "default", "description"},
+	).AddRow(
+		"NAME", name, "", "",
+	).AddRow(
+		"CREATED_ON", "created_on", "", "",
+	).AddRow(
+		"LOGIN_NAME", "myloginname", "", "",
+	).AddRow(
+		"DISPLAY_NAME", "display_name", "", "",
+	).AddRow(
+		"FIRST_NAME", "first_name", "", "",
+	).AddRow(
+		"LAST_NAME", "last_name", "", "",
+	).AddRow(
+		"EMAIL", "email", "", "",
+	).AddRow(
+		"MINS_TO_UNLOCK", "mins_to_unlock", "", "",
+	).AddRow(
+		"DAYS_TO_EXPIRY", "days_to_expiry", "", "",
+	).AddRow(
+		"COMMENT", "mock comment", "", "",
+	).AddRow(
+		"DISABLED", "false", "", "",
+	).AddRow(
+		"MUST_CHANGE_PASSWORD", "true", "", "",
+	).AddRow(
+		"SNOWFLAKE_LOCK", "snowflake_lock", "", "",
+	).AddRow(
+		"DEFAULT_WAREHOUSE", "default_warehouse", "", "",
+	).AddRow(
+		"DEFAULT_NAMESPACE", "default_namespace", "", "",
+	).AddRow(
+		"DEFAULT_ROLE", "default_role", "", "",
+	).AddRow(
+		"EXT_AUTHN_DUO", "ext_authn_duo", "", "",
+	).AddRow(
+		"EXT_AUTHN_UID", "ext_authn_uid", "", "",
+	).AddRow(
+		"MINS_TO_BYPASS_MFA", "mins_to_bypass_mfa", "", "",
+	).AddRow(
+		"OWNER", "owner", "", "",
+	).AddRow(
+		"LAST_SUCCESS_LOGIN", "last_success_login", "", "",
+	).AddRow(
+		"EXPIRES_AT_TIME", "expires_at_time", "", "",
+	).AddRow(
+		"LOCKED_UNTIL_TIME", "locked_until_time", "", "",
+	).AddRow(
+		"HAS_PASSWORD", "has_password", "", "",
+	).AddRow(
+		"HAS_RSA_PUBLIC_KEY", "false", "", "",
+	)
+
+	q := fmt.Sprintf(`^DESCRIBE USER "%s"$`, name)
+	mock.ExpectQuery(q).WillReturnRows(rows)
 }
 
 func TestUserRead(t *testing.T) {
 	r := require.New(t)
-
-	d := user(t, "good_name", map[string]interface{}{"name": "good_name"})
+	name := "good_name"
+	d := user(t, name, map[string]interface{}{"name": name})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		expectReadUser(mock)
+		expectReadUser(mock, name)
 		err := resources.ReadUser(d, db)
 		r.NoError(err)
 		r.Equal("mock comment", d.Get("comment").(string))
@@ -75,7 +127,7 @@ func TestUserRead(t *testing.T) {
 
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.User(d.Id()).Show()
+		q := snowflake.User(d.Id()).Describe()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err2 := resources.ReadUser(d, db)
 		r.Empty(d.State())
@@ -85,11 +137,11 @@ func TestUserRead(t *testing.T) {
 
 func TestUserExists(t *testing.T) {
 	r := require.New(t)
-
-	d := user(t, "good_name", map[string]interface{}{"name": "good_name"})
+	name := "good_name"
+	d := user(t, name, map[string]interface{}{"name": name})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		expectReadUser(mock)
+		expectReadUser(mock, name)
 		b, err := resources.UserExists(d, db)
 		r.NoError(err)
 		r.True(b)

--- a/pkg/snowflake/user.go
+++ b/pkg/snowflake/user.go
@@ -34,6 +34,53 @@ func ScanUser(row *sqlx.Row) (*user, error) {
 	return r, err
 }
 
+func ScanUserDescription(rows *sqlx.Rows) (*user, error) {
+	r := &user{}
+	var err error
+
+	for rows.Next() {
+		userProp := &DescribeUserProp{}
+		err = rows.StructScan(userProp)
+
+		// The "DESCRIBE USER ..." command returns the string "null" for null values
+		if userProp.Value.String == "null" {
+			userProp.Value.Valid = false
+			userProp.Value.String = ""
+		}
+
+		switch propery := userProp.Property; propery {
+		case "COMMENT":
+			r.Comment = userProp.Value
+		case "DEFAULT_NAMESPACE":
+			r.DefaultNamespace = userProp.Value
+		case "DEFAULT_ROLE":
+			r.DefaultRole = userProp.Value
+		case "DEFAULT_WAREHOUSE":
+			r.DefaultWarehouse = userProp.Value
+		case "DISABLED":
+			r.Disabled = userProp.Value.String == "true"
+		case "DISPLAY_NAME":
+			r.DisplayName = userProp.Value
+		case "EMAIL":
+			r.Email = userProp.Value
+		case "FIRST_NAME":
+			r.FirstName = userProp.Value
+		case "RSA_PUBLIC_KEY_FP":
+			r.HasRsaPublicKey = userProp.Value.Valid
+		case "LAST_NAME":
+			r.LastName = userProp.Value
+		case "LOGIN_NAME":
+			r.LoginName = userProp.Value
+		case "NAME":
+			r.Name = userProp.Value
+		}
+	}
+
+	err = rows.Err()
+
+	return r, err
+}
+
 type DescribeUserProp struct {
 	Property string         `db:"property"`
 	Value    sql.NullString `db:"value"`

--- a/pkg/snowflake/user_test.go
+++ b/pkg/snowflake/user_test.go
@@ -15,6 +15,9 @@ func TestUser(t *testing.T) {
 	q := u.Show()
 	r.Equal("SHOW USERS LIKE 'user1'", q)
 
+	q = u.Describe()
+	r.Equal(`DESCRIBE USER "user1"`, q)
+
 	q = u.Drop()
 	r.Equal(`DROP USER "user1"`, q)
 


### PR DESCRIPTION
This PR is supposed to solve #677 by using `DESCRIBE USER ...` instead of `SHOW USERS LIKE ...` in the `ReadUser` and `UserExists` functions.
While `SHOW USERS ...` requires the `MANAGE_GRANTS` global privilege, which usually requires the `SECURITYADMIN` role, the `DESCRIBE USER ...` does not.

## Test Plan
* [ ] acceptance tests


## References

* https://docs.snowflake.com/en/sql-reference/sql/show-users.html#usage-notes
* https://docs.snowflake.com/en/sql-reference/sql/desc-user.html#usage-notes