### PR TITLE
fix: Remove keybase since moving to github actions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,18 +33,3 @@ archives:
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
-
-signs:
-  - artifacts: checksum
-    cmd: keybase
-    args:
-      - pgp
-      - sign
-      - "-b"
-      - "-d"
-      - "-i"
-      - "${artifact}"
-      - "-o"
-      - "${signature}"
-      - "-k"
-      - "{{.Env.KEYBASE_KEY_ID}}"

--- a/Makefile
+++ b/Makefile
@@ -46,30 +46,6 @@ lint-missing-acceptance-tests:
 	done
 .PHONY: lint-missing-acceptance-tests
 
-check-release-prereqs:
-ifndef KEYBASE_KEY_ID
-	$(error KEYBASE_KEY_ID is undefined)
-endif
-.PHONY: check-release-prereqs
-
-release: setup check-release-prereqs ## run a release
-	./bin/bff bump
-	git push
-	goreleaser release --debug --rm-dist
-.PHONY: release
-
-release-prerelease: check-release-prereqs build ## release to github as a 'pre-release'
-	version=`./$(BASE_BINARY_NAME) -version`; \
-	git tag v"$$version"; \
-	git push
-	git push --tags
-	goreleaser release -f .goreleaser.prerelease.yml --debug --rm-dist
-.PHONY: release-prerelease
-
-release-snapshot: ## run a release
-	goreleaser release --snapshot
-.PHONY: release-snapshot
-
 build: ## build the binary
 	go build ${LDFLAGS} -o $(BASE_BINARY_NAME) .
 .PHONY: build


### PR DESCRIPTION
Fixing: 
```
   ⨯ release failed after 651.76s error=sign failed: terraform-provider-snowflake_0.26.2_SHA256SUMS: template: tmpl:1:6: executing "tmpl" at <.Env.KEYBASE_KEY_ID>: map has no entry for key "KEYBASE_KEY_ID"
```
