### PR TITLE
fix: make saml2_enable_sp_initiated bool throughout

### DIFF
--- a/pkg/resources/saml_integration.go
+++ b/pkg/resources/saml_integration.go
@@ -177,7 +177,7 @@ func CreateSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, ok := d.GetOk("saml2_enable_sp_initiated"); ok {
-		stmt.SetString(`SAML2_ENABLE_SP_INITIATED`, d.Get("saml2_enable_sp_initiated").(string))
+		stmt.SetBool(`SAML2_ENABLE_SP_INITIATED`, d.Get("saml2_enable_sp_initiated").(bool))
 	}
 
 	if _, ok := d.GetOk("saml2_snowflake_x509_cert"); ok {


### PR DESCRIPTION
I encountered the following crash with the latest provider version:
```
panic: interface conversion: interface {} is bool, not string

goroutine 99 [running]:
github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources.CreateSAMLIntegration(0x0, {0x10d01e0, 0xc0004b69c0})
	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources/saml_integration.go:180 +0xbf7
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xf98540, {0x12d9918, 0xc00002c1c0}, 0x2, {0x10d01e0, 0xc0004b69c0})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/resource.go:318 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000522ee0, {0x12d9918, 0xc00002c1c0}, 0xc00035fc70, 0xc0001f8f00, {0x10d01e0, 0xc0004b69c0})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/resource.go:456 +0x871
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000484048, {0x12d9918, 0xc00002c1c0}, 0xc00029fa90)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/grpc_provider.go:977 +0xd8a
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc00048c300, {0x12d99c0, 0xc0006f9e60}, 0xc000491380)
	github.com/hashicorp/terraform-plugin-go@v0.4.0/tfprotov5/tf5server/server.go:332 +0x6c
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x109bac0, 0xc00048c300}, {0x12d99c0, 0xc0006f9e60}, 0xc00030d740, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.4.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00040c540, {0x12ebc70, 0xc000568000}, 0xc0003e86c0, 0xc000482f00, 0x1a22960, 0x0)
	google.golang.org/grpc@v1.41.0/server.go:1279 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc00040c540, {0x12ebc70, 0xc000568000}, 0xc0003e86c0, 0x0)
	google.golang.org/grpc@v1.41.0/server.go:1608 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.41.0/server.go:923 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.41.0/server.go:921 +0x294
```

This line with the new saml integration appears to be the culprit.

## Test Plan
* [x] `make test` locally
* [ ] acceptance tests - I ran locally w/o creating a new Snowflake account (it failed in the expected ways). Let me know if you'd like me to go through that process in order to run the acceptance tests / CI tests. Happy to do that, just unsure of protocol with changes this small 👍 thanks!

## References
* 