### PR TITLE
fix: Make ReadWarehouse compatible with quoted resource identifiers

### DIFF
--- a/pkg/resources/warehouse_test.go
+++ b/pkg/resources/warehouse_test.go
@@ -44,7 +44,7 @@ func expectReadWarehouse(mock sqlmock.Sqlmock) {
 	rows = sqlmock.NewRows(
 		[]string{"key", "value", "default", "level", "description", "type"},
 	).AddRow("MAX_CONCURRENCY_LEVEL", 8, 8, "WAREHOUSE", "", "NUMBER")
-	mock.ExpectQuery("SHOW PARAMETERS IN WAREHOUSE good_name").WillReturnRows(rows)
+	mock.ExpectQuery("SHOW PARAMETERS IN WAREHOUSE \"good_name\"").WillReturnRows(rows)
 }
 
 func TestWarehouseRead(t *testing.T) {

--- a/pkg/snowflake/warehouse.go
+++ b/pkg/snowflake/warehouse.go
@@ -40,7 +40,7 @@ func (wb *WarehouseBuilder) Create() *CreateBuilder {
 
 // ShowParameters returns the query to show the parameters for the warehouse
 func (wb *WarehouseBuilder) ShowParameters() string {
-	return fmt.Sprintf("SHOW PARAMETERS IN WAREHOUSE %v", wb.Builder.name)
+	return fmt.Sprintf("SHOW PARAMETERS IN WAREHOUSE %q", wb.Builder.name)
 }
 
 func Warehouse(name string) *WarehouseBuilder {


### PR DESCRIPTION

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
* [x] internal tests
* [x] unit tests


## References
<!-- issues documentation links, etc  -->

* https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/862
* https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/844
* https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/791
* https://github.com/chanzuckerberg/terraform-provider-snowflake/issues/774