### PR TITLE
fix: Allow schema_name to be optional when using on_future

### DIFF
--- a/pkg/resources/external_table_grant.go
+++ b/pkg/resources/external_table_grant.go
@@ -22,7 +22,7 @@ var externalTableGrantSchema = map[string]*schema.Schema{
 	},
 	"schema_name": {
 		Type:        schema.TypeString,
-		Required:    true,
+		Optional:    true,
 		Description: "The name of the schema containing the current or future external tables on which to grant privileges.",
 		ForceNew:    true,
 	},
@@ -99,6 +99,9 @@ func CreateExternalTableGrant(d *schema.ResourceData, meta interface{}) error {
 	futureExternalTables := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
 
+	if (schemaName == "") && !futureExternalTables {
+		return errors.New("schema_name must be set unless on_future is true.")
+	}
 	if (externalTableName == "") && !futureExternalTables {
 		return errors.New("external_table_name must be set unless on_future is true.")
 	}


### PR DESCRIPTION
## summary of changes 

I've made `schema_name` optional for an `external_table_grant`, since when you use `on_future`, you don't have to pass the schema, just the database, and it will grant on all external tables in all schemes in the database.

Also added a check that if `schema_name` was not supplied then `on_future` was supplied.

## existing state, prior to my changes

Today, even the provider docs mention this should be possible:
https://registry.terraform.io/providers/chanzuckerberg/snowflake/latest/docs/resources/external_table_grant

> **on_future (Boolean)** When this is set to true and a schema_name is provided, apply this grant on all future external tables in the given schema. When this is true and no schema_name is provided apply this grant on all future external tables in the given database. The external_table_name and shares fields must be unset in order to use on_future.

But for some reason the `schema_name` is listed as required, so I'm getting this error:

> validate: error: failed to validate Terraform configuration in .
> ╷
> │ Error: Missing required argument
> │   .
> │   .
> │   .
> │ The argument "schema_name" is required, but no definition was found.
> ╵

## Test Plan

Didn't add any tests, since this case (i.e. external table grant with `on_future` & no `schema_name`) is already being tested in this test:
https://github.com/chanzuckerberg/terraform-provider-snowflake/blob/22373669a82a614b9ba9b1c6fcc404fbafa39cc2/pkg/resources/external_table_grant_test.go#L95

## References

* https://docs.snowflake.com/en/sql-reference/sql/grant-privilege.html
* This option is available in Snowflake:
```
> grant select on all external tables in database MY_DB to role MY_ROLE;
+------------------------------------------------------+
| status                                               |
|------------------------------------------------------|
| Statement executed successfully. 2 objects affected. |
+------------------------------------------------------+
1 Row(s) produced. Time Elapsed: 6.368s
```