### PR TITLE
fix: Enable REFERENCES privilege for materialized view grants

### DIFF
--- a/pkg/resources/materialized_view_grant.go
+++ b/pkg/resources/materialized_view_grant.go
@@ -14,6 +14,7 @@ They are used for validation in the schema object below.
 
 var validMaterializedViewPrivileges = NewPrivilegeSet(
 	privilegeOwnership,
+	privilegeReferences,
 	privilegeSelect,
 )
 


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
Per Snowflake Access Control Privileges documentation, Materialized view grant should support `REFERENCES`  privilege. 

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [x] unit tests

## References
* [view-privileges](https://docs.snowflake.com/en/user-guide/security-access-control-privileges.html#view-privileges)
* #738 