### PR TITLE
fix: update snowflake identifier validation condition

### DIFF
--- a/pkg/snowflake/validation.go
+++ b/pkg/snowflake/validation.go
@@ -42,6 +42,7 @@ func isIdentifierRune(r rune) bool {
 
 func isInitialIdentifierRune(r rune) bool {
 	return (r == '_' ||
+		r == '-' ||
 		(r >= 'A' && r <= 'Z') ||
 		(r >= 'a' && r <= 'z'))
 }

--- a/pkg/snowflake/validation_test.go
+++ b/pkg/snowflake/validation_test.go
@@ -16,6 +16,7 @@ func TestValidateIdentifier(t *testing.T) {
 		{"_1", true},
 		{"Aword", true},
 		{"azAZ09_$", true},
+		{"-30-Ab-", true},
 		{"invalidcharacter!", false},
 		{"1startwithnumber", false},
 		{"$startwithdollar", false},


### PR DESCRIPTION
Has been blocked by the same issues as others reported: 
[issue-846](https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/846)
[issue-862](https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/862)

For context, Snowflake object identifier can use special characters like `-` as long as it's [double quoted](https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html#double-quoted-identifiers). However currently the validation rule only allow characters used in [unquoted Snowflake object identifier](https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html#unquoted-identifiers).

As mentioned in the issue tickets, currently creating a role with `-` is allowed by the provider, but granting role with `-` to user or other roles is blocked by this validation. So I believe we should enable the dash character to provide consistent experience as in Snowflake console.


## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 