### PR TITLE
fix: Recreate notification integration when type changes

### DIFF
--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -53,7 +53,7 @@ resource snowflake_notification_integration integration {
 - **aws_sqs_role_arn** (String) AWS IAM role ARN for notification integration to assume
 - **azure_storage_queue_primary_uri** (String) The queue ID for the Azure Queue Storage queue created for Event Grid notifications
 - **azure_tenant_id** (String) The ID of the Azure Active Directory tenant used for identity management
-- **comment** (String)
+- **comment** (String) A comment for the integration
 - **direction** (String) Direction of the cloud messaging with respect to Snowflake (required only for error notifications)
 - **enabled** (Boolean)
 - **gcp_pubsub_subscription_name** (String) The subscription id that Snowflake will listen to when using the GCP_PUBSUB provider.

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -29,12 +29,14 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Default:      "QUEUE",
 		ValidateFunc: validation.StringInSlice([]string{"QUEUE"}, true),
 		Description:  "A type of integration",
+		ForceNew:     true,
 	},
 	"direction": &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
 		ValidateFunc: validation.StringInSlice([]string{"INBOUND", "OUTBOUND"}, true),
 		Description:  "Direction of the cloud messaging with respect to Snowflake (required only for error notifications)",
+		ForceNew:     true,
 	},
 	// This part of the schema is the cloudProviderParams in the Snowflake documentation and differs between vendors
 	"notification_provider": &schema.Schema{
@@ -42,6 +44,7 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Optional:     true,
 		ValidateFunc: validation.StringInSlice([]string{"AZURE_STORAGE_QUEUE", "AWS_SQS", "AWS_SNS", "GCP_PUBSUB"}, true),
 		Description:  "The third-party cloud message queuing service (e.g. AZURE_STORAGE_QUEUE, AWS_SQS, AWS_SNS)",
+		ForceNew:     true,
 	},
 	"azure_storage_queue_primary_uri": &schema.Schema{
 		Type:        schema.TypeString,
@@ -94,9 +97,9 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Description: "AWS IAM role ARN for notification integration to assume",
 	},
 	"comment": &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		Default:  "A comment for the integration",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "A comment for the integration",
 	},
 	"created_on": &schema.Schema{
 		Type:        schema.TypeString,


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

Edge case when changing the type of notification integration (e.g. from `AWS_SQS` to `AWS_SNS`) with the same name, Terraform attempts to `ALTER` it, which results in an error because required fields are different depending on the type.

This change forces recreation when any of the integration types change.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->

## References
<!-- issues documentation links, etc  -->

* [ALTER NOTIFICATION INTEGRATION](https://docs.snowflake.com/en/sql-reference/sql/alter-notification-integration.html)