### PR TITLE
fix: Add AWS_SNS notification_provider support for error notifications for Snowpipe.

### DIFF
--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -30,6 +30,11 @@ resource snowflake_notification_integration integration {
   notification_provider = "AWS_SQS"
   aws_sqs_arn           = "..." 
   aws_sqs_role_arn      = "..."
+	
+  # AWS_SNS
+	notification_provider = "AWS_SNS"
+	aws_sns_arn           = "..." 
+	aws_sns_role_arn      = "..."
 }
 ```
 
@@ -44,6 +49,8 @@ resource snowflake_notification_integration integration {
 
 - **aws_sqs_arn** (String) AWS SQS queue ARN for notification integration to connect to
 - **aws_sqs_role_arn** (String) AWS IAM role ARN for notification integration to assume
+- **aws_sns_arn** (String) AWS SNS topic ARN for notification integration to connect to
+- **aws_sns_role_arn** (String) AWS IAM role ARN for notification integration to assume
 - **azure_storage_queue_primary_uri** (String) The queue ID for the Azure Queue Storage queue created for Event Grid notifications
 - **azure_tenant_id** (String) The ID of the Azure Active Directory tenant used for identity management
 - **comment** (String)
@@ -51,13 +58,15 @@ resource snowflake_notification_integration integration {
 - **enabled** (Boolean)
 - **gcp_pubsub_subscription_name** (String) The subscription id that Snowflake will listen to when using the GCP_PUBSUB provider.
 - **id** (String) The ID of this resource.
-- **notification_provider** (String) The third-party cloud message queuing service (e.g. AZURE_STORAGE_QUEUE, AWS_SQS)
+- **notification_provider** (String) The third-party cloud message queuing service (e.g. AZURE_STORAGE_QUEUE, AWS_SQS, AWS_SNS)
 - **type** (String) A type of integration
 
 ### Read-Only
 
 - **aws_sqs_external_id** (String) The external ID that Snowflake will use when assuming the AWS role
 - **aws_sqs_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
+- **aws_sns_external_id** (String) The external ID that Snowflake will use when assuming the AWS role
+- **aws_sns_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
 - **created_on** (String) Date and time when the notification integration was created.
 
 ## Import

--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -30,11 +30,11 @@ resource snowflake_notification_integration integration {
   notification_provider = "AWS_SQS"
   aws_sqs_arn           = "..." 
   aws_sqs_role_arn      = "..."
-	
+
   # AWS_SNS
-	notification_provider = "AWS_SNS"
-	aws_sns_arn           = "..." 
-	aws_sns_role_arn      = "..."
+  notification_provider = "AWS_SNS"
+  aws_sns_arn           = "..." 
+  aws_sns_role_arn      = "..."
 }
 ```
 
