### PR TITLE
fix: remove share feature from stage because it isn't supported

### DIFF
--- a/docs/resources/stage_grant.md
+++ b/docs/resources/stage_grant.md
@@ -39,10 +39,9 @@ resource snowflake_stage_grant grant {
 ### Optional
 
 - **id** (String) The ID of this resource.
-- **on_future** (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future stages in the given schema. When this is true and no schema_name is provided apply this grant on all future stages in the given database. The stage_name and shares fields must be unset in order to use on_future.
+- **on_future** (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future stages in the given schema. When this is true and no schema_name is provided apply this grant on all future stages in the given database. The stage_name field must be unset in order to use on_future.
 - **privilege** (String) The privilege to grant on the stage.
 - **roles** (Set of String) Grants privilege to these roles.
-- **shares** (Set of String) Grants privilege to these shares (only valid if on_future is false).
 - **stage_name** (String) The name of the stage on which to grant privilege (only valid if on_future is false).
 - **with_grant_option** (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.
 

--- a/pkg/resources/stage_grant.go
+++ b/pkg/resources/stage_grant.go
@@ -49,20 +49,13 @@ var stageGrantSchema = map[string]*schema.Schema{
 		Description: "Grants privilege to these roles.",
 		ForceNew:    true,
 	},
-	"shares": {
-		Type:        schema.TypeSet,
-		Elem:        &schema.Schema{Type: schema.TypeString},
-		Optional:    true,
-		Description: "Grants privilege to these shares (only valid if on_future is false).",
-		ForceNew:    true,
-	},
 	"on_future": {
 		Type:          schema.TypeBool,
 		Optional:      true,
-		Description:   "When this is set to true and a schema_name is provided, apply this grant on all future stages in the given schema. When this is true and no schema_name is provided apply this grant on all future stages in the given database. The stage_name and shares fields must be unset in order to use on_future.",
+		Description:   "When this is set to true and a schema_name is provided, apply this grant on all future stages in the given schema. When this is true and no schema_name is provided apply this grant on all future stages in the given database. The stage_name field must be unset in order to use on_future.",
 		Default:       false,
 		ForceNew:      true,
-		ConflictsWith: []string{"stage_name", "shares"},
+		ConflictsWith: []string{"stage_name"},
 	},
 	"with_grant_option": {
 		Type:        schema.TypeBool,


### PR DESCRIPTION
Stages cannot be shared outside the account. So remove this feature.

## References
* https://docs.snowflake.com/en/user-guide/data-sharing-intro.html