### PR TITLE
feat: Add AWS privatelink connectivity support

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"io"
-	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/datasources"
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/db"

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -45,6 +45,10 @@ func TestDSN(t *testing.T) {
 			"user:pass@acct.region.snowflakecomputing.com:443?ocspFailOpen=true&region=region&role=role&validateDefaultParameters=true", false},
 		{"us-west-2 special case", args{"acct2", "user2", "pass2", false, "us-west-2", "role2"},
 			"user2:pass2@acct2.snowflakecomputing.com:443?ocspFailOpen=true&role=role2&validateDefaultParameters=true", false},
+		{"regionless privatelink", args{"orgname-accountname.privatelink", "user3", "pass3", false, "", "role3"},
+			"user3:pass3@orgname-accountname.privatelink.snowflakecomputing.com:443?account=orgname-accountname&ocspFailOpen=true&role=role3&validateDefaultParameters=true", false},
+		{"regioned privatelink", args{"accountname.us-east-1.privatelink", "user3", "pass3", false, "us-east-1", "role3"},
+			"user3:pass3@accountname.us-east-1.privatelink.snowflakecomputing.com:443?account=accountname&ocspFailOpen=true&role=role3&validateDefaultParameters=true", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- summary of changes -->

This change-set adds support for host resolution for accounts that use AWS Privatelink.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
* [x] unit tests
<!-- add more below if you think they are relevant -->


## References
<!-- issues documentation links, etc  -->
* https://docs.snowflake.com/en/user-guide/admin-security-privatelink.html