@@ -47,10 +47,10 @@ resource snowflake_notification_integration integration {
 
 ### Optional
 
+- **aws_sns_arn** (String) AWS SNS Topic ARN for notification integration to connect to
+- **aws_sns_role_arn** (String) AWS IAM role ARN for notification integration to assume
 - **aws_sqs_arn** (String) AWS SQS queue ARN for notification integration to connect to
 - **aws_sqs_role_arn** (String) AWS IAM role ARN for notification integration to assume
-- **aws_sns_arn** (String) AWS SNS topic ARN for notification integration to connect to
-- **aws_sns_role_arn** (String) AWS IAM role ARN for notification integration to assume
 - **azure_storage_queue_primary_uri** (String) The queue ID for the Azure Queue Storage queue created for Event Grid notifications
 - **azure_tenant_id** (String) The ID of the Azure Active Directory tenant used for identity management
 - **comment** (String)
@@ -63,10 +63,10 @@ resource snowflake_notification_integration integration {
 
 ### Read-Only
 
-- **aws_sqs_external_id** (String) The external ID that Snowflake will use when assuming the AWS role
-- **aws_sqs_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
 - **aws_sns_external_id** (String) The external ID that Snowflake will use when assuming the AWS role
 - **aws_sns_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
+- **aws_sqs_external_id** (String) The external ID that Snowflake will use when assuming the AWS role
+- **aws_sqs_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
 - **created_on** (String) Date and time when the notification integration was created.
 
 ## Import

--- a/examples/resources/snowflake_notification_integration/resource.tf
+++ b/examples/resources/snowflake_notification_integration/resource.tf
@@ -15,7 +15,7 @@ resource snowflake_notification_integration integration {
   notification_provider = "AWS_SQS"
   aws_sqs_arn           = "..." 
   aws_sqs_role_arn      = "..."
-
+  
 	# AWS_SNS
 	notification_provider = "AWS_SNS"
 	aws_sns_arn           = "..." 

--- a/examples/resources/snowflake_notification_integration/resource.tf
+++ b/examples/resources/snowflake_notification_integration/resource.tf
@@ -15,4 +15,9 @@ resource snowflake_notification_integration integration {
   notification_provider = "AWS_SQS"
   aws_sqs_arn           = "..." 
   aws_sqs_role_arn      = "..."
+
+	# AWS_SNS
+	notification_provider = "AWS_SNS"
+	aws_sns_arn           = "..." 
+	aws_sns_role_arn      = "..."
 }

--- a/examples/resources/snowflake_notification_integration/resource.tf
+++ b/examples/resources/snowflake_notification_integration/resource.tf
@@ -15,9 +15,9 @@ resource snowflake_notification_integration integration {
   notification_provider = "AWS_SQS"
   aws_sqs_arn           = "..." 
   aws_sqs_role_arn      = "..."
-  
-	# AWS_SNS
-	notification_provider = "AWS_SNS"
-	aws_sns_arn           = "..." 
-	aws_sns_role_arn      = "..."
+
+  # AWS_SNS
+  notification_provider = "AWS_SNS"
+  aws_sns_arn           = "..." 
+  aws_sns_role_arn      = "..."
 }

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -271,7 +271,7 @@ func ReadNotificationIntegration(data *schema.ResourceData, meta interface{}) er
 			if err = data.Set("aws_sqs_iam_user_arn", v.(string)); err != nil {
 				return err
 			}
-		case "AWS_SNS_TOPIC_ARN":
+		case "AWS_SNS_ARN":
 			if err = data.Set("aws_sns_arn", v.(string)); err != nil {
 				return err
 			}
@@ -357,7 +357,7 @@ func UpdateNotificationIntegration(data *schema.ResourceData, meta interface{}) 
 
 	if data.HasChange("aws_sns_arn") {
 		runSetStatement = true
-		stmt.SetString("AWS_SNS_TOPIC_ARN", data.Get("aws_sns_arn").(string))
+		stmt.SetString("AWS_SNS_ARN", data.Get("aws_sns_arn").(string))
 	}
 
 	if data.HasChange("aws_sns_role_arn") {

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -40,8 +40,8 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 	"notification_provider": &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
-		ValidateFunc: validation.StringInSlice([]string{"AZURE_STORAGE_QUEUE", "AWS_SQS", "GCP_PUBSUB"}, true),
-		Description:  "The third-party cloud message queuing service (e.g. AZURE_STORAGE_QUEUE, AWS_SQS)",
+		ValidateFunc: validation.StringInSlice([]string{"AZURE_STORAGE_QUEUE", "AWS_SQS", "AWS_SNS" "GCP_PUBSUB"}, true),
+		Description:  "The third-party cloud message queuing service (e.g. AZURE_STORAGE_QUEUE, AWS_SQS, AWS_SNS)",
 	},
 	"azure_storage_queue_primary_uri": &schema.Schema{
 		Type:        schema.TypeString,
@@ -69,6 +69,26 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Description: "AWS SQS queue ARN for notification integration to connect to",
 	},
 	"aws_sqs_role_arn": &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "AWS IAM role ARN for notification integration to assume",
+	},
+	"aws_sns_external_id": &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The external ID that Snowflake will use when assuming the AWS role",
+	},
+	"aws_sns_iam_user_arn": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The Snowflake user that will attempt to assume the AWS role.",
+	},
+	"aws_sns_arn": &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "AWS SNS Topic ARN for notification integration to connect to",
+	},
+	"aws_sns_role_arn": &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "AWS IAM role ARN for notification integration to assume",
@@ -141,6 +161,12 @@ func CreateNotificationIntegration(data *schema.ResourceData, meta interface{}) 
 	}
 	if v, ok := data.GetOk("aws_sqs_role_arn"); ok {
 		stmt.SetString(`AWS_SQS_ROLE_ARN`, v.(string))
+	}
+	if v, ok := data.GetOk("aws_sns_arn"); ok {
+		stmt.SetString(`AWS_SNS_ARN`, v.(string))
+	}
+	if v, ok := data.GetOk("aws_sns_role_arn"); ok {
+		stmt.SetString(`AWS_SNS_ROLE_ARN`, v.(string))
 	}
 	if v, ok := data.GetOk("gcp_pubsub_subscription_name"); ok {
 		stmt.SetString(`GCP_PUBSUB_SUBSCRIPTION_NAME`, v.(string))
@@ -245,6 +271,22 @@ func ReadNotificationIntegration(data *schema.ResourceData, meta interface{}) er
 			if err = data.Set("aws_sqs_iam_user_arn", v.(string)); err != nil {
 				return err
 			}
+		case "AWS_SNS_TOPIC_ARN":
+			if err = data.Set("aws_sns_arn", v.(string)); err != nil {
+				return err
+			}
+		case "AWS_SNS_ROLE_ARN":
+			if err = data.Set("aws_sns_role_arn", v.(string)); err != nil {
+				return err
+			}
+		case "SF_AWS_EXTERNAL_ID":
+			if err = data.Set("aws_sns_external_id", v.(string)); err != nil {
+				return err
+			}
+		case "SF_AWS_IAM_USER_ARN":
+			if err = data.Set("aws_sns_iam_user_arn", v.(string)); err != nil {
+				return err
+			}
 		case "GCP_PUBSUB_SUBSCRIPTION_NAME":
 			if err = data.Set("gcp_pubsub_subscription_name", v.(string)); err != nil {
 				return err
@@ -311,6 +353,16 @@ func UpdateNotificationIntegration(data *schema.ResourceData, meta interface{}) 
 	if data.HasChange("aws_sqs_role_arn") {
 		runSetStatement = true
 		stmt.SetString("AWS_SQS_ROLE_ARN", data.Get("aws_sqs_role_arn").(string))
+	}
+
+	if data.HasChange("aws_sns_arn") {
+		runSetStatement = true
+		stmt.SetString("AWS_SNS_TOPIC_ARN", data.Get("aws_sns_arn").(string))
+	}
+
+	if data.HasChange("aws_sns_role_arn") {
+		runSetStatement = true
+		stmt.SetString("AWS_SNS_ROLE_ARN", data.Get("aws_sns_role_arn").(string))
 	}
 
 	if data.HasChange("gcp_pubsub_subscription_name") {

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -40,7 +40,7 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 	"notification_provider": &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
-		ValidateFunc: validation.StringInSlice([]string{"AZURE_STORAGE_QUEUE", "AWS_SQS", "AWS_SNS" "GCP_PUBSUB"}, true),
+		ValidateFunc: validation.StringInSlice([]string{"AZURE_STORAGE_QUEUE", "AWS_SQS", "AWS_SNS", "GCP_PUBSUB"}, true),
 		Description:  "The third-party cloud message queuing service (e.g. AZURE_STORAGE_QUEUE, AWS_SQS, AWS_SNS)",
 	},
 	"azure_storage_queue_primary_uri": &schema.Schema{

--- a/pkg/resources/notification_integration_test.go
+++ b/pkg/resources/notification_integration_test.go
@@ -57,7 +57,7 @@ func TestNotificationIntegrationCreate(t *testing.T) {
 				"aws_sns_arn":           "some-sns-arn",
 				"aws_sns_role_arn":      "some-iam-role-arn",
 			},
-			expectSQL: `^CREATE NOTIFICATION INTEGRATION "test_notification_integration" AWS_SNS_TOPIC_ARN='some-sns-arn' AWS_SNS_ROLE_ARN='some-iam-role-arn' COMMENT='great comment' DIRECTION='OUTBOUND' NOTIFICATION_PROVIDER='AWS_SNS' TYPE='QUEUE' ENABLED=true$`,
+			expectSQL: `^CREATE NOTIFICATION INTEGRATION "test_notification_integration" AWS_SNS_ARN='some-sns-arn' AWS_SNS_ROLE_ARN='some-iam-role-arn' COMMENT='great comment' DIRECTION='OUTBOUND' NOTIFICATION_PROVIDER='AWS_SNS' TYPE='QUEUE' ENABLED=true$`,
 		},
 		{
 			notificationProvider: "GCP_PUBSUB",
@@ -156,7 +156,7 @@ func expectReadNotificationIntegration(mock sqlmock.Sqlmock, notificationProvide
 		descRows = descRows.
 			AddRow("NOTIFICATION_PROVIDER", "String", notificationProvider, nil).
 			AddRow("DIRECTION", "String", "OUTBOUND", nil).
-			AddRow("AWS_SNS_TOPIC_ARN", "String", "some-sns-arn", nil).
+			AddRow("AWS_SNS_ARN", "String", "some-sns-arn", nil).
 			AddRow("AWS_SNS_ROLE_ARN", "String", "some-iam-role-arn", nil).
 			AddRow("SF_AWS_EXTERNAL_ID", "String", "AGreatExternalID", nil).
 			AddRow("SF_AWS_IAM_USER_ARN", "String", "some-iam-user-arn", nil)

--- a/pkg/resources/notification_integration_test.go
+++ b/pkg/resources/notification_integration_test.go
@@ -48,6 +48,18 @@ func TestNotificationIntegrationCreate(t *testing.T) {
 			expectSQL: `^CREATE NOTIFICATION INTEGRATION "test_notification_integration" AWS_SQS_ARN='some-sqs-arn' AWS_SQS_ROLE_ARN='some-iam-role-arn' COMMENT='great comment' DIRECTION='OUTBOUND' NOTIFICATION_PROVIDER='AWS_SQS' TYPE='QUEUE' ENABLED=true$`,
 		},
 		{
+			notificationProvider: "AWS_SNS",
+			raw: map[string]interface{}{
+				"name":                  "test_notification_integration",
+				"comment":               "great comment",
+				"direction":             "OUTBOUND",
+				"notification_provider": "AWS_SNS",
+				"aws_sns_arn":           "some-sns-arn",
+				"aws_sns_role_arn":      "some-iam-role-arn",
+			},
+			expectSQL: `^CREATE NOTIFICATION INTEGRATION "test_notification_integration" AWS_SNS_TOPIC_ARN='some-sns-arn' AWS_SNS_ROLE_ARN='some-iam-role-arn' COMMENT='great comment' DIRECTION='OUTBOUND' NOTIFICATION_PROVIDER='AWS_SNS' TYPE='QUEUE' ENABLED=true$`,
+		},
+		{
 			notificationProvider: "GCP_PUBSUB",
 			raw: map[string]interface{}{
 				"name":                         "test_notification_integration",
@@ -82,6 +94,9 @@ func TestNotificationIntegrationRead(t *testing.T) {
 		},
 		{
 			notificationProvider: "AWS_SQS",
+		},
+		{
+			notificationProvider: "AWS_SNS",
 		},
 		{
 			notificationProvider: "GCP_PUBSUB",
@@ -137,6 +152,14 @@ func expectReadNotificationIntegration(mock sqlmock.Sqlmock, notificationProvide
 			AddRow("AWS_SQS_ROLE_ARN", "String", "some-iam-role-arn", nil).
 			AddRow("AWS_SQS_EXTERNAL_ID", "String", "AGreatExternalID", nil).
 			AddRow("AWS_SQS_IAM_USER_ARN", "String", "some-iam-user-arn", nil)
+	case "AWS_SNS":
+		descRows = descRows.
+			AddRow("NOTIFICATION_PROVIDER", "String", notificationProvider, nil).
+			AddRow("DIRECTION", "String", "OUTBOUND", nil).
+			AddRow("AWS_SNS_TOPIC_ARN", "String", "some-sns-arn", nil).
+			AddRow("AWS_SNS_ROLE_ARN", "String", "some-iam-role-arn", nil).
+			AddRow("SF_AWS_EXTERNAL_ID", "String", "AGreatExternalID", nil).
+			AddRow("SF_AWS_IAM_USER_ARN", "String", "some-iam-user-arn", nil)
 	case "GCP_PUBSUB":
 		descRows = descRows.
 			AddRow("NOTIFICATION_PROVIDER", "String", notificationProvider, nil).

--- a/pkg/snowflake/notification_integration_test.go
+++ b/pkg/snowflake/notification_integration_test.go
@@ -45,3 +45,23 @@ func TestNotificationIntegration_AWS(t *testing.T) {
 
 	r.Equal(`CREATE NOTIFICATION INTEGRATION "aws_sqs" AWS_SQS_ARN='some-sqs-arn' AWS_SQS_ROLE_ARN='some-iam-role-arn' DIRECTION='OUTBOUND' TYPE='QUEUE' ENABLED=true`, q)
 }
+
+func TestNotificationIntegration_AWS_SNS(t *testing.T) {
+	r := require.New(t)
+	builder := snowflake.NotificationIntegration("aws_sns")
+	r.NotNil(builder)
+
+	q := builder.Show()
+	r.Equal("SHOW NOTIFICATION INTEGRATIONS LIKE 'aws_sns'", q)
+
+	c := builder.Create()
+
+	c.SetString(`type`, `QUEUE`)
+	c.SetString(`direction`, `OUTBOUND`)
+	c.SetString(`aws_sns_arn`, `some-sns-arn`)
+	c.SetString(`aws_sns_role_arn`, `some-iam-role-arn`)
+	c.SetBool(`enabled`, true)
+	q = c.Statement()
+
+	r.Equal(`CREATE NOTIFICATION INTEGRATION "aws_sns" AWS_SNS_ARN='some-sns-arn' AWS_SNS_ROLE_ARN='some-iam-role-arn' DIRECTION='OUTBOUND' TYPE='QUEUE' ENABLED=true`, q)
+}


### PR DESCRIPTION
## Context
I am adding AWS SNS notification_provider support for error notifications for Snowpipe. The current Snowflake provider version supports this feature; however, it supports an outdated version of it that was using SQS. My goal is to adapt the current provider to support SNS instead of SQS and thus stay up to date with the Snowflake feature. The documentation link for the new Snowflake feature could be found [here](https://docs.snowflake.com/en/LIMITEDACCESS/data-load-snowpipe-notifications.html) 

Please keep some things in mind:
- This feature is currently in private preview and must be enabled on the account level
- I am not very experienced in Go and I would appreciate some guidance

## What I have tried to do (but does not seem to pass the tests)
 I took reference of PR [[595](https://github.com/chanzuckerberg/terraform-provider-snowflake/pull/595)] which essentially does the same thing I want to do but using SQS instead of SNS. 

However, I get the following errors when I try to run the test using `make` like:
```
  FAIL
  coverage: 55.0% of statements
  FAIL    github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources    11.599s
  ok      github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake    0.577s  coverage: 59.7% of statements
  ?       github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers  [no test files]
  ok      github.com/chanzuckerberg/terraform-provider-snowflake/pkg/validation   0.273s  coverage: 93.1% of statements
  ?       github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version      [no test files]
  FAIL
  make: *** [test] Error 1
```

What am I doing wrong that makes the tests fail? Am I on the right track? 

Happy to include further information if needed : ) 