### PR TITLE
fix: Allow legacy version of GrantIDs to be used with new grant functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHA=$(shell git rev-parse --short HEAD)
-VERSION=$(shell cat VERSION)
+VERSION=0.28.5
 export DIRTY=$(shell if `git diff-index --quiet HEAD --`; then echo false; else echo true;  fi)
 LDFLAGS=-ldflags "-w -s -X github.com/chanzuckerberg/go-misc/ver.GitSha=${SHA} -X github.com/chanzuckerberg/go-misc/ver.Version=${VERSION} -X github.com/chanzuckerberg/go-misc/ver.Dirty=${DIRTY}"
 export BASE_BINARY_NAME=terraform-provider-snowflake_v$(VERSION)
@@ -71,8 +71,8 @@ install: ## install the terraform-provider-snowflake binary in $GOPATH/bin
 .PHONY: install
 
 install-tf: build ## installs plugin where terraform can find it
-	mkdir -p $(HOME)/.terraform.d/plugins
-	cp ./$(BASE_BINARY_NAME) $(HOME)/.terraform.d/plugins/$(BASE_BINARY_NAME)
+	mkdir -p /usr/local/lib/terraform/registry.terraform.io/chanzuckerberg/snowflake/$(VERSION)/darwin_amd64
+	cp ./$(BASE_BINARY_NAME) /usr/local/lib/terraform/registry.terraform.io/chanzuckerberg/snowflake/$(VERSION)/darwin_amd64/
 .PHONY: install-tf
 
 uninstall-tf: build ## uninstalls plugin from where terraform can find it

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHA=$(shell git rev-parse --short HEAD)
-VERSION=0.28.5
+VERSION=$(shell cat VERSION)
 export DIRTY=$(shell if `git diff-index --quiet HEAD --`; then echo false; else echo true;  fi)
 LDFLAGS=-ldflags "-w -s -X github.com/chanzuckerberg/go-misc/ver.GitSha=${SHA} -X github.com/chanzuckerberg/go-misc/ver.Version=${VERSION} -X github.com/chanzuckerberg/go-misc/ver.Dirty=${DIRTY}"
 export BASE_BINARY_NAME=terraform-provider-snowflake_v$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ install: ## install the terraform-provider-snowflake binary in $GOPATH/bin
 .PHONY: install
 
 install-tf: build ## installs plugin where terraform can find it
-	mkdir -p /usr/local/lib/terraform/registry.terraform.io/chanzuckerberg/snowflake/$(VERSION)/darwin_amd64
-	cp ./$(BASE_BINARY_NAME) /usr/local/lib/terraform/registry.terraform.io/chanzuckerberg/snowflake/$(VERSION)/darwin_amd64/
+	mkdir -p $(HOME)/.terraform.d/plugins
+	cp ./$(BASE_BINARY_NAME) $(HOME)/.terraform.d/plugins/$(BASE_BINARY_NAME)
 .PHONY: install-tf
 
 uninstall-tf: build ## uninstalls plugin from where terraform can find it

--- a/pkg/resources/grant_helpers_internal_test.go
+++ b/pkg/resources/grant_helpers_internal_test.go
@@ -44,17 +44,17 @@ func TestGrantIDFromString(t *testing.T) {
 	// Bad ID -- not enough fields
 	id = "database|name-privilege"
 	_, err = grantIDFromString(id)
-	r.Equal(fmt.Errorf("5 or 6 fields allowed"), err)
+	r.Equal(fmt.Errorf("4 to 6 fields allowed in ID"), err)
 
 	// Bad ID -- privilege in wrong area
 	id = "database||name-privilege"
 	_, err = grantIDFromString(id)
-	r.Equal(fmt.Errorf("5 or 6 fields allowed"), err)
+	r.Equal(fmt.Errorf("4 to 6 fields allowed in ID"), err)
 
 	// too many fields
 	id = "database_name|schema|view_name|privilege|false|2|too-many"
 	_, err = grantIDFromString(id)
-	r.Equal(fmt.Errorf("5 or 6 fields allowed"), err)
+	r.Equal(fmt.Errorf("4 to 6 fields allowed in ID"), err)
 
 	// 0 lines
 	id = ""
@@ -108,4 +108,39 @@ func TestGrantStruct(t *testing.T) {
 	r.Equal("priv", newGrant.Privilege)
 	r.Equal([]string{"test3", "test4"}, newGrant.Roles)
 	r.Equal(false, newGrant.GrantOption)
+}
+
+func TestGrantLegacyID(t *testing.T) {
+	// Testing that grants with legacy ID structure resolves to expected output
+	r := require.New(t)
+	gID := "database_name|schema|view_name|priv|true"
+	grant, err := grantIDFromString(gID)
+	r.NoError(err)
+	r.Equal("database_name", grant.ResourceName)
+	r.Equal("schema", grant.SchemaName)
+	r.Equal("view_name", grant.ObjectName)
+	r.Equal("priv", grant.Privilege)
+	r.Equal([]string{}, grant.Roles)
+	r.Equal(true, grant.GrantOption)
+
+	gID = "database_name|schema|view_name|priv|false"
+	grant, err = grantIDFromString(gID)
+	r.NoError(err)
+	r.Equal("database_name", grant.ResourceName)
+	r.Equal("schema", grant.SchemaName)
+	r.Equal("view_name", grant.ObjectName)
+	r.Equal("priv", grant.Privilege)
+	r.Equal([]string{}, grant.Roles)
+	r.Equal(false, grant.GrantOption)
+
+	gID = "database_name|schema|view_name|priv"
+	grant, err = grantIDFromString(gID)
+	r.NoError(err)
+	r.Equal("database_name", grant.ResourceName)
+	r.Equal("schema", grant.SchemaName)
+	r.Equal("view_name", grant.ObjectName)
+	r.Equal("priv", grant.Privilege)
+	r.Equal([]string{}, grant.Roles)
+	r.Equal(false, grant.GrantOption)
+
 }


### PR DESCRIPTION
Allowing for legacy length/structure of GrantIDs to be used with the new multiple grants functionality. Role names in GrantIDs are not used for anything but uniqueness of the IDs. 

IDs will be created with the new structure whenever resources are dropped and recreated, and it will be invisible to the end user.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
* [x] unit tests

## References
* https://github.com/chanzuckerberg/terraform-provider-snowflake/pull/824