### PR TITLE
docs: Update host provider docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,25 +45,25 @@ provider "snowflake" {
 
 ### Required
 
-- **account** (String)
-- **username** (String)
+- **account** (String) The name of the Snowflake account. Can also come from the `SNOWFLAKE_ACCOUNT` environment variable.
+- **username** (String) Username for username+password authentication. Can come from the `SNOWFLAKE_USER` environment variable.
 
 ### Optional
 
-- **browser_auth** (Boolean)
-- **host** (String) Supports passing in a custom host value to the snowflake go driver for use with privatelink
-- **oauth_access_token** (String, Sensitive)
-- **oauth_client_id** (String, Sensitive)
-- **oauth_client_secret** (String, Sensitive)
-- **oauth_endpoint** (String, Sensitive)
-- **oauth_redirect_url** (String, Sensitive)
-- **oauth_refresh_token** (String, Sensitive)
-- **password** (String, Sensitive)
-- **private_key** (String, Sensitive)
+- **browser_auth** (Boolean) Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_USE_BROWSER_AUTH` environment variable.
+- **host** (String) Supports passing in a custom host value to the snowflake go driver for use with privatelink.
+- **oauth_access_token** (String, Sensitive) Token for use with OAuth. Generating the token is left to other tools. Cannot be used with `browser_auth`, `private_key_path`, `oauth_refresh_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_ACCESS_TOKEN` environment variable.
+- **oauth_client_id** (String, Sensitive) Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_CLIENT_ID` environment variable.
+- **oauth_client_secret** (String, Sensitive) Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_CLIENT_SECRET` environment variable.
+- **oauth_endpoint** (String, Sensitive) Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_ENDPOINT` environment variable.
+- **oauth_redirect_url** (String, Sensitive) Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_REDIRECT_URL` environment variable.
+- **oauth_refresh_token** (String, Sensitive) Token for use with OAuth. Setup and generation of the token is left to other tools. Should be used in conjunction with `oauth_client_id`, `oauth_client_secret`, `oauth_endpoint`, `oauth_redirect_url`. Cannot be used with `browser_auth`, `private_key_path`, `oauth_access_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_REFRESH_TOKEN` environment variable.
+- **password** (String, Sensitive) Password for username+password auth. Cannot be used with `browser_auth` or `private_key_path`. Can be source from `SNOWFLAKE_PASSWORD` environment variable.
+- **private_key** (String, Sensitive) Private Key for username+private-key auth. Cannot be used with `browser_auth` or `password`. Can be source from `SNOWFLAKE_PRIVATE_KEY` environment variable.
 - **private_key_passphrase** (String, Sensitive) Supports the encryption ciphers aes-128-cbc, aes-128-gcm, aes-192-cbc, aes-192-gcm, aes-256-cbc, aes-256-gcm, and des-ede3-cbc
-- **private_key_path** (String, Sensitive)
-- **region** (String)
-- **role** (String)
+- **private_key_path** (String, Sensitive) Path to a private key for using keypair authentication. Cannot be used with `browser_auth`, `oauth_access_token` or `password`. Can be source from `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.
+- **region** (String) [Snowflake region](https://docs.snowflake.com/en/user-guide/intro-regions.html) to use. Can be source from the `SNOWFLAKE_REGION` environment variable.
+- **role** (String) Snowflake role to use for operations. If left unset, default role for user will be used. Can come from the `SNOWFLAKE_ROLE` environment variable.
 
 ## Authentication
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ provider "snowflake" {
 
   // optional
   role = "..."
+  host = "..."
 }
 ```
 
@@ -150,38 +151,3 @@ If you choose to use Username and Password Authentication, export these credenti
 export SNOWFLAKE_USER='...'
 export SNOWFLAKE_PASSWORD='...'
 ```
-
-## Argument Reference
-
-In addition to [generic `provider` arguments](https://www.terraform.io/docs/configuration/providers.html)
-(e.g. `alias` and `version`), the following arguments are supported in the Snowflake
- `provider` block:
-
-* `account` - (required) The name of the Snowflake account. Can also come from the
-  `SNOWFLAKE_ACCOUNT` environment variable.
-* `username` - (required) Username for username+password authentication. Can come from the
-  `SNOWFLAKE_USER` environment variable.
-* `region` - (required) [Snowflake region](https://docs.snowflake.com/en/user-guide/intro-regions.html) to use. Can be source from the `SNOWFLAKE_REGION` environment variable.
-* `password` - (optional) Password for username+password auth. Cannot be used with `browser_auth` or
-  `private_key_path`. Can be source from `SNOWFLAKE_PASSWORD` environment variable.
-* `oauth_access_token` - (optional) Token for use with OAuth. Generating the token is left to other
-  tools. Cannot be used with `browser_auth`, `private_key_path`, `oauth_refresh_token` or `password`.
-  Can be sourced from `SNOWFLAKE_OAUTH_ACCESS_TOKEN` environment variable.
-* `oauth_refresh_token` - (optional) Token for use with OAuth. Setup and generation of the token is
-  left to other tools. Should be used in conjunction with `oauth_client_id`, `oauth_client_secret`,
-  `oauth_endpoint`, `oauth_redirect_url`. Cannot be used with `browser_auth`, `private_key_path`,
-  `oauth_access_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_REFRESH_TOKEN` environment
-  variable.
-* `oauth_client_id` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from
-  `SNOWFLAKE_OAUTH_CLIENT_ID` environment variable.
-* `oauth_client_secret` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from
-  `SNOWFLAKE_OAUTH_CLIENT_SECRET` environment variable.
-* `oauth_endpoint` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from
-  `SNOWFLAKE_OAUTH_ENDPOINT` environment variable.
-* `oauth_redirect_url` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from
-  `SNOWFLAKE_OAUTH_REDIRECT_URL` environment variable.
-* `private_key_path` - (optional) Path to a private key for using keypair authentication.. Cannot be
-  used with `browser_auth`, `oauth_access_token` or `password`. Can be source from
-  `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.
-* `role` - (optional) Snowflake role to use for operations. If left unset, default role for user
-  will be used. Can come from the `SNOWFLAKE_ROLE` environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -18,4 +18,5 @@ provider "snowflake" {
 
   // optional
   role = "..."
+  host = "..."
 }

--- a/pkg/datasources/procedures_acceptance_test.go
+++ b/pkg/datasources/procedures_acceptance_test.go
@@ -23,7 +23,7 @@ func TestAccProcedures(t *testing.T) {
 					resource.TestCheckResourceAttr("data.snowflake_procedures.t", "database", databaseName),
 					resource.TestCheckResourceAttr("data.snowflake_procedures.t", "schema", schemaName),
 					resource.TestCheckResourceAttrSet("data.snowflake_procedures.t", "procedures.#"),
-					resource.TestCheckResourceAttr("data.snowflake_procedures.t", "procedures.#", "3"),
+					resource.TestCheckResourceAttr("data.snowflake_procedures.t", "procedures.#", "2"),
 				),
 			},
 		},

--- a/pkg/datasources/procedures_acceptance_test.go
+++ b/pkg/datasources/procedures_acceptance_test.go
@@ -23,7 +23,7 @@ func TestAccProcedures(t *testing.T) {
 					resource.TestCheckResourceAttr("data.snowflake_procedures.t", "database", databaseName),
 					resource.TestCheckResourceAttr("data.snowflake_procedures.t", "schema", schemaName),
 					resource.TestCheckResourceAttrSet("data.snowflake_procedures.t", "procedures.#"),
-					resource.TestCheckResourceAttr("data.snowflake_procedures.t", "procedures.#", "2"),
+					resource.TestCheckResourceAttr("data.snowflake_procedures.t", "procedures.#", "3"),
 				),
 			},
 		},

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -30,16 +30,19 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"account": {
 				Type:        schema.TypeString,
+				Description: "The name of the Snowflake account. Can also come from the `SNOWFLAKE_ACCOUNT` environment variable.",
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SNOWFLAKE_ACCOUNT", nil),
 			},
 			"username": {
 				Type:        schema.TypeString,
+				Description: "Username for username+password authentication. Can come from the `SNOWFLAKE_USER` environment variable.",
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SNOWFLAKE_USER", nil),
 			},
 			"password": {
 				Type:          schema.TypeString,
+				Description:   "Password for username+password auth. Cannot be used with `browser_auth` or `private_key_path`. Can be source from `SNOWFLAKE_PASSWORD` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_PASSWORD", nil),
 				Sensitive:     true,
@@ -47,6 +50,7 @@ func Provider() *schema.Provider {
 			},
 			"oauth_access_token": {
 				Type:          schema.TypeString,
+				Description:   "Token for use with OAuth. Generating the token is left to other tools. Cannot be used with `browser_auth`, `private_key_path`, `oauth_refresh_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_ACCESS_TOKEN` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_ACCESS_TOKEN", nil),
 				Sensitive:     true,
@@ -54,6 +58,7 @@ func Provider() *schema.Provider {
 			},
 			"oauth_refresh_token": {
 				Type:          schema.TypeString,
+				Description:   "Token for use with OAuth. Setup and generation of the token is left to other tools. Should be used in conjunction with `oauth_client_id`, `oauth_client_secret`, `oauth_endpoint`, `oauth_redirect_url`. Cannot be used with `browser_auth`, `private_key_path`, `oauth_access_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_REFRESH_TOKEN` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_REFRESH_TOKEN", nil),
 				Sensitive:     true,
@@ -62,6 +67,7 @@ func Provider() *schema.Provider {
 			},
 			"oauth_client_id": {
 				Type:          schema.TypeString,
+				Description:   "Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_CLIENT_ID` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_CLIENT_ID", nil),
 				Sensitive:     true,
@@ -70,6 +76,7 @@ func Provider() *schema.Provider {
 			},
 			"oauth_client_secret": {
 				Type:          schema.TypeString,
+				Description:   "Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_CLIENT_SECRET` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_CLIENT_SECRET", nil),
 				Sensitive:     true,
@@ -78,6 +85,7 @@ func Provider() *schema.Provider {
 			},
 			"oauth_endpoint": {
 				Type:          schema.TypeString,
+				Description:   "Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_ENDPOINT` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_ENDPOINT", nil),
 				Sensitive:     true,
@@ -86,6 +94,7 @@ func Provider() *schema.Provider {
 			},
 			"oauth_redirect_url": {
 				Type:          schema.TypeString,
+				Description:   "Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_REDIRECT_URL` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_OAUTH_REDIRECT_URL", nil),
 				Sensitive:     true,
@@ -94,6 +103,7 @@ func Provider() *schema.Provider {
 			},
 			"browser_auth": {
 				Type:          schema.TypeBool,
+				Description:   "Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_USE_BROWSER_AUTH` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_USE_BROWSER_AUTH", nil),
 				Sensitive:     false,
@@ -101,6 +111,7 @@ func Provider() *schema.Provider {
 			},
 			"private_key_path": {
 				Type:          schema.TypeString,
+				Description:   "Path to a private key for using keypair authentication. Cannot be used with `browser_auth`, `oauth_access_token` or `password`. Can be source from `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_PRIVATE_KEY_PATH", nil),
 				Sensitive:     true,
@@ -108,6 +119,7 @@ func Provider() *schema.Provider {
 			},
 			"private_key": {
 				Type:          schema.TypeString,
+				Description:   "Private Key for username+private-key auth. Cannot be used with `browser_auth` or `password`. Can be source from `SNOWFLAKE_PRIVATE_KEY` environment variable.",
 				Optional:      true,
 				DefaultFunc:   schema.EnvDefaultFunc("SNOWFLAKE_PRIVATE_KEY", nil),
 				Sensitive:     true,
@@ -123,17 +135,19 @@ func Provider() *schema.Provider {
 			},
 			"role": {
 				Type:        schema.TypeString,
+				Description: "Snowflake role to use for operations. If left unset, default role for user will be used. Can come from the `SNOWFLAKE_ROLE` environment variable.",
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SNOWFLAKE_ROLE", nil),
 			},
 			"region": {
 				Type:        schema.TypeString,
+				Description: "[Snowflake region](https://docs.snowflake.com/en/user-guide/intro-regions.html) to use. Can be source from the `SNOWFLAKE_REGION` environment variable.",
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SNOWFLAKE_REGION", "us-west-2"),
 			},
 			"host": {
 				Type:        schema.TypeString,
-				Description: "Supports passing in a custom host value to the snowflake go driver for use with privatelink",
+				Description: "Supports passing in a custom host value to the snowflake go driver for use with privatelink.",
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SNOWFLAKE_HOST", nil),
 			},

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -105,38 +105,3 @@ If you choose to use Username and Password Authentication, export these credenti
 export SNOWFLAKE_USER='...'
 export SNOWFLAKE_PASSWORD='...'
 ```
-
-## Argument Reference
-
-In addition to [generic `provider` arguments](https://www.terraform.io/docs/configuration/providers.html)
-(e.g. `alias` and `version`), the following arguments are supported in the Snowflake
- `provider` block:
-
-* `account` - (required) The name of the Snowflake account. Can also come from the
-  `SNOWFLAKE_ACCOUNT` environment variable.
-* `username` - (required) Username for username+password authentication. Can come from the
-  `SNOWFLAKE_USER` environment variable.
-* `region` - (required) [Snowflake region](https://docs.snowflake.com/en/user-guide/intro-regions.html) to use. Can be source from the `SNOWFLAKE_REGION` environment variable.
-* `password` - (optional) Password for username+password auth. Cannot be used with `browser_auth` or
-  `private_key_path`. Can be source from `SNOWFLAKE_PASSWORD` environment variable.
-* `oauth_access_token` - (optional) Token for use with OAuth. Generating the token is left to other
-  tools. Cannot be used with `browser_auth`, `private_key_path`, `oauth_refresh_token` or `password`.
-  Can be sourced from `SNOWFLAKE_OAUTH_ACCESS_TOKEN` environment variable.
-* `oauth_refresh_token` - (optional) Token for use with OAuth. Setup and generation of the token is
-  left to other tools. Should be used in conjunction with `oauth_client_id`, `oauth_client_secret`,
-  `oauth_endpoint`, `oauth_redirect_url`. Cannot be used with `browser_auth`, `private_key_path`,
-  `oauth_access_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_REFRESH_TOKEN` environment
-  variable.
-* `oauth_client_id` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from
-  `SNOWFLAKE_OAUTH_CLIENT_ID` environment variable.
-* `oauth_client_secret` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from
-  `SNOWFLAKE_OAUTH_CLIENT_SECRET` environment variable.
-* `oauth_endpoint` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from
-  `SNOWFLAKE_OAUTH_ENDPOINT` environment variable.
-* `oauth_redirect_url` - (optional) Required when `oauth_refresh_token` is used. Can be sourced from
-  `SNOWFLAKE_OAUTH_REDIRECT_URL` environment variable.
-* `private_key_path` - (optional) Path to a private key for using keypair authentication.. Cannot be
-  used with `browser_auth`, `oauth_access_token` or `password`. Can be source from
-  `SNOWFLAKE_PRIVATE_KEY_PATH` environment variable.
-* `role` - (optional) Snowflake role to use for operations. If left unset, default role for user
-  will be used. Can come from the `SNOWFLAKE_ROLE` environment variable.


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

Added missing `host` provider documentation. But then realized that the provider.go schema was missing descriptions that `terraform-plugin-docs` is capable of auto generating for us. So I went ahead and fixed that too.

## References
<!-- issues documentation links, etc  -->

* #959 