### PR TITLE
feat: Support DIRECTORY option on stage create

### DIFF
--- a/docs/resources/stage.md
+++ b/docs/resources/stage.md
@@ -45,6 +45,7 @@ resource "snowflake_stage_grant" "grant_example_stage" {
 - **comment** (String) Specifies a comment for the stage.
 - **copy_options** (String) Specifies the copy options for the stage.
 - **credentials** (String, Sensitive) Specifies the credentials for the stage.
+- **directory** (String) Specifies the directory settings for the stage.
 - **encryption** (String) Specifies the encryption settings for the stage.
 - **file_format** (String) Specifies the file format for the stage.
 - **id** (String) The ID of this resource.

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -283,6 +283,11 @@ func ReadStage(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	err = d.Set("directory", stageDesc.Directory)
+	if err != nil {
+		return err
+	}
+
 	err = d.Set("storage_integration", s.StorageIntegration)
 	if err != nil {
 		return err

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -72,6 +72,12 @@ var stageSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "Specifies a comment for the stage.",
 	},
+	"directory": {
+		Type:        schema.TypeString,
+		ForceNew:    true,
+		Optional:    true,
+		Description: "Specifies the directory settings for the stage.",
+	},
 	"aws_external_id": {
 		Type:     schema.TypeString,
 		Optional: true,
@@ -174,6 +180,10 @@ func CreateStage(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("copy_options"); ok {
 		builder.WithCopyOptions(v.(string))
+	}
+
+	if v, ok := d.GetOk("directory"); ok {
+		builder.WithDirectory(v.(string))
 	}
 
 	if v, ok := d.GetOk("encryption"); ok {

--- a/pkg/resources/stage_test.go
+++ b/pkg/resources/stage_test.go
@@ -73,7 +73,8 @@ func expectReadStage(mock sqlmock.Sqlmock) {
 		"parent_property", "property", "property_type", "property_value", "property_default"},
 	).AddRow("STAGE_LOCATION", "URL", "string", `["s3://load/test/"]`, "").
 		AddRow("STAGE_CREDENTIALS", "AWS_EXTERNAL_ID", "string", "test", "").
-		AddRow("STAGE_FILE_FORMAT", "FORMAT_NAME", "string", "CSV", "")
+		AddRow("STAGE_FILE_FORMAT", "FORMAT_NAME", "string", "CSV", "").
+		AddRow("DIRECTORY", "ENABLED", "Boolean", true, false)
 	mock.ExpectQuery(`^DESCRIBE STAGE "test_db"."test_schema"."test_stage"$`).WillReturnRows(rows)
 }
 

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -253,6 +253,7 @@ type descStageResult struct {
 	SnowflakeIamUser string
 	FileFormat       string
 	CopyOptions      string
+	Directory        string
 }
 
 type descStageRow struct {
@@ -266,6 +267,7 @@ func DescStage(db *sql.DB, query string) (*descStageResult, error) {
 	r := &descStageResult{}
 	var ff []string
 	var co []string
+	var dir []string
 	rows, err := Query(db, query)
 	if err != nil {
 		return r, err
@@ -297,11 +299,16 @@ func DescStage(db *sql.DB, query string) (*descStageResult, error) {
 			if row.PropertyValue != row.PropertyDefault {
 				co = append(co, fmt.Sprintf("%s = %s", row.Property, row.PropertyValue))
 			}
+		case "DIRECTORY":
+			if row.PropertyValue != row.PropertyDefault {
+				dir = append(dir, fmt.Sprintf("%s = %s", row.Property, row.PropertyValue))
+			}
 		}
 	}
 
 	r.FileFormat = strings.Join(ff, " ")
 	r.CopyOptions = strings.Join(co, " ")
+	r.Directory = strings.Join(dir, " ")
 	return r, nil
 }
 

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -21,6 +21,7 @@ type StageBuilder struct {
 	schema             string
 	url                string
 	credentials        string
+	directory          string
 	storageIntegration string
 	encryption         string
 	fileFormat         string
@@ -71,6 +72,12 @@ func (sb *StageBuilder) WithFileFormat(f string) *StageBuilder {
 // WithCopyOptions adds copy options to the StageBuilder
 func (sb *StageBuilder) WithCopyOptions(c string) *StageBuilder {
 	sb.copyOptions = c
+	return sb
+}
+
+// WithDirectory adds directory option to the StageBuilder
+func (sb *StageBuilder) WithDirectory(d string) *StageBuilder {
+	sb.directory = d
 	return sb
 }
 
@@ -148,6 +155,10 @@ func (sb *StageBuilder) Create() string {
 
 	if sb.copyOptions != "" {
 		q.WriteString(fmt.Sprintf(` COPY_OPTIONS = (%v)`, sb.copyOptions))
+	}
+
+	if sb.directory != "" {
+		q.WriteString(fmt.Sprintf(` DIRECTORY = (%v)`, sb.directory))
 	}
 
 	if sb.comment != "" {

--- a/pkg/snowflake/stage_test.go
+++ b/pkg/snowflake/stage_test.go
@@ -28,11 +28,14 @@ func TestStageCreate(t *testing.T) {
 	s.WithCopyOptions("on_error='skip_file'")
 	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file')`)
 
+	s.WithDirectory("ENABLE=TRUE")
+	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') DIRECTORY = (ENABLE=TRUE)`)
+
 	s.WithComment("Yee'haw")
-	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') COMMENT = 'Yee\'haw'`, s.Create())
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') DIRECTORY = (ENABLE=TRUE) COMMENT = 'Yee\'haw'`, s.Create())
 
 	s.WithStorageIntegration("MY_INTEGRATION")
-	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') STORAGE_INTEGRATION = MY_INTEGRATION ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') COMMENT = 'Yee\'haw'`, s.Create())
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') STORAGE_INTEGRATION = MY_INTEGRATION ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') DIRECTORY = (ENABLE=TRUE) COMMENT = 'Yee\'haw'`, s.Create())
 }
 
 func TestStageRename(t *testing.T) {


### PR DESCRIPTION
This adds passing the `DIRECTORY` option of `CREATE STAGE` (as `directory`) in the stage resource.
This is only supported on create as the ALTER capabilities don't really align. As a result this PR suggests to ForceNew on `directory` change.

## Test Plan
This is currently not tested using acceptance tests

* [ ] acceptance tests