### PR TITLE
fix: Fixed Any Role Values External OAUTH Integration

### DIFF
--- a/pkg/resources/external_oauth_integration.go
+++ b/pkg/resources/external_oauth_integration.go
@@ -104,7 +104,7 @@ var oauthExternalIntegrationSchema = map[string]*schema.Schema{
 		Default:     "DISABLE",
 		Description: "Specifies whether the OAuth client or user can use a role that is not defined in the OAuth access token.",
 		ValidateFunc: validation.StringInSlice([]string{
-			"DISABLE ", "ENABLE ", "ENABLE_FOR_PRIVILEGE",
+			"DISABLE", "ENABLE", "ENABLE_FOR_PRIVILEGE",
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {


### PR DESCRIPTION
Fixed Any Role Values External OAUTH Integration. There were spaces in the allowed values
## Test Plan
* [x] acceptance tests
* [x] tests

## References
See #879 
* 