### PR TITLE
fix: Update goreleaser env Dirty to false

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - "-w -s -X github.com/chanzuckerberg/go-misc/ver.GitSha={{.Commit}} -X github.com/chanzuckerberg/go-misc/ver.Version={{.Version}} -X github.com/chanzuckerberg/go-misc/ver.Dirty={{.Env.DIRTY}}"
+    - "-w -s -X github.com/chanzuckerberg/go-misc/ver.GitSha={{.Commit}} -X github.com/chanzuckerberg/go-misc/ver.Version={{.Version}} -X github.com/chanzuckerberg/go-misc/ver.Dirty=false"
   ignore:
     - goos: darwin
       goarch: '386'


### PR DESCRIPTION
Fixing: `   ⨯ release failed after 0.07s error=template: tmpl:1:181: executing "tmpl" at <.Env.DIRTY>: map has no entry for key "DIRTY"`