### PR TITLE
fix: Handling of task error_integration nulls

### DIFF
--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -309,8 +309,12 @@ func UpdatePipe(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("error_integration") {
-		errorIntegration := d.Get("error_integration")
-		q := builder.ChangeErrorIntegration(errorIntegration.(string))
+		var q string
+		if errorIntegration, ok := d.GetOk("error_integration"); ok {
+			q = builder.ChangeErrorIntegration(errorIntegration.(string))
+		} else {
+			q = builder.RemoveErrorIntegration()
+		}
 		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating pipe error_integration on %v", d.Id())

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -277,6 +277,11 @@ func ReadPipe(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// The "DESCRIBE PIPE ..." command returns the string "null" for error_integration
+	if pipe.ErrorIntegration.String == "null" {
+		pipe.ErrorIntegration.Valid = false
+		pipe.ErrorIntegration.String = ""
+	}
 	err = d.Set("error_integration", pipe.ErrorIntegration.String)
 	if err != nil {
 		return err

--- a/pkg/resources/pipe_test.go
+++ b/pkg/resources/pipe_test.go
@@ -39,6 +39,8 @@ func TestPipeCreate(t *testing.T) {
 		expectReadPipe(mock)
 		err := resources.CreatePipe(d, db)
 		r.NoError(err)
+
+		r.Empty(d.Get("error_integration"), "Null string must be treated as empty")
 	})
 }
 
@@ -67,6 +69,6 @@ func TestPipeRead(t *testing.T) {
 func expectReadPipe(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
 		"created_on", "name", "database_name", "schema_name", "definition", "owner", "notification_channel", "comment", "error_integration"},
-	).AddRow("2019-12-23 17:20:50.088 +0000", "test_pipe", "test_db", "test_schema", "test definition", "N", "test", "great comment", "test_integration")
+	).AddRow("2019-12-23 17:20:50.088 +0000", "test_pipe", "test_db", "test_schema", "test definition", "N", "test", "great comment", "null")
 	mock.ExpectQuery(`^SHOW PIPES LIKE 'test_pipe' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -322,6 +322,11 @@ func ReadTask(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// The "DESCRIBE TASK ..." command returns the string "null" for error_integration
+	if t.ErrorIntegration.String == "null" {
+		t.ErrorIntegration.Valid = false
+		t.ErrorIntegration.String = ""
+	}
 	err = d.Set("error_integration", t.ErrorIntegration.String)
 	if err != nil {
 		return err

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -537,8 +537,12 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("error_integration") {
-		errorIntegration := d.Get("error_integration")
-		q := builder.ChangeErrorIntegration(errorIntegration.(string))
+		var q string
+		if errorIntegration, ok := d.GetOk("error_integration"); ok {
+			q = builder.ChangeErrorIntegration(errorIntegration.(string))
+		} else {
+			q = builder.RemoveErrorIntegration()
+		}
 		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating task error_integration on %v", d.Id())

--- a/pkg/resources/task_test.go
+++ b/pkg/resources/task_test.go
@@ -49,6 +49,8 @@ func TestTaskCreate(t *testing.T) {
 		expectReadTaskParams(mock)
 		err := resources.CreateTask(d, db)
 		r.NoError(err)
+
+		r.Empty(d.Get("error_integration"), "Null string must be treated as empty")
 	})
 }
 
@@ -119,7 +121,7 @@ func TestTaskCreateManagedWithoutInitSize(t *testing.T) {
 func expectReadTask(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
 		"created_on", "name", "database_name", "schema_name", "owner", "comment", "warehouse", "schedule", "predecessors", "state", "definition", "condition", "error_integration"},
-	).AddRow("2020-05-14 17:20:50.088 +0000", "test_task", "test_db", "test_schema", "ACCOUNTADMIN", "wow comment", "", "", "", "started", "select hi from hello", "", "test_integration")
+	).AddRow("2020-05-14 17:20:50.088 +0000", "test_task", "test_db", "test_schema", "ACCOUNTADMIN", "wow comment", "", "", "", "started", "select hi from hello", "", "null")
 	mock.ExpectQuery(`^SHOW TASKS LIKE 'test_task' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
 }
 
@@ -134,10 +136,9 @@ func TestTaskRead(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":              "test_task",
-		"database":          "test_db",
-		"schema":            "test_schema",
-		"error_integration": "test_notification_integration",
+		"name":     "test_task",
+		"database": "test_db",
+		"schema":   "test_schema",
 	}
 
 	d := task(t, "test_db|test_schema|test_task", in)

--- a/pkg/snowflake/pipe.go
+++ b/pkg/snowflake/pipe.go
@@ -145,6 +145,11 @@ func (pb *PipeBuilder) ChangeErrorIntegration(c string) string {
 	return fmt.Sprintf(`ALTER PIPE %v SET ERROR_INTEGRATION = %v`, pb.QualifiedName(), EscapeString(c))
 }
 
+// RemoveErrorIntegration returns the SQL query that will remove the error_integration on the pipe.
+func (pb *PipeBuilder) RemoveErrorIntegration() string {
+	return fmt.Sprintf(`ALTER PIPE %v UNSET ERROR_INTEGRATION`, pb.QualifiedName())
+}
+
 // Drop returns the SQL query that will drop a pipe.
 func (pb *PipeBuilder) Drop() string {
 	return fmt.Sprintf(`DROP PIPE %v`, pb.QualifiedName())

--- a/pkg/snowflake/task.go
+++ b/pkg/snowflake/task.go
@@ -325,6 +325,11 @@ func (tb *TaskBuilder) ChangeErrorIntegration(c string) string {
 	return fmt.Sprintf(`ALTER TASK %v SET ERROR_INTEGRATION = %v`, tb.QualifiedName(), EscapeString(c))
 }
 
+// RemoveErrorIntegration returns the SQL query that will remove the error_integration on the task.
+func (tb *TaskBuilder) RemoveErrorIntegration() string {
+	return fmt.Sprintf(`ALTER TASK %v UNSET ERROR_INTEGRATION`, tb.QualifiedName())
+}
+
 type task struct {
 	Id               string         `db:"id"`
 	CreatedOn        string         `db:"created_on"`


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

Fixes problem introduced in #830.

Tested the latest release v0.25.35 and discovered that `DESCRIBE TASK` returns a string "null", rather than an actual NULL. Frustrating, but there seems to be a similar issue with `DESCRIBE USER` handled in a similar way.

Those with task error notifications preview enabled and any tasks without `error_notification` set will see this:

```
# snowflake_task.task will be updated in-place
  ~ resource "snowflake_task" "task" {
      - error_integration  = "null" -> null
        id                 = "DB|SCHEMA|TASK"
        name               = "TASK"
        # (8 unchanged attributes hidden)
    }
```

Worse still, when it tries to update the `error_notification` to empty, it produced the following invalid SQL:

```sql
ALTER TASK "DB"."SCHEMA"."TASK" SET ERROR_INTEGRATION = 
```

To fix this, I implemented proper unsetting of that parameter.

Both problems have been around in the pipe implementation of error integration (also me last year #595), which task was largely copied from, so I propagated both fixes there too. Apologies for these oversights!

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] unit tests
<!-- add more below if you think they are relevant -->

## References
<!-- issues documentation links, etc  -->

- #830
- #595