### PR TITLE
fix: tagging for db, external_table, schema

### DIFF
--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -44,7 +44,7 @@ var databaseSchema = map[string]*schema.Schema{
 	"tag": tagReferenceSchema,
 }
 
-var databaseProperties = []string{"comment", "data_retention_time_in_days"}
+var databaseProperties = []string{"comment", "data_retention_time_in_days", "tag"}
 
 // Database returns a pointer to the resource representing a database
 func Database() *schema.Resource {
@@ -152,6 +152,7 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] updating database %v", d.Id())
 	return UpdateResource("database", databaseProperties, databaseSchema, snowflake.Database, ReadDatabase)(d, meta)
 }
 

--- a/pkg/resources/external_table.go
+++ b/pkg/resources/external_table.go
@@ -299,44 +299,10 @@ func UpdateExternalTable(data *schema.ResourceData, meta interface{}) error {
 	dbSchema := data.Get("schema").(string)
 	name := data.Get("name").(string)
 
-	// This type conversion is due to the test framework in the terraform-plugin-sdk having limited support
-	// for data types in the HCL2ValueFromConfigValue method.
-	columns := []map[string]string{}
-	for _, column := range data.Get("column").([]interface{}) {
-		columnDef := map[string]string{}
-		for key, val := range column.(map[string]interface{}) {
-			columnDef[key] = val.(string)
-		}
-		columns = append(columns, columnDef)
-	}
 	builder := snowflake.ExternalTable(name, database, dbSchema)
-	builder.WithColumns(columns)
-	builder.WithFileFormat(data.Get("file_format").(string))
-	builder.WithLocation(data.Get("location").(string))
 
-	builder.WithAutoRefresh(data.Get("auto_refresh").(bool))
-	builder.WithRefreshOnCreate(data.Get("refresh_on_create").(bool))
-	builder.WithCopyGrants(data.Get("copy_grants").(bool))
-
-	// Set optionals
-	if v, ok := data.GetOk("partition_by"); ok {
-		partitionBys := expandStringList(v.([]interface{}))
-		builder.WithPartitionBys(partitionBys)
-	}
-
-	if v, ok := data.GetOk("pattern"); ok {
-		builder.WithPattern(v.(string))
-	}
-
-	if v, ok := data.GetOk("aws_sns_topic"); ok {
-		builder.WithAwsSNSTopic(v.(string))
-	}
-
-	if v, ok := data.GetOk("comment"); ok {
-		builder.WithComment(v.(string))
-	}
-
-	if v, ok := data.GetOk("tag"); ok {
+	if data.HasChange("tag") {
+		v := data.Get("tag")
 		tags := getTags(v)
 		builder.WithTags(tags.toSnowflakeTagValues())
 	}

--- a/pkg/resources/external_table.go
+++ b/pkg/resources/external_table.go
@@ -135,6 +135,7 @@ func ExternalTable() *schema.Resource {
 	return &schema.Resource{
 		Create: CreateExternalTable,
 		Read:   ReadExternalTable,
+		Update: UpdateExternalTable,
 		Delete: DeleteExternalTable,
 
 		Schema: externalTableSchema,
@@ -289,6 +290,75 @@ func ReadExternalTable(data *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+// UpdateExternalTable implements schema.UpdateFunc
+func UpdateExternalTable(data *schema.ResourceData, meta interface{}) error {
+	db := meta.(*sql.DB)
+	database := data.Get("database").(string)
+	dbSchema := data.Get("schema").(string)
+	name := data.Get("name").(string)
+
+	// This type conversion is due to the test framework in the terraform-plugin-sdk having limited support
+	// for data types in the HCL2ValueFromConfigValue method.
+	columns := []map[string]string{}
+	for _, column := range data.Get("column").([]interface{}) {
+		columnDef := map[string]string{}
+		for key, val := range column.(map[string]interface{}) {
+			columnDef[key] = val.(string)
+		}
+		columns = append(columns, columnDef)
+	}
+	builder := snowflake.ExternalTable(name, database, dbSchema)
+	builder.WithColumns(columns)
+	builder.WithFileFormat(data.Get("file_format").(string))
+	builder.WithLocation(data.Get("location").(string))
+
+	builder.WithAutoRefresh(data.Get("auto_refresh").(bool))
+	builder.WithRefreshOnCreate(data.Get("refresh_on_create").(bool))
+	builder.WithCopyGrants(data.Get("copy_grants").(bool))
+
+	// Set optionals
+	if v, ok := data.GetOk("partition_by"); ok {
+		partitionBys := expandStringList(v.([]interface{}))
+		builder.WithPartitionBys(partitionBys)
+	}
+
+	if v, ok := data.GetOk("pattern"); ok {
+		builder.WithPattern(v.(string))
+	}
+
+	if v, ok := data.GetOk("aws_sns_topic"); ok {
+		builder.WithAwsSNSTopic(v.(string))
+	}
+
+	if v, ok := data.GetOk("comment"); ok {
+		builder.WithComment(v.(string))
+	}
+
+	if v, ok := data.GetOk("tag"); ok {
+		tags := getTags(v)
+		builder.WithTags(tags.toSnowflakeTagValues())
+	}
+
+	stmt := builder.Update()
+	err := snowflake.Exec(db, stmt)
+	if err != nil {
+		return errors.Wrapf(err, "error updating externalTable %v", name)
+	}
+
+	externalTableID := &externalTableID{
+		DatabaseName:      database,
+		SchemaName:        dbSchema,
+		ExternalTableName: name,
+	}
+	dataIDInput, err := externalTableID.String()
+	if err != nil {
+		return err
+	}
+	data.SetId(dataIDInput)
+
+	return ReadExternalTable(data, meta)
 }
 
 // DeleteExternalTable implements schema.DeleteFunc

--- a/pkg/resources/tag.go
+++ b/pkg/resources/tag.go
@@ -48,7 +48,6 @@ var tagReferenceSchema = &schema.Schema{
 	Type:        schema.TypeList,
 	Required:    false,
 	Optional:    true,
-	ForceNew:    true,
 	MinItems:    0,
 	Description: "Definitions of a tag to associate with the resource.",
 	Elem: &schema.Resource{
@@ -56,27 +55,23 @@ var tagReferenceSchema = &schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Tag name, e.g. department.",
 			},
 			"value": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Tag value, e.g. marketing_info.",
 			},
 			"database": {
 				Type:        schema.TypeString,
 				Required:    false,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Name of the database that the tag was created in.",
 			},
 			"schema": {
 				Type:        schema.TypeString,
 				Required:    false,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Name of the schema that the tag was created in.",
 			},
 		},

--- a/pkg/snowflake/external_table_test.go
+++ b/pkg/snowflake/external_table_test.go
@@ -21,6 +21,13 @@ func TestExternalTableCreate(t *testing.T) {
 	r.Equal(s.Create(), `CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( file format ) COMMENT = 'Test Comment'`)
 }
 
+func TestExternalTableUpdate(t *testing.T){
+	r := require.New(t)
+	s := ExternalTable("test_table", "test_db", "test_schema")
+	s.WithTags([]TagValue{{Name: "tag1", Value: "value1", Schema: "test_schema", Database: "test_db"}})
+	r.Equal(s.Update(), `ALTER EXTERNAL TABLE "test_db"."test_schema"."test_table" TAG "test_db"."test_schema"."tag1" = "value1"`)
+}
+
 func TestExternalTableDrop(t *testing.T) {
 	r := require.New(t)
 	s := ExternalTable("test_table", "test_db", "test_schema")


### PR DESCRIPTION
tagging for database, external_table and schema were not working. this is caused by two separate problems 1) the command for updating tags never runs and 2) the command itself was incorrect. This PR aims to fix both of these issues. In addition, tags were previously marked as force new, when they really shouldn't be. It would be very bad to accidentally delete a database just because the tags are getting changed, for example. A consequence of removing force new means that we now have to implement update command for external_table, which uses tags, but does not have its own update command. 

## Test Plan
* [ ] acceptance tests

## References

* 