### PR TITLE
fix: add missing quotes to resources in documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ setup: ## setup development dependencies
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
 	curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh
 	bash .download-tfproviderlint.sh
-	go get golang.org/x/tools/cmd/goimports
+	go get -d golang.org/x/tools/cmd/goimports
 .PHONY: setup
 
 lint: fmt ## run the fast go linters

--- a/docs/resources/account_grant.md
+++ b/docs/resources/account_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_account_grant grant {
+resource "snowflake_account_grant" "grant" {
   roles             = ["role1", "role2"]
   privilege         = "CREATE ROLE"
   with_grant_option = false

--- a/docs/resources/database_grant.md
+++ b/docs/resources/database_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_database_grant grant {
+resource "snowflake_database_grant" "grant" {
   database_name = "db"
 
   privilege = "USAGE"

--- a/docs/resources/external_table.md
+++ b/docs/resources/external_table.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_external_table external_table {
+resource "snowflake_external_table" "external_table" {
   database = "db"
   schema   = "schema"
   name     = "external_table"

--- a/docs/resources/external_table_grant.md
+++ b/docs/resources/external_table_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_external_table_grant grant {
+resource "snowflake_external_table_grant" "grant" {
   database_name       = "db"
   schema_name         = "schema"
   external_table_name = "external_table"

--- a/docs/resources/file_format_grant.md
+++ b/docs/resources/file_format_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_file_format_grant grant {
+resource "snowflake_file_format_grant" "grant" {
   database_name     = "db"
   schema_name       = "schema"
   file_format_name  = "file_format"

--- a/docs/resources/function_grant.md
+++ b/docs/resources/function_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_function_grant grant {
+resource "snowflake_function_grant" "grant" {
   database_name   = "db"
   schema_name     = "schema"
   function_name  = "function"

--- a/docs/resources/integration_grant.md
+++ b/docs/resources/integration_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_integration_grant grant {
+resource "snowflake_integration_grant" "grant" {
   integration_name = "integration"
 
   privilege = "USAGE"

--- a/docs/resources/managed_account.md
+++ b/docs/resources/managed_account.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_managed_account account {
+resource "snowflake_managed_account" "account" {
   name           = "managed account"
   admin_name     = "admin"
   admin_password = "secret"

--- a/docs/resources/network_policy.md
+++ b/docs/resources/network_policy.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_network_policy policy {
+resource "snowflake_network_policy" "policy" {
   name    = "policy"
   comment = "A policy."
 

--- a/docs/resources/network_policy_attachment.md
+++ b/docs/resources/network_policy_attachment.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_network_policy_attachment attach {
+resource "snowflake_network_policy_attachment" "attach" {
   network_policy_name = "policy"
   set_for_account     = false
   users = ["user1", "user2"]

--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_notification_integration integration {
+resource "snowflake_notification_integration" "integration" {
   name    = "notification"
   comment = "A notification integration."
   

--- a/docs/resources/pipe.md
+++ b/docs/resources/pipe.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_pipe pipe {
+resource "snowflake_pipe" "pipe" {
   database = "db"
   schema   = "schema"
   name     = "pipe"

--- a/docs/resources/pipe_grant.md
+++ b/docs/resources/pipe_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_pipe_grant grant {
+resource "snowflake_pipe_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   sequence_name = "sequence"

--- a/docs/resources/procedure_grant.md
+++ b/docs/resources/procedure_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_procedure_grant grant {
+resource "snowflake_procedure_grant" "grant" {
   database_name   = "db"
   schema_name     = "schema"
   procedure_name  = "procedure"

--- a/docs/resources/resource_monitor.md
+++ b/docs/resources/resource_monitor.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_resource_monitor monitor {
+resource "snowflake_resource_monitor" "monitor" {
   name         = "monitor"
   credit_quota = 100
 

--- a/docs/resources/resource_monitor_grant.md
+++ b/docs/resources/resource_monitor_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_monitor_grant grant {
+resource "snowflake_monitor_grant" "grant" {
   monitor_name      = "monitor"
   privilege         = "MODIFY"
   roles             = ["role1"]

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_role role {
+resource "snowflake_role" "role" {
   name    = "role1"
   comment = "A role."
 }

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_schema schema {
+resource "snowflake_schema" "schema" {
   database = "db"
   name     = "schema"
   comment  = "A schema."

--- a/docs/resources/schema_grant.md
+++ b/docs/resources/schema_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_schema_grant grant {
+resource "snowflake_schema_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
 

--- a/docs/resources/sequence_grant.md
+++ b/docs/resources/sequence_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_sequence_grant grant {
+resource "snowflake_sequence_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   sequence_name = "sequence"

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_share test {
+resource "snowflake_share" "test" {
 	name           = "share_name"
 	comment        = "cool comment"
 }

--- a/docs/resources/stage_grant.md
+++ b/docs/resources/stage_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_stage_grant grant {
+resource "snowflake_stage_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   stage_name    = "stage"

--- a/docs/resources/storage_integration.md
+++ b/docs/resources/storage_integration.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_storage_integration integration {
+resource "snowflake_storage_integration" "integration" {
   name    = "storage"
   comment = "A storage integration."
   type    = "EXTERNAL_STAGE"

--- a/docs/resources/stream.md
+++ b/docs/resources/stream.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_stream stream {
+resource "snowflake_stream" "stream" {
   comment = "A stream."
 
   database = "db"

--- a/docs/resources/stream_grant.md
+++ b/docs/resources/stream_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_stream_grant grant {
+resource "snowflake_stream_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   stream_name   = "view"

--- a/docs/resources/table_grant.md
+++ b/docs/resources/table_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_table_grant grant {
+resource "snowflake_table_grant" "grant" {
   database_name = "database"
   schema_name   = "schema"
   table_name    = "table"

--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_task task {
+resource "snowflake_task" "task" {
   comment = "my task"
 
   database  = "db"

--- a/docs/resources/task_grant.md
+++ b/docs/resources/task_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_task_grant grant {
+resource "snowflake_task_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   task_name = "task"

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_user user {
+resource "snowflake_user" "user" {
   name         = "Snowflake User"
   login_name   = "snowflake_user"
   comment      = "A user of snowflake."

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_view view {
+resource "snowflake_view" "view" {
   database = "db"
   schema   = "schema"
   name     = "view"

--- a/docs/resources/view_grant.md
+++ b/docs/resources/view_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_view_grant grant {
+resource "snowflake_view_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   view_name     = "view"

--- a/docs/resources/warehouse.md
+++ b/docs/resources/warehouse.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_warehouse w {
+resource "snowflake_warehouse" "warehouse" {
   name           = "test"
   comment        = "foo"
   warehouse_size = "small"

--- a/docs/resources/warehouse_grant.md
+++ b/docs/resources/warehouse_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_warehouse_grant grant {
+resource "snowflake_warehouse_grant" "grant" {
   warehouse_name = "wh"
   privilege      = "MODIFY"
 

--- a/examples/resources/snowflake_account_grant/resource.tf
+++ b/examples/resources/snowflake_account_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_account_grant grant {
+resource "snowflake_account_grant" "grant" {
   roles             = ["role1", "role2"]
   privilege         = "CREATE ROLE"
   with_grant_option = false

--- a/examples/resources/snowflake_database_grant/resource.tf
+++ b/examples/resources/snowflake_database_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_database_grant grant {
+resource "snowflake_database_grant" "grant" {
   database_name = "db"
 
   privilege = "USAGE"

--- a/examples/resources/snowflake_external_table/resource.tf
+++ b/examples/resources/snowflake_external_table/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_external_table external_table {
+resource "snowflake_external_table" "external_table" {
   database = "db"
   schema   = "schema"
   name     = "external_table"

--- a/examples/resources/snowflake_external_table_grant/resource.tf
+++ b/examples/resources/snowflake_external_table_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_external_table_grant grant {
+resource "snowflake_external_table_grant" "grant" {
   database_name       = "db"
   schema_name         = "schema"
   external_table_name = "external_table"

--- a/examples/resources/snowflake_file_format_grant/resource.tf
+++ b/examples/resources/snowflake_file_format_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_file_format_grant grant {
+resource "snowflake_file_format_grant" "grant" {
   database_name     = "db"
   schema_name       = "schema"
   file_format_name  = "file_format"

--- a/examples/resources/snowflake_function_grant/resource.tf
+++ b/examples/resources/snowflake_function_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_function_grant grant {
+resource "snowflake_function_grant" "grant" {
   database_name   = "db"
   schema_name     = "schema"
   function_name  = "function"

--- a/examples/resources/snowflake_integration_grant/resource.tf
+++ b/examples/resources/snowflake_integration_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_integration_grant grant {
+resource "snowflake_integration_grant" "grant" {
   integration_name = "integration"
 
   privilege = "USAGE"

--- a/examples/resources/snowflake_managed_account/resource.tf
+++ b/examples/resources/snowflake_managed_account/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_managed_account account {
+resource "snowflake_managed_account" "account" {
   name           = "managed account"
   admin_name     = "admin"
   admin_password = "secret"

--- a/examples/resources/snowflake_network_policy/resource.tf
+++ b/examples/resources/snowflake_network_policy/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_network_policy policy {
+resource "snowflake_network_policy" "policy" {
   name    = "policy"
   comment = "A policy."
 

--- a/examples/resources/snowflake_network_policy_attachment/resource.tf
+++ b/examples/resources/snowflake_network_policy_attachment/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_network_policy_attachment attach {
+resource "snowflake_network_policy_attachment" "attach" {
   network_policy_name = "policy"
   set_for_account     = false
   users = ["user1", "user2"]

--- a/examples/resources/snowflake_notification_integration/resource.tf
+++ b/examples/resources/snowflake_notification_integration/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_notification_integration integration {
+resource "snowflake_notification_integration" "integration" {
   name    = "notification"
   comment = "A notification integration."
   

--- a/examples/resources/snowflake_pipe/resource.tf
+++ b/examples/resources/snowflake_pipe/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_pipe pipe {
+resource "snowflake_pipe" "pipe" {
   database = "db"
   schema   = "schema"
   name     = "pipe"

--- a/examples/resources/snowflake_pipe_grant/resource.tf
+++ b/examples/resources/snowflake_pipe_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_pipe_grant grant {
+resource "snowflake_pipe_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   sequence_name = "sequence"

--- a/examples/resources/snowflake_procedure_grant/resource.tf
+++ b/examples/resources/snowflake_procedure_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_procedure_grant grant {
+resource "snowflake_procedure_grant" "grant" {
   database_name   = "db"
   schema_name     = "schema"
   procedure_name  = "procedure"

--- a/examples/resources/snowflake_resource_monitor/resource.tf
+++ b/examples/resources/snowflake_resource_monitor/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_resource_monitor monitor {
+resource "snowflake_resource_monitor" "monitor" {
   name         = "monitor"
   credit_quota = 100
 

--- a/examples/resources/snowflake_resource_monitor_grant/resource.tf
+++ b/examples/resources/snowflake_resource_monitor_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_monitor_grant grant {
+resource "snowflake_monitor_grant" "grant" {
   monitor_name      = "monitor"
   privilege         = "MODIFY"
   roles             = ["role1"]

--- a/examples/resources/snowflake_role/resource.tf
+++ b/examples/resources/snowflake_role/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_role role {
+resource "snowflake_role" "role" {
   name    = "role1"
   comment = "A role."
 }

--- a/examples/resources/snowflake_schema/resource.tf
+++ b/examples/resources/snowflake_schema/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_schema schema {
+resource "snowflake_schema" "schema" {
   database = "db"
   name     = "schema"
   comment  = "A schema."

--- a/examples/resources/snowflake_schema_grant/resource.tf
+++ b/examples/resources/snowflake_schema_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_schema_grant grant {
+resource "snowflake_schema_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
 

--- a/examples/resources/snowflake_sequence_grant/resource.tf
+++ b/examples/resources/snowflake_sequence_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_sequence_grant grant {
+resource "snowflake_sequence_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   sequence_name = "sequence"

--- a/examples/resources/snowflake_share/resource.tf
+++ b/examples/resources/snowflake_share/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_share test {
+resource "snowflake_share" "test" {
 	name           = "share_name"
 	comment        = "cool comment"
 }

--- a/examples/resources/snowflake_stage/resource.tf
+++ b/examples/resources/snowflake_stage/resource.tf
@@ -1,4 +1,3 @@
-
 resource "snowflake_stage" "example_stage" {
   name        = "EXAMPLE_STAGE"
   url         = "s3://com.example.bucket/prefix"

--- a/examples/resources/snowflake_stage_grant/resource.tf
+++ b/examples/resources/snowflake_stage_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_stage_grant grant {
+resource "snowflake_stage_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   stage_name    = "stage"

--- a/examples/resources/snowflake_storage_integration/resource.tf
+++ b/examples/resources/snowflake_storage_integration/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_storage_integration integration {
+resource "snowflake_storage_integration" "integration" {
   name    = "storage"
   comment = "A storage integration."
   type    = "EXTERNAL_STAGE"

--- a/examples/resources/snowflake_stream/resource.tf
+++ b/examples/resources/snowflake_stream/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_stream stream {
+resource "snowflake_stream" "stream" {
   comment = "A stream."
 
   database = "db"

--- a/examples/resources/snowflake_stream_grant/resource.tf
+++ b/examples/resources/snowflake_stream_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_stream_grant grant {
+resource "snowflake_stream_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   stream_name   = "view"

--- a/examples/resources/snowflake_table_grant/resource.tf
+++ b/examples/resources/snowflake_table_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_table_grant grant {
+resource "snowflake_table_grant" "grant" {
   database_name = "database"
   schema_name   = "schema"
   table_name    = "table"

--- a/examples/resources/snowflake_task/resource.tf
+++ b/examples/resources/snowflake_task/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_task task {
+resource "snowflake_task" "task" {
   comment = "my task"
 
   database  = "db"

--- a/examples/resources/snowflake_task_grant/resource.tf
+++ b/examples/resources/snowflake_task_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_task_grant grant {
+resource "snowflake_task_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   task_name = "task"

--- a/examples/resources/snowflake_user/resource.tf
+++ b/examples/resources/snowflake_user/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_user user {
+resource "snowflake_user" "user" {
   name         = "Snowflake User"
   login_name   = "snowflake_user"
   comment      = "A user of snowflake."

--- a/examples/resources/snowflake_view/resource.tf
+++ b/examples/resources/snowflake_view/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_view view {
+resource "snowflake_view" "view" {
   database = "db"
   schema   = "schema"
   name     = "view"

--- a/examples/resources/snowflake_view_grant/resource.tf
+++ b/examples/resources/snowflake_view_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_view_grant grant {
+resource "snowflake_view_grant" "grant" {
   database_name = "db"
   schema_name   = "schema"
   view_name     = "view"

--- a/examples/resources/snowflake_warehouse/resource.tf
+++ b/examples/resources/snowflake_warehouse/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_warehouse w {
+resource "snowflake_warehouse" "warehouse" {
   name           = "test"
   comment        = "foo"
   warehouse_size = "small"

--- a/examples/resources/snowflake_warehouse_grant/resource.tf
+++ b/examples/resources/snowflake_warehouse_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_warehouse_grant grant {
+resource "snowflake_warehouse_grant" "grant" {
   warehouse_name = "wh"
   privilege      = "MODIFY"
 


### PR DESCRIPTION
Fix documentation by adding quotes to resources naming & generate doc.

## Test Plan

seems like no test is needed.

## References
 