### PR TITLE
fix: changing sns topic for pipe resource

### DIFF
--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -58,6 +58,7 @@ var pipeSchema = map[string]*schema.Schema{
 	"aws_sns_topic_arn": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		ForceNew:    true,
 		Description: "Specifies the Amazon Resource Name (ARN) for the SNS topic for your S3 bucket.",
 	},
 	"integration": &schema.Schema{


### PR DESCRIPTION
Fixes #816 

As far as I can see `ALTER PIPE` doesn't allow to change the SNS topic for an existing snowpipe.

Thus I added `ForceNew` parameter in case someone changes the SNS topic for a snowpipe via TF.

## Test Plan
Really small change... unfortunately don't have a test setup for this provider available and thus it is untested. Would love if someone can have a short look there and verify it's working...

## References
* https://docs.snowflake.com/en/sql-reference/sql/alter-pipe.html - can't find any details that the SNS topic can be changed