### PR TITLE
feat: Allow in-place renaming of Snowflake tables

### DIFF
--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -22,7 +22,6 @@ var tableSchema = map[string]*schema.Schema{
 	"name": {
 		Type:        schema.TypeString,
 		Required:    true,
-		ForceNew:    true,
 		Description: "Specifies the identifier for the table; must be unique for the database and schema in which the table is created.",
 	},
 	"schema": {

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -602,6 +602,7 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return errors.Wrapf(err, "error updating table name on %v", d.Id())
 		}
+		d.SetId(fmt.Sprintf("%v|%v|%v", dbName, schema, name.(string)))
 	}
 	if d.HasChange("comment") {
 		comment := d.Get("comment")

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -595,20 +595,20 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 	builder := snowflake.Table(tableName, dbName, schema)
 
 	db := meta.(*sql.DB)
-	if d.HasChange("comment") {
-		comment := d.Get("comment")
-		q := builder.ChangeComment(comment.(string))
-		err := snowflake.Exec(db, q)
-		if err != nil {
-			return errors.Wrapf(err, "error updating table comment on %v", d.Id())
-		}
-	}
 	if d.HasChange("name") {
 		name := d.Get("name")
 		q := builder.Rename(name.(string))
 		err := snowflake.Exec(db, q)
 		if err != nil {
 			return errors.Wrapf(err, "error updating table name on %v", d.Id())
+		}
+	}
+	if d.HasChange("comment") {
+		comment := d.Get("comment")
+		q := builder.ChangeComment(comment.(string))
+		err := snowflake.Exec(db, q)
+		if err != nil {
+			return errors.Wrapf(err, "error updating table comment on %v", d.Id())
 		}
 	}
 	if d.HasChange("cluster_by") {

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -603,7 +603,14 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 			return errors.Wrapf(err, "error updating table comment on %v", d.Id())
 		}
 	}
-
+	if d.HasChange("name") {
+		name := d.Get("name")
+		q := builder.Rename(name.(string))
+		err := snowflake.Exec(db, q)
+		if err != nil {
+			return errors.Wrapf(err, "error updating table name on %v", d.Id())
+		}
+	}
 	if d.HasChange("cluster_by") {
 		cb := expandStringList(d.Get("cluster_by").([]interface{}))
 

--- a/pkg/snowflake/table.go
+++ b/pkg/snowflake/table.go
@@ -625,6 +625,12 @@ func (tb *TableBuilder) ShowPrimaryKeys() string {
 	return fmt.Sprintf(`SHOW PRIMARY KEYS IN TABLE %s`, tb.QualifiedName())
 }
 
+func (tb *TableBuilder) Rename(newName string) string {
+	oldName := tb.QualifiedName()
+	tb.name = newName
+	return fmt.Sprintf(`ALTER TABLE %s RENAME TO %s`, oldName, tb.QualifiedName())
+}
+
 type table struct {
 	CreatedOn           sql.NullString `db:"created_on"`
 	TableName           sql.NullString `db:"name"`

--- a/pkg/snowflake/table_test.go
+++ b/pkg/snowflake/table_test.go
@@ -247,3 +247,9 @@ func TestTableUnsetTag(t *testing.T) {
 	s := Table("test_table", "test_db", "test_schema")
 	r.Equal(s.UnsetTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db"}), `ALTER TABLE "test_db"."test_schema"."test_table" UNSET TAG "test_db"."test_schema"."tag"`)
 }
+
+func TestTableRename(t *testing.T) {
+	r := require.New(t)
+	s := Table("test_table1", "test_db", "test_schema")
+	r.Equal(s.Rename("test_table2"), `ALTER TABLE "test_db"."test_schema"."test_table1" RENAME TO "test_db"."test_schema"."test_table2"`)
+}


### PR DESCRIPTION
Allow changing the name of Snowflake tables without destroying then recreating the table.

## Test Plan
* [ ] acceptance tests
* [ ] unit tests

## References
- Feature Request: #891 
- [Snowflake Documentation for Renaming a Table](https://docs.snowflake.com/en/sql-reference/sql/alter-table.html#syntax)