### PR TITLE
feat: Expose GCP_PUBSUB_SERVICE_ACCOUNT attribute in notification integration

### DIFF
--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -67,6 +67,7 @@ resource snowflake_notification_integration integration {
 - **aws_sns_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
 - **aws_sqs_external_id** (String) The external ID that Snowflake will use when assuming the AWS role
 - **aws_sqs_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
+- **gcp_pubsub_service_account** (String) The GCP service account identifier that Snowflake will use when assuming the GCP role.
 - **created_on** (String) Date and time when the notification integration was created.
 
 ## Import

--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -67,8 +67,8 @@ resource snowflake_notification_integration integration {
 - **aws_sns_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
 - **aws_sqs_external_id** (String) The external ID that Snowflake will use when assuming the AWS role
 - **aws_sqs_iam_user_arn** (String) The Snowflake user that will attempt to assume the AWS role.
-- **gcp_pubsub_service_account** (String) The GCP service account identifier that Snowflake will use when assuming the GCP role.
 - **created_on** (String) Date and time when the notification integration was created.
+- **gcp_pubsub_service_account** (String) The GCP service account identifier that Snowflake will use when assuming the GCP role
 
 ## Import
 

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -111,6 +111,11 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "The subscription id that Snowflake will listen to when using the GCP_PUBSUB provider.",
 	},
+	"gcp_pubsub_service_account": &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The GCP service account identifier that Snowflake will use when assuming the GCP role",
+	},
 }
 
 // NotificationIntegration returns a pointer to the resource representing a notification integration
@@ -292,6 +297,10 @@ func ReadNotificationIntegration(data *schema.ResourceData, meta interface{}) er
 			}
 		case "GCP_PUBSUB_SUBSCRIPTION_NAME":
 			if err = data.Set("gcp_pubsub_subscription_name", v.(string)); err != nil {
+				return err
+			}
+		case "GCP_PUBSUB_SERVICE_ACCOUNT":
+			if err = data.Set("gcp_pubsub_service_account", v.(string)); err != nil {
 				return err
 			}
 		default:


### PR DESCRIPTION
This updates the "notification integration" resource to expose the GCP_PUBSUB_SERVICE_ACCOUNT generated when using GCP_PUBSUB provider as described in https://docs.snowflake.com/en/user-guide/data-load-snowpipe-auto-gcs.html#step-2-grant-snowflake-access-to-the-pub-sub-subscription.

The field is exposed as "gcp_pubsub_service_account".

## Test Plan

This hasn't been tested yet using the acceptance framework.

* [ ] acceptance tests