### PR TITLE
feat: allow in-place renaming of Snowflake schemas

### DIFF
--- a/pkg/snowflake/schema.go
+++ b/pkg/snowflake/schema.go
@@ -133,13 +133,17 @@ func (sb *SchemaBuilder) Create() string {
 
 // Rename returns the SQL query that will rename the schema.
 func (sb *SchemaBuilder) Rename(newName string) string {
-	return fmt.Sprintf(`ALTER SCHEMA %v RENAME TO "%v"`, sb.QualifiedName(), newName)
+	oldName := sb.QualifiedName()
+	sb.name = newName
+	return fmt.Sprintf(`ALTER SCHEMA %v RENAME TO %v`, oldName, sb.QualifiedName())
 }
 
 // Swap returns the SQL query that Swaps all objects (tables, views, etc.) and
 // metadata, including identifiers, between the two specified schemas.
 func (sb *SchemaBuilder) Swap(targetSchema string) string {
-	return fmt.Sprintf(`ALTER SCHEMA %v SWAP WITH "%v"`, sb.QualifiedName(), targetSchema)
+	sourceSchema := sb.QualifiedName()
+	sb.name = targetSchema
+	return fmt.Sprintf(`ALTER SCHEMA %v SWAP WITH %v`, sourceSchema, sb.QualifiedName())
 }
 
 // ChangeComment returns the SQL query that will update the comment on the schema.


### PR DESCRIPTION
Similar to PR https://github.com/chanzuckerberg/terraform-provider-snowflake/pull/904, allow changing the name of Snowflake schemas without destroying then recreating the schema.

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests

<details>
<summary>Acceptance tests logs</summary>

```
❯ make test-acceptance
goimports -w -d $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./dist/*")
go mod tidy -compat=1.17
SKIP_MANAGED_ACCOUNT_TEST=1 TF_ACC=1 go test -v -coverprofile=coverage.txt -covermode=atomic  ./...
?   	github.com/chanzuckerberg/terraform-provider-snowflake	[no test files]
=== RUN   TestAccCurrentAccount
=== PAUSE TestAccCurrentAccount
=== RUN   TestDatabase
=== PAUSE TestDatabase
=== RUN   TestDatabases
=== PAUSE TestDatabases
=== RUN   TestAccExternalFunctions
=== PAUSE TestAccExternalFunctions
=== RUN   TestAccExternalTables
    external_tables_acceptance_test.go:15: Skipping TestAccExternalTable
--- SKIP: TestAccExternalTables (0.00s)
=== RUN   TestAccFileFormats
=== PAUSE TestAccFileFormats
=== RUN   TestAccFunctions
=== PAUSE TestAccFunctions
=== RUN   TestAccMaskingPolicies
=== PAUSE TestAccMaskingPolicies
=== RUN   TestAccMaterializedViews
=== PAUSE TestAccMaterializedViews
=== RUN   TestAccPipes
=== PAUSE TestAccPipes
=== RUN   TestAccProcedures
=== PAUSE TestAccProcedures
=== RUN   TestAccResourceMonitors
=== PAUSE TestAccResourceMonitors
=== RUN   TestAccRowAccessPolicies
=== PAUSE TestAccRowAccessPolicies
=== RUN   TestAccSchemas
=== PAUSE TestAccSchemas
=== RUN   TestAccSequences
=== PAUSE TestAccSequences
=== RUN   TestAccStages
=== PAUSE TestAccStages
=== RUN   TestAccStorageIntegrations
=== PAUSE TestAccStorageIntegrations
=== RUN   TestAccStreams
=== PAUSE TestAccStreams
=== RUN   TestAcc_SystemGenerateSCIMAccessToken
    system_generate_scim_access_token_acceptance_test.go:15: Skipping TestAccScimIntegration
--- SKIP: TestAcc_SystemGenerateSCIMAccessToken (0.00s)
=== RUN   TestAccSystemGetAWSSNSIAMPolicy_basic
=== PAUSE TestAccSystemGetAWSSNSIAMPolicy_basic
=== RUN   TestAccSystemGetPrivateLinkConfig_aws
=== PAUSE TestAccSystemGetPrivateLinkConfig_aws
=== RUN   TestAccSystemGetSnowflakePlatformInfo
=== PAUSE TestAccSystemGetSnowflakePlatformInfo
=== RUN   TestAccTables
=== PAUSE TestAccTables
=== RUN   TestAccTasks
=== PAUSE TestAccTasks
=== RUN   TestAccViews
=== PAUSE TestAccViews
=== RUN   TestAccWarehouses
=== PAUSE TestAccWarehouses
=== CONT  TestAccCurrentAccount
=== CONT  TestAccSchemas
=== CONT  TestAccSystemGetPrivateLinkConfig_aws
=== CONT  TestAccTasks
=== CONT  TestAccStorageIntegrations
=== CONT  TestAccSystemGetAWSSNSIAMPolicy_basic
=== CONT  TestAccMaskingPolicies
=== CONT  TestAccTables
=== CONT  TestAccSystemGetSnowflakePlatformInfo
=== CONT  TestAccWarehouses
=== CONT  TestAccRowAccessPolicies
=== CONT  TestAccStreams
=== CONT  TestAccProcedures
=== CONT  TestAccResourceMonitors
=== CONT  TestAccMaterializedViews
=== CONT  TestAccExternalFunctions
--- PASS: TestAccMaskingPolicies (40.58s)
=== CONT  TestAccFunctions
--- PASS: TestAccSchemas (40.82s)
=== CONT  TestAccFileFormats
--- PASS: TestAccResourceMonitors (50.85s)
=== CONT  TestDatabases
--- PASS: TestAccRowAccessPolicies (53.59s)
=== CONT  TestAccStages
[DEBUG] extracting materialized view query: CREATE SECURE MATERIALIZED VIEW "HKLKTMNOGP"."CFNNMSJHBC"."AAXMRHIOJF" comment = 'Terraform test resource' AS SELECT * FROM QWGGHNSWRK
[DEBUG] extracting materialized view query: CREATE SECURE MATERIALIZED VIEW "HKLKTMNOGP"."CFNNMSJHBC"."AAXMRHIOJF" comment = 'Terraform test resource' AS SELECT * FROM QWGGHNSWRK
--- PASS: TestAccMaterializedViews (59.19s)
=== CONT  TestDatabase
--- PASS: TestAccFileFormats (21.37s)
=== CONT  TestAccViews
--- PASS: TestAccStages (16.19s)
=== CONT  TestAccSequences
--- PASS: TestAccCurrentAccount (70.52s)
=== CONT  TestAccPipes
--- PASS: TestAccWarehouses (70.73s)
--- PASS: TestAccStreams (71.86s)
--- PASS: TestAccStorageIntegrations (74.12s)
[DEBUG] extracting view query CREATE VIEW "UMMQVRUXOB"."ZJYYEWCJIH"."ZIARIHIQEU" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES where ROLE_OWNER like 'foo%'
[DEBUG] extracting view query CREATE VIEW "UMMQVRUXOB"."ZJYYEWCJIH"."ZIARIHIQEU" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES where ROLE_OWNER like 'foo%'
--- PASS: TestAccSystemGetAWSSNSIAMPolicy_basic (79.26s)
--- PASS: TestAccSystemGetSnowflakePlatformInfo (79.52s)
--- PASS: TestAccViews (17.37s)
--- PASS: TestAccProcedures (81.53s)
--- PASS: TestAccSystemGetPrivateLinkConfig_aws (84.06s)
--- PASS: TestAccTables (85.16s)
--- PASS: TestAccSequences (19.25s)
--- PASS: TestAccTasks (91.06s)
--- PASS: TestAccExternalFunctions (92.82s)
--- PASS: TestAccFunctions (52.25s)
--- PASS: TestAccPipes (22.39s)
--- PASS: TestDatabase (36.08s)
--- PASS: TestDatabases (48.86s)
PASS
coverage: 69.2% of statements
ok  	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/datasources	100.192s	coverage: 69.2% of statements
?   	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/db	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestDSN
=== RUN   TestDSN/simple
=== RUN   TestDSN/us-west-2_special_case
=== RUN   TestDSN/customhostwregion
=== RUN   TestDSN/customhostignoreregion
--- PASS: TestDSN (0.00s)
    --- PASS: TestDSN/simple (0.00s)
    --- PASS: TestDSN/us-west-2_special_case (0.00s)
    --- PASS: TestDSN/customhostwregion (0.00s)
    --- PASS: TestDSN/customhostignoreregion (0.00s)
=== RUN   TestOAuthDSN
=== RUN   TestOAuthDSN/simple_oauth
=== RUN   TestOAuthDSN/oauth_over_password
=== RUN   TestOAuthDSN/empty_token_no_password_errors_out
--- PASS: TestOAuthDSN (0.00s)
    --- PASS: TestOAuthDSN/simple_oauth (0.00s)
    --- PASS: TestOAuthDSN/oauth_over_password (0.00s)
    --- PASS: TestOAuthDSN/empty_token_no_password_errors_out (0.00s)
=== RUN   TestGetOauthDATA
=== RUN   TestGetOauthDATA/simpleData
=== RUN   TestGetOauthDATA/errorData
--- PASS: TestGetOauthDATA (0.00s)
    --- PASS: TestGetOauthDATA/simpleData (0.00s)
    --- PASS: TestGetOauthDATA/errorData (0.00s)
=== RUN   TestGetOauthResponse
=== RUN   TestGetOauthResponse/simpleContent
--- PASS: TestGetOauthResponse (0.00s)
    --- PASS: TestGetOauthResponse/simpleContent (0.00s)
=== RUN   TestGetOauthAccessToken
=== RUN   TestGetOauthAccessToken/simpleAccessToken
=== RUN   TestGetOauthAccessToken/errorAccessToken
--- PASS: TestGetOauthAccessToken (0.00s)
    --- PASS: TestGetOauthAccessToken/simpleAccessToken (0.00s)
    --- PASS: TestGetOauthAccessToken/errorAccessToken (0.00s)
PASS
coverage: 30.4% of statements
ok  	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/provider	0.260s	coverage: 30.4% of statements
=== RUN   TestGrantIDFromString
--- PASS: TestGrantIDFromString (0.00s)
=== RUN   TestGrantStruct
--- PASS: TestGrantStruct (0.00s)
=== RUN   TestGrantLegacyID
--- PASS: TestGrantLegacyID (0.00s)
=== RUN   TestGrantIDFromStringRoleGrant
--- PASS: TestGrantIDFromStringRoleGrant (0.00s)
=== RUN   TestExpandStringList
--- PASS: TestExpandStringList (0.00s)
=== RUN   TestExpandBlankStringList
--- PASS: TestExpandBlankStringList (0.00s)
=== RUN   TestPipeIDFromString
--- PASS: TestPipeIDFromString (0.00s)
=== RUN   TestPipeStruct
--- PASS: TestPipeStruct (0.00s)
=== RUN   TestPipeCopyStatementDiffSuppress
=== RUN   TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressMultiLineWindows
=== RUN   TestPipeCopyStatementDiffSuppress/TestDiffSuppressSingleLine
=== RUN   TestPipeCopyStatementDiffSuppress/TestDiffSuppressMultiLineUnix
=== RUN   TestPipeCopyStatementDiffSuppress/TestDiffSuppressMultiLineWindows
=== RUN   TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressSingleLine
=== RUN   TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressMultiLineUnix
=== RUN   TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressMultiLineWindowsWithEndStatement
=== RUN   TestPipeCopyStatementDiffSuppress/TestDiffSuppressSingleLineWithEndStatement
=== RUN   TestPipeCopyStatementDiffSuppress/TestDiffSuppressMultiLineUnixWithEndStatement
=== RUN   TestPipeCopyStatementDiffSuppress/TestDiffSuppressMultiLineWindowsWithEndStatement
=== RUN   TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressSingleLineWithEndStatement
=== RUN   TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressMultiLineUnixWithEndStatement
--- PASS: TestPipeCopyStatementDiffSuppress (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressMultiLineWindows (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestDiffSuppressSingleLine (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestDiffSuppressMultiLineUnix (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestDiffSuppressMultiLineWindows (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressSingleLine (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressMultiLineUnix (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressMultiLineWindowsWithEndStatement (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestDiffSuppressSingleLineWithEndStatement (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestDiffSuppressMultiLineUnixWithEndStatement (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestDiffSuppressMultiLineWindowsWithEndStatement (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressSingleLineWithEndStatement (0.00s)
    --- PASS: TestPipeCopyStatementDiffSuppress/TestNoDiffSuppressMultiLineUnixWithEndStatement (0.00s)
=== RUN   TestExtractTriggerInts
--- PASS: TestExtractTriggerInts (0.00s)
=== RUN   Test_grantToRole
2022/04/13 15:37:12 [DEBUG] exec stmt GRANT ROLE "foo" TO ROLE "bar"
--- PASS: Test_grantToRole (0.00s)
=== RUN   Test_grantToUser
2022/04/13 15:37:12 [DEBUG] exec stmt GRANT ROLE "foo" TO USER "bar"
--- PASS: Test_grantToUser (0.00s)
=== RUN   Test_readGrants
--- PASS: Test_readGrants (0.00s)
=== RUN   Test_revokeRoleFromRole
2022/04/13 15:37:12 [DEBUG] exec stmt REVOKE ROLE "foo" FROM ROLE "bar"
--- PASS: Test_revokeRoleFromRole (0.00s)
=== RUN   Test_revokeRoleFromUser
2022/04/13 15:37:12 [DEBUG] exec stmt REVOKE ROLE "foo" FROM USER "bar"
--- PASS: Test_revokeRoleFromUser (0.00s)
=== RUN   TestSchemaIDFromString
--- PASS: TestSchemaIDFromString (0.00s)
=== RUN   TestSchemaStruct
--- PASS: TestSchemaStruct (0.00s)
=== RUN   TestStreamIDFromString
--- PASS: TestStreamIDFromString (0.00s)
=== RUN   TestStreamStruct
--- PASS: TestStreamStruct (0.00s)
=== RUN   TestStreamOnTableIDFromString
--- PASS: TestStreamOnTableIDFromString (0.00s)
=== RUN   TestTableIDFromString
--- PASS: TestTableIDFromString (0.00s)
=== RUN   TestTableStruct
--- PASS: TestTableStruct (0.00s)
=== RUN   TestStringFromTaskID
--- PASS: TestStringFromTaskID (0.00s)
=== RUN   TestTaskIDFromString
--- PASS: TestTaskIDFromString (0.00s)
=== RUN   TestSplitViewID
--- PASS: TestSplitViewID (0.00s)
=== RUN   TestAccAccountGrant_defaults
=== PAUSE TestAccAccountGrant_defaults
=== RUN   TestAcc_AccountGrantManagedTask
=== PAUSE TestAcc_AccountGrantManagedTask
=== RUN   TestAcc_AccountGrantManageSupportCases
=== PAUSE TestAcc_AccountGrantManageSupportCases
=== RUN   TestAccountGrant
--- PASS: TestAccountGrant (0.00s)
=== RUN   TestAccountGrantCreate
2022/04/13 15:37:12 [DEBUG] exec stmt GRANT CREATE DATABASE ON ACCOUNT  TO ROLE "test-role-2" WITH GRANT OPTION
2022/04/13 15:37:12 [DEBUG] exec stmt GRANT CREATE DATABASE ON ACCOUNT  TO ROLE "test-role-1" WITH GRANT OPTION
2022/04/13 15:37:12 [DEBUG] query stmt SHOW GRANTS ON ACCOUNT
--- PASS: TestAccountGrantCreate (0.00s)
=== RUN   TestAccountGrantRead
2022/04/13 15:37:12 [DEBUG] query stmt SHOW GRANTS ON ACCOUNT
--- PASS: TestAccountGrantRead (0.00s)
=== RUN   TestMonitorExecution
2022/04/13 15:37:12 [DEBUG] query stmt SHOW GRANTS ON ACCOUNT
--- PASS: TestMonitorExecution (0.00s)
=== RUN   TestExecuteTask
2022/04/13 15:37:12 [DEBUG] query stmt SHOW GRANTS ON ACCOUNT
--- PASS: TestExecuteTask (0.00s)
=== RUN   TestApplyMaskingPolicy
2022/04/13 15:37:12 [DEBUG] query stmt SHOW GRANTS ON ACCOUNT
--- PASS: TestApplyMaskingPolicy (0.00s)
=== RUN   TestAcc_ApiIntegration
--- PASS: TestAcc_ApiIntegration (17.67s)
=== RUN   TestAPIIntegration
--- PASS: TestAPIIntegration (0.00s)
=== RUN   TestAPIIntegrationCreate
--- PASS: TestAPIIntegrationCreate (0.00s)
=== RUN   TestAPIIntegrationRead
--- PASS: TestAPIIntegrationRead (0.00s)
=== RUN   TestAPIIntegrationDelete
--- PASS: TestAPIIntegrationDelete (0.00s)
=== RUN   TestAcc_Database
=== PAUSE TestAcc_Database
=== RUN   TestAccDatabaseGrant_basic
=== PAUSE TestAccDatabaseGrant_basic
=== RUN   TestDatabaseGrant
--- PASS: TestDatabaseGrant (0.00s)
=== RUN   TestDatabaseGrantCreate
--- PASS: TestDatabaseGrantCreate (0.00s)
=== RUN   TestDatabaseGrantRead
--- PASS: TestDatabaseGrantRead (0.00s)
=== RUN   TestDatabase
--- PASS: TestDatabase (0.00s)
=== RUN   TestDatabaseCreate
--- PASS: TestDatabaseCreate (0.00s)
=== RUN   TestDatabaseRead
--- PASS: TestDatabaseRead (0.00s)
=== RUN   TestDatabaseDelete
--- PASS: TestDatabaseDelete (0.00s)
=== RUN   TestDatabaseCreateFromShare
--- PASS: TestDatabaseCreateFromShare (0.00s)
=== RUN   TestDatabaseCreateFromDatabase
--- PASS: TestDatabaseCreateFromDatabase (0.00s)
=== RUN   TestDatabaseCreateFromReplica
--- PASS: TestDatabaseCreateFromReplica (0.00s)
=== RUN   TestAcc_ExternalFunction
--- PASS: TestAcc_ExternalFunction (61.11s)
=== RUN   TestExternalFunction
--- PASS: TestExternalFunction (0.00s)
=== RUN   TestExternalFunctionCreate
--- PASS: TestExternalFunctionCreate (0.00s)
=== RUN   TestExternalFunctionRead
--- PASS: TestExternalFunctionRead (0.00s)
=== RUN   TestExternalFunctionReadReturnTypeVariant
--- PASS: TestExternalFunctionReadReturnTypeVariant (0.00s)
=== RUN   TestExternalFunctionDelete
--- PASS: TestExternalFunctionDelete (0.00s)
=== RUN   TestAcc_ExternalOauthIntegration
=== PAUSE TestAcc_ExternalOauthIntegration
=== RUN   TestExternalOauthIntegration
--- PASS: TestExternalOauthIntegration (0.00s)
=== RUN   TestExternalOauthIntegrationCreate
--- PASS: TestExternalOauthIntegrationCreate (0.00s)
=== RUN   TestExternalOauthIntegrationRead
--- PASS: TestExternalOauthIntegrationRead (0.00s)
=== RUN   TestExternalOauthIntegrationDelete
--- PASS: TestExternalOauthIntegrationDelete (0.00s)
=== RUN   TestAcc_ExternalStage
=== PAUSE TestAcc_ExternalStage
=== RUN   TestAccExternalTable
    external_table_acceptance_test.go:15: Skipping TestAccExternalTable
--- SKIP: TestAccExternalTable (0.00s)
=== RUN   TestAcc_ExternalTableFutureGrant
--- PASS: TestAcc_ExternalTableFutureGrant (18.32s)
=== RUN   TestExternalTableGrant
--- PASS: TestExternalTableGrant (0.00s)
=== RUN   TestExternalTableGrantCreate
--- PASS: TestExternalTableGrantCreate (0.00s)
=== RUN   TestExternalTableGrantRead
--- PASS: TestExternalTableGrantRead (0.00s)
=== RUN   TestFutureExternalTableGrantCreate
--- PASS: TestFutureExternalTableGrantCreate (0.00s)
=== RUN   TestExternalTable
--- PASS: TestExternalTable (0.00s)
=== RUN   TestExternalTableCreate
--- PASS: TestExternalTableCreate (0.00s)
=== RUN   TestExternalTableRead
--- PASS: TestExternalTableRead (0.00s)
=== RUN   TestExternalTableDelete
--- PASS: TestExternalTableDelete (0.00s)
=== RUN   TestAcc_FileFormatCSV
=== PAUSE TestAcc_FileFormatCSV
=== RUN   TestAcc_FileFormatJSON
=== PAUSE TestAcc_FileFormatJSON
=== RUN   TestAcc_FileFormatAvro
=== PAUSE TestAcc_FileFormatAvro
=== RUN   TestAcc_FileFormatORC
=== PAUSE TestAcc_FileFormatORC
=== RUN   TestAcc_FileFormatParquet
=== PAUSE TestAcc_FileFormatParquet
=== RUN   TestAcc_FileFormatXML
=== PAUSE TestAcc_FileFormatXML
=== RUN   TestAcc_FileFormatGrantFutureGrant
--- PASS: TestAcc_FileFormatGrantFutureGrant (9.82s)
=== RUN   TestFileFormatGrant
--- PASS: TestFileFormatGrant (0.00s)
=== RUN   TestFileFormatGrantCreate
--- PASS: TestFileFormatGrantCreate (0.00s)
=== RUN   TestFileFormatGrantRead
--- PASS: TestFileFormatGrantRead (0.00s)
=== RUN   TestFutureFileFormatGrantCreate
--- PASS: TestFutureFileFormatGrantCreate (0.00s)
=== RUN   TestFileFormat
--- PASS: TestFileFormat (0.00s)
=== RUN   TestFileFormatCreate
--- PASS: TestFileFormatCreate (0.00s)
=== RUN   TestFileFormatCreateInvalidOptions
--- PASS: TestFileFormatCreateInvalidOptions (0.00s)
=== RUN   TestAcc_Function
--- PASS: TestAcc_Function (12.48s)
=== RUN   TestAcc_FunctionFutureGrant
--- PASS: TestAcc_FunctionFutureGrant (8.15s)
=== RUN   TestFunctionGrant
--- PASS: TestFunctionGrant (0.00s)
=== RUN   TestFunctionGrantCreate
--- PASS: TestFunctionGrantCreate (0.00s)
=== RUN   TestFunctionGrantRead
--- PASS: TestFunctionGrantRead (0.00s)
=== RUN   TestFutureFunctionGrantCreate
--- PASS: TestFutureFunctionGrantCreate (0.00s)
=== RUN   TestFunction
--- PASS: TestFunction (0.00s)
=== RUN   TestFunctionCreate
--- PASS: TestFunctionCreate (0.00s)
=== RUN   TestFunctionRead
--- PASS: TestFunctionRead (0.00s)
=== RUN   TestFunctionDelete
--- PASS: TestFunctionDelete (0.00s)
=== RUN   TestIntegrationGrant
--- PASS: TestIntegrationGrant (0.00s)
=== RUN   TestIntegrationGrantCreate
--- PASS: TestIntegrationGrantCreate (0.00s)
=== RUN   TestIntegrationGrantRead
--- PASS: TestIntegrationGrantRead (0.00s)
=== RUN   TestAcc_InternalStage
=== PAUSE TestAcc_InternalStage
=== RUN   TestAcc_ManagedAccount
    managed_account_acceptance_test.go:19: Skipping TestAccManagedAccount
--- SKIP: TestAcc_ManagedAccount (0.00s)
=== RUN   TestManagedAccount
--- PASS: TestManagedAccount (0.00s)
=== RUN   TestManagedAccountCreate
--- PASS: TestManagedAccountCreate (10.00s)
=== RUN   TestManagedAccountRead
--- PASS: TestManagedAccountRead (0.00s)
=== RUN   TestAcc_MaskingPolicy
=== PAUSE TestAcc_MaskingPolicy
=== RUN   TestAcc_MaskingPolicyGrant
--- PASS: TestAcc_MaskingPolicyGrant (9.32s)
=== RUN   TestMaskingPolicyGrant
--- PASS: TestMaskingPolicyGrant (0.00s)
=== RUN   TestMaskingPolicyGrantCreate
--- PASS: TestMaskingPolicyGrantCreate (0.00s)
=== RUN   TestMaskingPolicyGrantRead
--- PASS: TestMaskingPolicyGrantRead (0.00s)
=== RUN   TestMaskingPolicy
--- PASS: TestMaskingPolicy (0.00s)
=== RUN   TestMaskingPolicyCreate
--- PASS: TestMaskingPolicyCreate (0.00s)
=== RUN   TestMaskingPolicyDelete
--- PASS: TestMaskingPolicyDelete (0.00s)
=== RUN   TestAcc_MaterializedView
=== PAUSE TestAcc_MaterializedView
=== RUN   TestAcc_MaterializedView2
=== PAUSE TestAcc_MaterializedView2
=== RUN   TestAcc_MaterializedViewFutureGrant
--- PASS: TestAcc_MaterializedViewFutureGrant (9.36s)
=== RUN   TestMaterializedViewGrant
--- PASS: TestMaterializedViewGrant (0.00s)
=== RUN   TestMaterializedViewGrantCreate
--- PASS: TestMaterializedViewGrantCreate (0.00s)
=== RUN   TestMaterializedViewGrantRead
--- PASS: TestMaterializedViewGrantRead (0.00s)
=== RUN   TestFutureMaterializedViewGrantCreate
--- PASS: TestFutureMaterializedViewGrantCreate (0.00s)
=== RUN   TestMaterializedView
--- PASS: TestMaterializedView (0.00s)
=== RUN   TestMaterializedViewCreate
[DEBUG] extracting materialized view query: SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'
--- PASS: TestMaterializedViewCreate (0.00s)
=== RUN   TestMaterializedViewCreateOrReplace
[DEBUG] extracting materialized view query: SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'
--- PASS: TestMaterializedViewCreateOrReplace (0.00s)
=== RUN   TestMaterializedViewCreateAmpersand
[DEBUG] extracting materialized view query: SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'
--- PASS: TestMaterializedViewCreateAmpersand (0.00s)
=== RUN   TestMaterializedViewRead
--- PASS: TestMaterializedViewRead (0.00s)
=== RUN   TestAcc_NetworkPolicy
=== PAUSE TestAcc_NetworkPolicy
=== RUN   TestAcc_NetworkPolicyAttachment
=== PAUSE TestAcc_NetworkPolicyAttachment
=== RUN   TestNetworkPolicyAttachment
--- PASS: TestNetworkPolicyAttachment (0.00s)
=== RUN   TestNetworkPolicyAttachmentCreate
--- PASS: TestNetworkPolicyAttachmentCreate (0.00s)
=== RUN   TestNetworkPolicyAttachmentDelete
--- PASS: TestNetworkPolicyAttachmentDelete (0.00s)
=== RUN   TestNetworkPolicy
--- PASS: TestNetworkPolicy (0.00s)
=== RUN   TestNetworkPolicyCreate
--- PASS: TestNetworkPolicyCreate (0.00s)
=== RUN   TestNetworkPolicyDelete
--- PASS: TestNetworkPolicyDelete (0.00s)
=== RUN   TestIpListToString
--- PASS: TestIpListToString (0.00s)
=== RUN   TestNetworkPolicyRead
--- PASS: TestNetworkPolicyRead (0.00s)
=== RUN   TestAcc_NotificationIntegration
--- PASS: TestAcc_NotificationIntegration (14.56s)
=== RUN   TestNotificationIntegration
--- PASS: TestNotificationIntegration (0.00s)
=== RUN   TestNotificationIntegrationCreate
--- PASS: TestNotificationIntegrationCreate (0.00s)
=== RUN   TestNotificationIntegrationRead
--- PASS: TestNotificationIntegrationRead (0.00s)
=== RUN   TestNotificationIntegrationDelete
--- PASS: TestNotificationIntegrationDelete (0.00s)
=== RUN   TestAcc_OAuthIntegration
=== PAUSE TestAcc_OAuthIntegration
=== RUN   TestOAuthIntegration
--- PASS: TestOAuthIntegration (0.00s)
=== RUN   TestOAuthIntegrationCreate
--- PASS: TestOAuthIntegrationCreate (0.00s)
=== RUN   TestOAuthIntegrationRead
--- PASS: TestOAuthIntegrationRead (0.00s)
=== RUN   TestOAuthIntegrationDelete
--- PASS: TestOAuthIntegrationDelete (0.00s)
=== RUN   TestAcc_Pipe
--- PASS: TestAcc_Pipe (9.64s)
=== RUN   TestAcc_PipeGrant
--- PASS: TestAcc_PipeGrant (10.20s)
=== RUN   TestPipeGrant
--- PASS: TestPipeGrant (0.00s)
=== RUN   TestPipeGrantCreate
--- PASS: TestPipeGrantCreate (0.00s)
=== RUN   TestPipeGrantRead
--- PASS: TestPipeGrantRead (0.00s)
=== RUN   TestFuturePipeGrantCreate
--- PASS: TestFuturePipeGrantCreate (0.00s)
=== RUN   TestPipe
--- PASS: TestPipe (0.00s)
=== RUN   TestPipeCreate
--- PASS: TestPipeCreate (0.00s)
=== RUN   TestPipeRead
--- PASS: TestPipeRead (0.00s)
=== RUN   TestAcc_Procedure
--- PASS: TestAcc_Procedure (10.10s)
=== RUN   TestAcc_ProcedureFutureGrant
--- PASS: TestAcc_ProcedureFutureGrant (8.90s)
=== RUN   TestProcedureGrant
--- PASS: TestProcedureGrant (0.00s)
=== RUN   TestProcedureGrantCreate
--- PASS: TestProcedureGrantCreate (0.00s)
=== RUN   TestProcedureGrantRead
--- PASS: TestProcedureGrantRead (0.00s)
=== RUN   TestFutureProcedureGrantCreate
--- PASS: TestFutureProcedureGrantCreate (0.00s)
=== RUN   TestProcedure
--- PASS: TestProcedure (0.00s)
=== RUN   TestProcedureCreate
--- PASS: TestProcedureCreate (0.00s)
=== RUN   TestProcedureRead
--- PASS: TestProcedureRead (0.00s)
=== RUN   TestProcedureDelete
--- PASS: TestProcedureDelete (0.00s)
=== RUN   TestAcc_ResourceMonitor
=== PAUSE TestAcc_ResourceMonitor
=== RUN   TestAccResourceMonitor_defaults
=== PAUSE TestAccResourceMonitor_defaults
=== RUN   TestResourceMonitorGrant
--- PASS: TestResourceMonitorGrant (0.00s)
=== RUN   TestResourceMonitorGrantCreate
--- PASS: TestResourceMonitorGrantCreate (0.00s)
=== RUN   TestResourceMonitorGrantRead
--- PASS: TestResourceMonitorGrantRead (0.00s)
=== RUN   TestResourceMonitor
--- PASS: TestResourceMonitor (0.00s)
=== RUN   TestResourceMonitorCreate
--- PASS: TestResourceMonitorCreate (0.00s)
=== RUN   TestResourceMonitorDelete
--- PASS: TestResourceMonitorDelete (0.00s)
=== RUN   TestResourceMonitorExists
--- PASS: TestResourceMonitorExists (0.00s)
=== RUN   TestResourceMonitorRead
--- PASS: TestResourceMonitorRead (0.00s)
=== RUN   TestAcc_Role
=== PAUSE TestAcc_Role
=== RUN   TestAcc_GrantRole
=== PAUSE TestAcc_GrantRole
=== RUN   TestRoleGrants
--- PASS: TestRoleGrants (0.00s)
=== RUN   TestRoleGrantsCreate
--- PASS: TestRoleGrantsCreate (0.00s)
=== RUN   TestRoleGrantsRead
--- PASS: TestRoleGrantsRead (0.00s)
=== RUN   TestRoleGrantsDelete
--- PASS: TestRoleGrantsDelete (0.00s)
=== RUN   TestRoleGrantsReadLegacyId
--- PASS: TestRoleGrantsReadLegacyId (0.00s)
=== RUN   TestAccRoleOwnershipGrant_defaults
=== PAUSE TestAccRoleOwnershipGrant_defaults
=== RUN   TestRoleOwnershipGrant
--- PASS: TestRoleOwnershipGrant (0.00s)
=== RUN   TestRoleOwnershipGrantCreate
--- PASS: TestRoleOwnershipGrantCreate (0.00s)
=== RUN   TestRoleOwnershipGrantRead
--- PASS: TestRoleOwnershipGrantRead (0.00s)
=== RUN   TestRoleOwnershipGrantDelete
--- PASS: TestRoleOwnershipGrantDelete (0.00s)
=== RUN   TestRole
--- PASS: TestRole (0.00s)
=== RUN   TestRoleCreate
--- PASS: TestRoleCreate (0.00s)
=== RUN   TestRoleRead
--- PASS: TestRoleRead (0.00s)
=== RUN   TestRoleDelete
--- PASS: TestRoleDelete (0.00s)
=== RUN   TestAcc_RowAccessPolicy
=== PAUSE TestAcc_RowAccessPolicy
=== RUN   TestAcc_RowAccessPolicyGrant
=== PAUSE TestAcc_RowAccessPolicyGrant
=== RUN   TestRowAccessPolicyGrant
--- PASS: TestRowAccessPolicyGrant (0.00s)
=== RUN   TestRowAccessPolicyGrantCreate
--- PASS: TestRowAccessPolicyGrantCreate (0.00s)
=== RUN   TestRowAccessPolicyGrantRead
--- PASS: TestRowAccessPolicyGrantRead (0.00s)
=== RUN   TestRowAccessPolicy
--- PASS: TestRowAccessPolicy (0.00s)
=== RUN   TestRowAccessPolicyCreate
--- PASS: TestRowAccessPolicyCreate (0.00s)
=== RUN   TestRowAccessPolicyDelete
--- PASS: TestRowAccessPolicyDelete (0.00s)
=== RUN   TestAcc_SamlIntegration
--- PASS: TestAcc_SamlIntegration (7.71s)
=== RUN   TestSAMLIntegration
--- PASS: TestSAMLIntegration (0.00s)
=== RUN   TestSAMLIntegrationCreate
--- PASS: TestSAMLIntegrationCreate (0.00s)
=== RUN   TestSAMLIntegrationRead
--- PASS: TestSAMLIntegrationRead (0.00s)
=== RUN   TestSAMLIntegrationDelete
--- PASS: TestSAMLIntegrationDelete (0.00s)
=== RUN   TestAcc_Schema
=== PAUSE TestAcc_Schema
=== RUN   TestAcc_SchemaRename
=== PAUSE TestAcc_SchemaRename
=== RUN   TestAcc_SchemaGrant
=== PAUSE TestAcc_SchemaGrant
=== RUN   TestAcc_SchemaFutureGrants
=== PAUSE TestAcc_SchemaFutureGrants
=== RUN   TestSchemaGrant
--- PASS: TestSchemaGrant (0.00s)
=== RUN   TestSchemaGrantCreate
--- PASS: TestSchemaGrantCreate (0.00s)
=== RUN   TestSchemaGrantRead
--- PASS: TestSchemaGrantRead (0.00s)
=== RUN   TestFutureSchemaGrantCreate
--- PASS: TestFutureSchemaGrantCreate (0.00s)
=== RUN   TestSchema
--- PASS: TestSchema (0.00s)
=== RUN   TestSchemaCreate
--- PASS: TestSchemaCreate (0.00s)
=== RUN   TestSchemaRead
--- PASS: TestSchemaRead (0.00s)
=== RUN   TestAcc_ScimIntegration
    scim_integration_acceptance_test.go:15: Skipping TestAccScimIntegration
--- SKIP: TestAcc_ScimIntegration (0.00s)
=== RUN   TestSCIMIntegration
--- PASS: TestSCIMIntegration (0.00s)
=== RUN   TestSCIMIntegrationCreate
--- PASS: TestSCIMIntegrationCreate (0.00s)
=== RUN   TestSCIMIntegrationRead
--- PASS: TestSCIMIntegrationRead (0.00s)
=== RUN   TestSCIMIntegrationDelete
--- PASS: TestSCIMIntegrationDelete (0.00s)
=== RUN   TestAcc_Sequence
=== PAUSE TestAcc_Sequence
=== RUN   TestAcc_SequenceFutureGrant
--- PASS: TestAcc_SequenceFutureGrant (8.68s)
=== RUN   TestSequenceGrant
--- PASS: TestSequenceGrant (0.00s)
=== RUN   TestSequenceGrantCreate
--- PASS: TestSequenceGrantCreate (0.00s)
=== RUN   TestSequenceGrantRead
--- PASS: TestSequenceGrantRead (0.00s)
=== RUN   TestFutureSequenceGrantCreate
--- PASS: TestFutureSequenceGrantCreate (0.00s)
=== RUN   TestSequence
--- PASS: TestSequence (0.00s)
=== RUN   TestSequenceCreate
--- PASS: TestSequenceCreate (0.00s)
=== RUN   TestSequenceRead
--- PASS: TestSequenceRead (0.00s)
=== RUN   TestSequenceDelete
--- PASS: TestSequenceDelete (0.00s)
=== RUN   TestAcc_Share
=== PAUSE TestAcc_Share
=== RUN   TestShare
--- PASS: TestShare (0.00s)
=== RUN   TestShareCreate
--- PASS: TestShareCreate (0.00s)
=== RUN   TestStripAccountFromName
--- PASS: TestStripAccountFromName (0.00s)
=== RUN   TestShareRead
--- PASS: TestShareRead (0.00s)
=== RUN   TestAccStageGrant_defaults
=== PAUSE TestAccStageGrant_defaults
=== RUN   TestAcc_StageFutureGrant
--- PASS: TestAcc_StageFutureGrant (8.51s)
=== RUN   TestStageGrant
--- PASS: TestStageGrant (0.00s)
=== RUN   TestStageGrantCreate
--- PASS: TestStageGrantCreate (0.00s)
=== RUN   TestStageGrantRead
--- PASS: TestStageGrantRead (0.00s)
=== RUN   TestFutureStageGrantCreate
--- PASS: TestFutureStageGrantCreate (0.00s)
=== RUN   TestStage
--- PASS: TestStage (0.00s)
=== RUN   TestInternalStageCreate
--- PASS: TestInternalStageCreate (0.00s)
=== RUN   TestExternalStageCreate
--- PASS: TestExternalStageCreate (0.00s)
=== RUN   TestStageRead
--- PASS: TestStageRead (0.00s)
=== RUN   TestAccStorageIntegration_validation
=== PAUSE TestAccStorageIntegration_validation
=== RUN   TestAccStorageIntegration_aws
=== PAUSE TestAccStorageIntegration_aws
=== RUN   TestStorageIntegration
--- PASS: TestStorageIntegration (0.00s)
=== RUN   TestStorageIntegrationCreate
--- PASS: TestStorageIntegrationCreate (0.00s)
=== RUN   TestStorageIntegrationRead
--- PASS: TestStorageIntegrationRead (0.00s)
=== RUN   TestStorageIntegrationReadEmpty
--- PASS: TestStorageIntegrationReadEmpty (0.00s)
=== RUN   TestStorageIntegrationUpdate
--- PASS: TestStorageIntegrationUpdate (0.00s)
=== RUN   TestStorageIntegrationDelete
--- PASS: TestStorageIntegrationDelete (0.00s)
=== RUN   TestAcc_Stream
=== PAUSE TestAcc_Stream
=== RUN   TestAccStreamGrant_basic
--- PASS: TestAccStreamGrant_basic (9.91s)
=== RUN   TestAccStreamGrante_future
--- PASS: TestAccStreamGrante_future (8.16s)
=== RUN   TestStreamGrant
--- PASS: TestStreamGrant (0.00s)
=== RUN   TestStreamGrantCreate
--- PASS: TestStreamGrantCreate (0.00s)
=== RUN   TestStreamGrantRead
--- PASS: TestStreamGrantRead (0.00s)
=== RUN   TestFutureStreamGrantCreate
--- PASS: TestFutureStreamGrantCreate (0.00s)
=== RUN   TestStream
--- PASS: TestStream (0.00s)
=== RUN   TestStreamCreate
--- PASS: TestStreamCreate (0.00s)
=== RUN   TestStreamRead
--- PASS: TestStreamRead (0.00s)
=== RUN   TestStreamReadAppendOnlyMode
--- PASS: TestStreamReadAppendOnlyMode (0.00s)
=== RUN   TestStreamReadDefaultMode
--- PASS: TestStreamReadDefaultMode (0.00s)
=== RUN   TestStreamDelete
--- PASS: TestStreamDelete (0.00s)
=== RUN   TestStreamUpdate
--- PASS: TestStreamUpdate (0.00s)
=== RUN   TestAcc_Table
=== PAUSE TestAcc_Table
=== RUN   TestAcc_TableDefaults
=== PAUSE TestAcc_TableDefaults
=== RUN   TestAcc_TableTags
=== PAUSE TestAcc_TableTags
=== RUN   TestAcc_TableIdentity
=== PAUSE TestAcc_TableIdentity
=== RUN   TestAcc_TableRename
=== PAUSE TestAcc_TableRename
=== RUN   TestAccTableGrant_defaults
=== PAUSE TestAccTableGrant_defaults
=== RUN   TestTableGrant
--- PASS: TestTableGrant (0.00s)
=== RUN   TestTableGrantCreate
--- PASS: TestTableGrantCreate (0.00s)
=== RUN   TestTableGrantUpdate
--- PASS: TestTableGrantUpdate (0.00s)
=== RUN   TestTableGrantRead
--- PASS: TestTableGrantRead (0.00s)
=== RUN   TestFutureTableGrantCreate
--- PASS: TestFutureTableGrantCreate (0.00s)
=== RUN   TestTable
--- PASS: TestTable (0.00s)
=== RUN   TestTableCreate
--- PASS: TestTableCreate (0.00s)
=== RUN   TestTableRead
--- PASS: TestTableRead (0.00s)
=== RUN   TestTableDelete
--- PASS: TestTableDelete (0.00s)
=== RUN   TestAcc_Tag
=== PAUSE TestAcc_Tag
=== RUN   TestTag
--- PASS: TestTag (0.00s)
=== RUN   TestTagCreate
--- PASS: TestTagCreate (0.00s)
=== RUN   TestTagUpdate
--- PASS: TestTagUpdate (0.00s)
=== RUN   TestTagDelete
--- PASS: TestTagDelete (0.00s)
=== RUN   TestTagRead
--- PASS: TestTagRead (0.00s)
=== RUN   TestAcc_Task
=== PAUSE TestAcc_Task
=== RUN   TestAcc_Task_Managed
=== PAUSE TestAcc_Task_Managed
=== RUN   TestAcc_Task_SwitchScheduled
=== PAUSE TestAcc_Task_SwitchScheduled
=== RUN   TestAcc_TaskGrant
--- PASS: TestAcc_TaskGrant (14.56s)
=== RUN   TestTaskGrant
--- PASS: TestTaskGrant (0.00s)
=== RUN   TestTaskGrantCreate
--- PASS: TestTaskGrantCreate (0.00s)
=== RUN   TestTaskGrantRead
--- PASS: TestTaskGrantRead (0.00s)
=== RUN   TestFutureTaskGrantCreate
--- PASS: TestFutureTaskGrantCreate (0.00s)
=== RUN   TestTask
--- PASS: TestTask (0.00s)
=== RUN   TestTaskCreate
--- PASS: TestTaskCreate (0.00s)
=== RUN   TestTaskCreateManagedWithInitSize
--- PASS: TestTaskCreateManagedWithInitSize (0.00s)
=== RUN   TestTaskCreateManagedWithoutInitSize
--- PASS: TestTaskCreateManagedWithoutInitSize (0.00s)
=== RUN   TestTaskRead
--- PASS: TestTaskRead (0.00s)
=== RUN   TestAcc_User
=== PAUSE TestAcc_User
=== RUN   TestAccUserOwnershipGrant_defaults
=== PAUSE TestAccUserOwnershipGrant_defaults
=== RUN   TestUserOwnershipGrant
--- PASS: TestUserOwnershipGrant (0.00s)
=== RUN   TestUserOwnershipGrantCreate
--- PASS: TestUserOwnershipGrantCreate (0.00s)
=== RUN   TestUserOwnershipGrantRead
--- PASS: TestUserOwnershipGrantRead (0.00s)
=== RUN   TestUserOwnershipGrantDelete
--- PASS: TestUserOwnershipGrantDelete (0.00s)
=== RUN   TestAcc_UserPublicKeys
=== PAUSE TestAcc_UserPublicKeys
=== RUN   TestUserPublicKeys
--- PASS: TestUserPublicKeys (0.00s)
=== RUN   TestUserPublicKeysCreate
--- PASS: TestUserPublicKeysCreate (0.00s)
=== RUN   TestUsePublicKeysrDelete
--- PASS: TestUsePublicKeysrDelete (0.00s)
=== RUN   TestUser
--- PASS: TestUser (0.00s)
=== RUN   TestUserCreate
--- PASS: TestUserCreate (0.00s)
=== RUN   TestUserRead
--- PASS: TestUserRead (0.00s)
=== RUN   TestUserExists
--- PASS: TestUserExists (0.00s)
=== RUN   TestUserDelete
--- PASS: TestUserDelete (0.00s)
=== RUN   TestAcc_View
=== PAUSE TestAcc_View
=== RUN   TestAcc_View2
=== PAUSE TestAcc_View2
=== RUN   TestAcc_ViewGrantBasic
=== PAUSE TestAcc_ViewGrantBasic
=== RUN   TestAcc_ViewGrantShares
=== PAUSE TestAcc_ViewGrantShares
=== RUN   TestAcc_FutureViewGrantChange
=== PAUSE TestAcc_FutureViewGrantChange
=== RUN   TestViewGrant
--- PASS: TestViewGrant (0.00s)
=== RUN   TestViewGrantCreate
--- PASS: TestViewGrantCreate (0.00s)
=== RUN   TestViewGrantRead
--- PASS: TestViewGrantRead (0.00s)
=== RUN   TestFutureViewGrantCreate
--- PASS: TestFutureViewGrantCreate (0.00s)
=== RUN   TestView
--- PASS: TestView (0.00s)
=== RUN   TestViewCreate
[DEBUG] extracting view query SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'
--- PASS: TestViewCreate (0.00s)
=== RUN   TestViewCreateOrReplace
[DEBUG] extracting view query SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'
--- PASS: TestViewCreateOrReplace (0.00s)
=== RUN   TestViewCreateAmpersand
[DEBUG] extracting view query SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'
--- PASS: TestViewCreateAmpersand (0.00s)
=== RUN   TestDiffSuppressStatement
=== RUN   TestDiffSuppressStatement/select
=== RUN   TestDiffSuppressStatement/view_1
=== RUN   TestDiffSuppressStatement/view_2
--- PASS: TestDiffSuppressStatement (0.00s)
    --- PASS: TestDiffSuppressStatement/select (0.00s)
    --- PASS: TestDiffSuppressStatement/view_1 (0.00s)
    --- PASS: TestDiffSuppressStatement/view_2 (0.00s)
=== RUN   TestViewRead
SHOW VIEWS LIKE 'good_name' IN SCHEMA "test_db"."test_schema"
--- PASS: TestViewRead (0.00s)
=== RUN   TestAcc_Warehouse
=== PAUSE TestAcc_Warehouse
=== RUN   TestAcc_WarehouseGrant
=== PAUSE TestAcc_WarehouseGrant
=== RUN   TestWarehouseGrant
--- PASS: TestWarehouseGrant (0.00s)
=== RUN   TestWarehouseGrantCreate
--- PASS: TestWarehouseGrantCreate (0.00s)
=== RUN   TestWarehouse
--- PASS: TestWarehouse (0.00s)
=== RUN   TestWarehouseCreate
--- PASS: TestWarehouseCreate (0.00s)
=== RUN   TestWarehouseRead
--- PASS: TestWarehouseRead (0.00s)
=== RUN   TestWarehouseDelete
--- PASS: TestWarehouseDelete (0.00s)
=== CONT  TestAccAccountGrant_defaults
=== CONT  TestAcc_SchemaGrant
=== CONT  TestAcc_SchemaRename
=== CONT  TestAcc_Tag
=== CONT  TestAcc_WarehouseGrant
=== CONT  TestAcc_Warehouse
=== CONT  TestAcc_FutureViewGrantChange
=== CONT  TestAcc_ViewGrantShares
=== CONT  TestAcc_ViewGrantBasic
=== CONT  TestAcc_View2
=== CONT  TestAcc_View
=== CONT  TestAcc_UserPublicKeys
=== CONT  TestAccUserOwnershipGrant_defaults
=== CONT  TestAcc_User
=== CONT  TestAcc_MaterializedView
=== CONT  TestAcc_Task_SwitchScheduled
[DEBUG] extracting view query CREATE SECURE VIEW "yxrcxiftzu"."PUBLIC"."yxrcxiftzu" comment = 'Terraform test resource' AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES where ROLE_OWNER like 'foo%%';
[DEBUG] extracting view query CREATE SECURE VIEW "yxrcxiftzu"."PUBLIC"."yxrcxiftzu" comment = 'Terraform test resource' AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES where ROLE_OWNER like 'foo%%';
--- PASS: TestAcc_View2 (30.85s)
=== CONT  TestAcc_Task_Managed
--- PASS: TestAcc_Warehouse (47.68s)
=== CONT  TestAcc_Task
--- PASS: TestAccUserOwnershipGrant_defaults (48.20s)
=== CONT  TestAccDatabaseGrant_basic
[DEBUG] extracting view query CREATE SECURE VIEW "TYONKVDSDH"."TYONKVDSDH"."KVYSMSOHGH" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
[DEBUG] extracting view query CREATE SECURE VIEW "GEHDEVFDBQ"."GEHDEVFDBQ"."PPNOGJETQA" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
--- PASS: TestAcc_UserPublicKeys (50.51s)
=== CONT  TestAcc_FileFormatCSV
--- PASS: TestAccAccountGrant_defaults (50.51s)
=== CONT  TestAcc_ExternalStage
[DEBUG] extracting view query CREATE SECURE VIEW "TYONKVDSDH"."TYONKVDSDH"."KVYSMSOHGH" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
[DEBUG] extracting view query CREATE SECURE VIEW "XJRQETRKOG"."XJRQETRKOG"."IHSVHLPZOS" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
[DEBUG] extracting view query CREATE SECURE VIEW "GEHDEVFDBQ"."GEHDEVFDBQ"."PPNOGJETQA" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
[DEBUG] extracting view query CREATE SECURE VIEW "XJRQETRKOG"."XJRQETRKOG"."IHSVHLPZOS" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
--- PASS: TestAcc_ViewGrantBasic (54.15s)
=== CONT  TestAcc_FileFormatJSON
[DEBUG] extracting materialized view query: CREATE SECURE MATERIALIZED VIEW "DAVBSENPTA"."JCSXYEHVBB"."QETEYJMVKR" comment = 'Terraform test resource' AS SELECT ID, DATA FROM "BIRMHHDCPU";
{GVYUVYBWLT GVYUVYBWLT GVYUVYBWLT GVYUVYBWLT}
[DEBUG] extracting view query CREATE SECURE VIEW "GEHDEVFDBQ"."GEHDEVFDBQ"."PPNOGJETQA" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
[DEBUG] extracting materialized view query: CREATE SECURE MATERIALIZED VIEW "DAVBSENPTA"."JCSXYEHVBB"."QETEYJMVKR" comment = 'Terraform test resource' AS SELECT ID, DATA FROM "BIRMHHDCPU";
[DEBUG] extracting view query CREATE SECURE VIEW "LZOTRZNHWK"."PUBLIC"."LZOTRZNHWK" comment = 'Terraform test resource' AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
--- PASS: TestAcc_WarehouseGrant (58.63s)
=== CONT  TestAcc_ExternalOauthIntegration
--- PASS: TestAcc_ViewGrantShares (59.76s)
=== CONT  TestAcc_MaskingPolicy
[DEBUG] extracting view query CREATE SECURE VIEW "LZOTRZNHWK"."PUBLIC"."LZOTRZNHWK" comment = 'Terraform test resource' AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
[DEBUG] extracting view query CREATE SECURE VIEW "GEHDEVFDBQ"."GEHDEVFDBQ"."PPNOGJETQA" AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
--- PASS: TestAcc_Tag (60.48s)
=== CONT  TestAcc_Stream
--- PASS: TestAcc_MaterializedView (60.65s)
=== CONT  TestAcc_InternalStage
--- PASS: TestAcc_View (61.54s)
=== CONT  TestAccTableGrant_defaults
--- PASS: TestAcc_SchemaRename (63.17s)
=== CONT  TestAcc_FileFormatXML
--- PASS: TestAcc_FutureViewGrantChange (65.07s)
=== CONT  TestAcc_TableRename
[DEBUG] IMPORT
--- PASS: TestAcc_Task_Managed (36.88s)
=== CONT  TestAcc_FileFormatParquet
--- PASS: TestAcc_FileFormatCSV (18.23s)
=== CONT  TestAcc_TableIdentity
--- PASS: TestAccDatabaseGrant_basic (21.82s)
=== CONT  TestAcc_TableTags
--- PASS: TestAcc_ExternalStage (20.10s)
=== CONT  TestAcc_TableDefaults
--- PASS: TestAcc_User (72.25s)
=== CONT  TestAcc_FileFormatORC
--- PASS: TestAcc_SchemaGrant (72.35s)
=== CONT  TestAcc_Table
--- PASS: TestAcc_ExternalOauthIntegration (16.01s)
=== CONT  TestAcc_FileFormatAvro
--- PASS: TestAcc_FileFormatParquet (17.62s)
=== CONT  TestAcc_AccountGrantManageSupportCases
--- PASS: TestAcc_FileFormatJSON (31.32s)
=== CONT  TestAcc_Database
=== CONT  TestAcc_AccountGrantManagedTask
--- PASS: TestAcc_Task_SwitchScheduled (88.02s)
=== CONT  TestAccStageGrant_defaults
--- PASS: TestAcc_FileFormatORC (22.86s)
--- PASS: TestAcc_MaskingPolicy (37.10s)
=== CONT  TestAcc_Sequence
=== CONT  TestAccStorageIntegration_aws
--- PASS: TestAcc_TableIdentity (28.39s)
--- PASS: TestAcc_TableDefaults (29.07s)
=== CONT  TestAcc_Share
--- PASS: TestAcc_InternalStage (40.09s)
=== CONT  TestAccStorageIntegration_validation
--- PASS: TestAcc_Task (53.28s)
=== CONT  TestAcc_SchemaFutureGrants
--- PASS: TestAcc_AccountGrantManagedTask (14.07s)
=== CONT  TestAcc_OAuthIntegration
--- PASS: TestAcc_FileFormatXML (40.72s)
=== CONT  TestAcc_RowAccessPolicy
--- PASS: TestAcc_AccountGrantManageSupportCases (26.85s)
=== CONT  TestAccResourceMonitor_defaults
--- PASS: TestAcc_Share (14.10s)
=== CONT  TestAcc_Schema
--- PASS: TestAccStageGrant_defaults (18.97s)
=== CONT  TestAcc_Role
--- PASS: TestAccResourceMonitor_defaults (14.83s)
=== CONT  TestAcc_RowAccessPolicyGrant
{ZJYWZMTTJG DNZKVWADER DNZKVWADER DNZKVWADER}
{OWBGXIQGUX DNZKVWADER DNZKVWADER DNZKVWADER}
--- PASS: TestAcc_Schema (18.82s)
=== CONT  TestAcc_ResourceMonitor
--- PASS: TestAcc_FileFormatAvro (58.09s)
=== CONT  TestAccRoleOwnershipGrant_defaults
--- PASS: TestAccStorageIntegration_aws (40.04s)
=== CONT  TestAcc_GrantRole
--- PASS: TestAcc_TableTags (68.30s)
=== CONT  TestAcc_NetworkPolicy
--- PASS: TestAccTableGrant_defaults (81.75s)
=== CONT  TestAcc_NetworkPolicyAttachment
--- PASS: TestAcc_RowAccessPolicy (41.92s)
=== CONT  TestAcc_MaterializedView2
--- PASS: TestAcc_OAuthIntegration (45.03s)
--- PASS: TestAccStorageIntegration_validation (46.55s)
--- PASS: TestAcc_TableRename (83.16s)
--- PASS: TestAcc_Role (35.43s)
--- PASS: TestAcc_Stream (89.86s)
--- PASS: TestAccRoleOwnershipGrant_defaults (19.24s)
--- PASS: TestAcc_Database (70.46s)
--- PASS: TestAcc_RowAccessPolicyGrant (30.36s)
--- PASS: TestAcc_SchemaFutureGrants (56.83s)
--- PASS: TestAcc_Sequence (61.34s)
--- PASS: TestAcc_NetworkPolicyAttachment (16.51s)
[DEBUG] extracting materialized view query: CREATE SECURE MATERIALIZED VIEW "AMCMVTXWBQ"."JRJMQWJMKJ"."YGDQGYYEFC" comment = 'Terraform test resource' AS SELECT ID, DATA FROM "MFCJSLXBCT" WHERE ID LIKE 'foo%';
[DEBUG] extracting materialized view query: CREATE SECURE MATERIALIZED VIEW "AMCMVTXWBQ"."JRJMQWJMKJ"."YGDQGYYEFC" comment = 'Terraform test resource' AS SELECT ID, DATA FROM "MFCJSLXBCT" WHERE ID LIKE 'foo%';
--- PASS: TestAcc_ResourceMonitor (30.27s)
--- PASS: TestAcc_MaterializedView2 (18.26s)
--- PASS: TestAcc_NetworkPolicy (28.58s)
--- PASS: TestAcc_GrantRole (39.53s)
--- PASS: TestAcc_Table (121.91s)
PASS
coverage: 66.2% of statements
ok  	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources	461.916s	coverage: 66.2% of statements
=== RUN   TestExternalFunctionCreate
--- PASS: TestExternalFunctionCreate (0.00s)
=== RUN   TestExternalFunctionDrop
--- PASS: TestExternalFunctionDrop (0.00s)
=== RUN   TestExternalFunctionShow
--- PASS: TestExternalFunctionShow (0.00s)
=== RUN   TestExternalTableCreate
--- PASS: TestExternalTableCreate (0.00s)
=== RUN   TestExternalTableUpdate
{tag1 test_db test_schema value1}
--- PASS: TestExternalTableUpdate (0.00s)
=== RUN   TestExternalTableDrop
--- PASS: TestExternalTableDrop (0.00s)
=== RUN   TestExternalTableShow
--- PASS: TestExternalTableShow (0.00s)
=== RUN   TestFileFormatCreateCSV
--- PASS: TestFileFormatCreateCSV (0.00s)
=== RUN   TestFileFormatCreateJSON
--- PASS: TestFileFormatCreateJSON (0.00s)
=== RUN   TestFileFormatChangeComment
--- PASS: TestFileFormatChangeComment (0.00s)
=== RUN   TestFileFormatChangeCompression
--- PASS: TestFileFormatChangeCompression (0.00s)
=== RUN   TestFileFormatChangeRecordDelimiter
--- PASS: TestFileFormatChangeRecordDelimiter (0.00s)
=== RUN   TestFileFormatChangeFieldDelimiter
--- PASS: TestFileFormatChangeFieldDelimiter (0.00s)
=== RUN   TestFileFormatChangeFileExtension
--- PASS: TestFileFormatChangeFileExtension (0.00s)
=== RUN   TestFileFormatChangeDateFormat
--- PASS: TestFileFormatChangeDateFormat (0.00s)
=== RUN   TestFileFormatChangeTimeFormat
--- PASS: TestFileFormatChangeTimeFormat (0.00s)
=== RUN   TestFileFormatChangeTimestampFormat
--- PASS: TestFileFormatChangeTimestampFormat (0.00s)
=== RUN   TestFileFormatChangeBinaryFormat
--- PASS: TestFileFormatChangeBinaryFormat (0.00s)
=== RUN   TestFileFormatChangeValidateUTF8
--- PASS: TestFileFormatChangeValidateUTF8 (0.00s)
=== RUN   TestFileFormatChangeEmptyFieldAsNull
--- PASS: TestFileFormatChangeEmptyFieldAsNull (0.00s)
=== RUN   TestFileFormatChangeErrorOnColumnCountMismatch
--- PASS: TestFileFormatChangeErrorOnColumnCountMismatch (0.00s)
=== RUN   TestFileFormatChangeEscape
--- PASS: TestFileFormatChangeEscape (0.00s)
=== RUN   TestFileFormatChangeFieldOptionallyEnclosedBy
--- PASS: TestFileFormatChangeFieldOptionallyEnclosedBy (0.00s)
=== RUN   TestFileFormatChangeEscapeUnenclosedField
--- PASS: TestFileFormatChangeEscapeUnenclosedField (0.00s)
=== RUN   TestFileFormatChangeNullIf
--- PASS: TestFileFormatChangeNullIf (0.00s)
=== RUN   TestFileFormatChangeEncoding
--- PASS: TestFileFormatChangeEncoding (0.00s)
=== RUN   TestFileFormatChangeSkipHeader
--- PASS: TestFileFormatChangeSkipHeader (0.00s)
=== RUN   TestFileFormatChangeSkipBlankLines
--- PASS: TestFileFormatChangeSkipBlankLines (0.00s)
=== RUN   TestFileFormatChangeTrimSpace
--- PASS: TestFileFormatChangeTrimSpace (0.00s)
=== RUN   TestFileFormatChangeEnableOctal
--- PASS: TestFileFormatChangeEnableOctal (0.00s)
=== RUN   TestFileFormatChangeAllowDuplicate
--- PASS: TestFileFormatChangeAllowDuplicate (0.00s)
=== RUN   TestFileFormatChangeStripOuterArray
--- PASS: TestFileFormatChangeStripOuterArray (0.00s)
=== RUN   TestFileFormatChangeStripNullValues
--- PASS: TestFileFormatChangeStripNullValues (0.00s)
=== RUN   TestFileFormatChangeReplaceInvalidCharacters
--- PASS: TestFileFormatChangeReplaceInvalidCharacters (0.00s)
=== RUN   TestFileFormatChangeIgnoreUTF8Errors
--- PASS: TestFileFormatChangeIgnoreUTF8Errors (0.00s)
=== RUN   TestFileFormatChangeSkipByteOrderMark
--- PASS: TestFileFormatChangeSkipByteOrderMark (0.00s)
=== RUN   TestFileFormatChangeBinaryAsText
--- PASS: TestFileFormatChangeBinaryAsText (0.00s)
=== RUN   TestFileFormatChangePreserveSpace
--- PASS: TestFileFormatChangePreserveSpace (0.00s)
=== RUN   TestFileFormatChangeStripOuterElement
--- PASS: TestFileFormatChangeStripOuterElement (0.00s)
=== RUN   TestFileFormatChangeDisableSnowflakeData
--- PASS: TestFileFormatChangeDisableSnowflakeData (0.00s)
=== RUN   TestFileFormatChangeDisableAutoConvert
--- PASS: TestFileFormatChangeDisableAutoConvert (0.00s)
=== RUN   TestFileFormatDrop
--- PASS: TestFileFormatDrop (0.00s)
=== RUN   TestFileFormatDescribe
--- PASS: TestFileFormatDescribe (0.00s)
=== RUN   TestFileFormatShow
--- PASS: TestFileFormatShow (0.00s)
=== RUN   TestFunctionQualifiedName
--- PASS: TestFunctionQualifiedName (0.00s)
=== RUN   TestFunctionCreate
--- PASS: TestFunctionCreate (0.00s)
=== RUN   TestFunctionCreateWithJavaScriptFunction
--- PASS: TestFunctionCreateWithJavaScriptFunction (0.00s)
=== RUN   TestFunctionCreateWithJavaFunction
--- PASS: TestFunctionCreateWithJavaFunction (0.00s)
=== RUN   TestFunctionCreateWithJavaFunctionWithImports
--- PASS: TestFunctionCreateWithJavaFunctionWithImports (0.00s)
=== RUN   TestFunctionCreateWithJavaFunctionWithTargetPath
--- PASS: TestFunctionCreateWithJavaFunctionWithTargetPath (0.00s)
=== RUN   TestFunctionDrop
--- PASS: TestFunctionDrop (0.00s)
=== RUN   TestFunctionShow
--- PASS: TestFunctionShow (0.00s)
=== RUN   TestFunctionRename
--- PASS: TestFunctionRename (0.00s)
=== RUN   TestFunctionChangeComment
--- PASS: TestFunctionChangeComment (0.00s)
=== RUN   TestFunctionRemoveComment
--- PASS: TestFunctionRemoveComment (0.00s)
=== RUN   TestFunctionDescribe
--- PASS: TestFunctionDescribe (0.00s)
=== RUN   TestFunctionArgumentsSignature
--- PASS: TestFunctionArgumentsSignature (0.00s)
=== RUN   TestFormatStringList
--- PASS: TestFormatStringList (0.00s)
=== RUN   TestFormatStringListWithEscape
--- PASS: TestFormatStringListWithEscape (0.00s)
=== RUN   TestViewSelectStatementExtractor_Extract
=== RUN   TestViewSelectStatementExtractor_Extract/basic
[DEBUG] extracting view query create view foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/caps
[DEBUG] extracting view query CREATE VIEW FOO AS SELECT * FROM BAR;
=== RUN   TestViewSelectStatementExtractor_Extract/parens
[DEBUG] extracting view query create view foo as (select * from bar);
=== RUN   TestViewSelectStatementExtractor_Extract/multiline
[DEBUG] extracting view query
create view foo as
select *
from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/multilineComment
[DEBUG] extracting view query
create view foo as
-- comment
select *
from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/secure
[DEBUG] extracting view query create secure view foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/replace
[DEBUG] extracting view query create or replace view foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/recursive
[DEBUG] extracting view query create recursive view foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/ine
[DEBUG] extracting view query create view if not exists foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/comment
[DEBUG] extracting view query create view foo comment='asdf' as select * from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/commentEscape
[DEBUG] extracting view query create view foo comment='asdf\'s are fun' as select * from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/identifier
[DEBUG] extracting view query create view "foo"."bar"."bam" comment='asdf\'s are fun' as select * from bar;
=== RUN   TestViewSelectStatementExtractor_Extract/full
[DEBUG] extracting view query CREATE SECURE VIEW "rgdxfmnfhh"."PUBLIC"."rgdxfmnfhh" COMMENT = 'Terraform test resource' AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
--- PASS: TestViewSelectStatementExtractor_Extract (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/basic (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/caps (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/parens (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/multiline (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/multilineComment (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/secure (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/replace (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/recursive (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/ine (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/comment (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/commentEscape (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/identifier (0.00s)
    --- PASS: TestViewSelectStatementExtractor_Extract/full (0.00s)
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/basic
[DEBUG] extracting materialized view query: create materialized view foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/caps
[DEBUG] extracting materialized view query: CREATE MATERIALIZED VIEW FOO AS SELECT * FROM BAR;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/parens
[DEBUG] extracting materialized view query: create materialized view foo as (select * from bar);
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/multiline
[DEBUG] extracting materialized view query:
create materialized view foo as
select *
from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/multilineComment
[DEBUG] extracting materialized view query:
create materialized view foo as
-- comment
select *
from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/secure
[DEBUG] extracting materialized view query: create secure materialized view foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/replace
[DEBUG] extracting materialized view query: create or replace materialized view foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/ine
[DEBUG] extracting materialized view query: create materialized view if not exists foo as select * from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/comment
[DEBUG] extracting materialized view query: create materialized view foo comment='asdf' as select * from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/commentEscape
[DEBUG] extracting materialized view query: create materialized view foo comment='asdf\'s are fun' as select * from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/clusterBy
[DEBUG] extracting materialized view query: create materialized view foo cluster by (c1, c2) as select * from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/identifier
[DEBUG] extracting materialized view query: create materialized view "foo"."bar"."bam" comment='asdf\'s are fun' as select * from bar;
=== RUN   TestViewSelectStatementExtractor_ExtractMaterializedView/full
[DEBUG] extracting materialized view query: CREATE SECURE MATERIALIZED VIEW "rgdxfmnfhh"."PUBLIC"."rgdxfmnfhh" COMMENT = 'Terraform test resource' CLUSTER BY (C1, C2) AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES
--- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/basic (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/caps (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/parens (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/multiline (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/multilineComment (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/secure (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/replace (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/ine (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/comment (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/commentEscape (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/clusterBy (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/identifier (0.00s)
    --- PASS: TestViewSelectStatementExtractor_ExtractMaterializedView/full (0.00s)
=== RUN   TestViewSelectStatementExtractor_consumeToken
=== RUN   TestViewSelectStatementExtractor_consumeToken/basic_-_found
=== RUN   TestViewSelectStatementExtractor_consumeToken/basic_-_not_found
=== RUN   TestViewSelectStatementExtractor_consumeToken/basic_-_not_found#01
--- PASS: TestViewSelectStatementExtractor_consumeToken (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeToken/basic_-_found (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeToken/basic_-_not_found (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeToken/basic_-_not_found#01 (0.00s)
=== RUN   TestViewSelectStatementExtractor_consumeSpace
=== RUN   TestViewSelectStatementExtractor_consumeSpace/simple
simple
=== RUN   TestViewSelectStatementExtractor_consumeSpace/empty
empty
=== RUN   TestViewSelectStatementExtractor_consumeSpace/middle
middle
--- PASS: TestViewSelectStatementExtractor_consumeSpace (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeSpace/simple (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeSpace/empty (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeSpace/middle (0.00s)
=== RUN   TestViewSelectStatementExtractor_consumeComment
=== RUN   TestViewSelectStatementExtractor_consumeComment/basic
=== RUN   TestViewSelectStatementExtractor_consumeComment/escaped
--- PASS: TestViewSelectStatementExtractor_consumeComment (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeComment/basic (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeComment/escaped (0.00s)
=== RUN   TestViewSelectStatementExtractor_consumeClusterBy
=== RUN   TestViewSelectStatementExtractor_consumeClusterBy/none
=== RUN   TestViewSelectStatementExtractor_consumeClusterBy/single
=== RUN   TestViewSelectStatementExtractor_consumeClusterBy/double
--- PASS: TestViewSelectStatementExtractor_consumeClusterBy (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeClusterBy/none (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeClusterBy/single (0.00s)
    --- PASS: TestViewSelectStatementExtractor_consumeClusterBy/double (0.00s)
=== RUN   TestPipeCreate
--- PASS: TestPipeCreate (0.00s)
=== RUN   TestPipeChangeComment
--- PASS: TestPipeChangeComment (0.00s)
=== RUN   TestPipeRemoveComment
--- PASS: TestPipeRemoveComment (0.00s)
=== RUN   TestPipeDrop
--- PASS: TestPipeDrop (0.00s)
=== RUN   TestPipeShow
--- PASS: TestPipeShow (0.00s)
=== RUN   TestProcedureQualifiedName
--- PASS: TestProcedureQualifiedName (0.00s)
=== RUN   TestProcedureCreate
--- PASS: TestProcedureCreate (0.00s)
=== RUN   TestProcedureCreateWithOptionalParams
--- PASS: TestProcedureCreateWithOptionalParams (0.00s)
=== RUN   TestProcedureDrop
--- PASS: TestProcedureDrop (0.00s)
=== RUN   TestProcedureShow
--- PASS: TestProcedureShow (0.00s)
=== RUN   TestProcedureRename
--- PASS: TestProcedureRename (0.00s)
=== RUN   TestProcedureChangeComment
--- PASS: TestProcedureChangeComment (0.00s)
=== RUN   TestProcedureRemoveComment
--- PASS: TestProcedureRemoveComment (0.00s)
=== RUN   TestProcedureChangeExecuteAs
--- PASS: TestProcedureChangeExecuteAs (0.00s)
=== RUN   TestProcedureDescribe
--- PASS: TestProcedureDescribe (0.00s)
=== RUN   TestProcedureArgumentsSignature
--- PASS: TestProcedureArgumentsSignature (0.00s)
=== RUN   TestSchemaCreate
--- PASS: TestSchemaCreate (0.00s)
=== RUN   TestSchemaRename
--- PASS: TestSchemaRename (0.00s)
=== RUN   TestSchemaSwap
--- PASS: TestSchemaSwap (0.00s)
=== RUN   TestSchemaChangeComment
--- PASS: TestSchemaChangeComment (0.00s)
=== RUN   TestSchemaRemoveComment
--- PASS: TestSchemaRemoveComment (0.00s)
=== RUN   TestSchemaChangeDataRetentionDays
--- PASS: TestSchemaChangeDataRetentionDays (0.00s)
=== RUN   TestSchemaRemoveDataRetentionDays
--- PASS: TestSchemaRemoveDataRetentionDays (0.00s)
=== RUN   TestSchemaManage
--- PASS: TestSchemaManage (0.00s)
=== RUN   TestSchemaUnmanage
--- PASS: TestSchemaUnmanage (0.00s)
=== RUN   TestSchemaDrop
--- PASS: TestSchemaDrop (0.00s)
=== RUN   TestSchemaUndrop
--- PASS: TestSchemaUndrop (0.00s)
=== RUN   TestSchemaUse
--- PASS: TestSchemaUse (0.00s)
=== RUN   TestSchemaShow
--- PASS: TestSchemaShow (0.00s)
=== RUN   TestSequenceCreate
--- PASS: TestSequenceCreate (0.00s)
=== RUN   TestSequenceDrop
--- PASS: TestSequenceDrop (0.00s)
=== RUN   TestSequenceShow
--- PASS: TestSequenceShow (0.00s)
=== RUN   TestSortStrings
--- PASS: TestSortStrings (0.00s)
=== RUN   TestStageCreate
--- PASS: TestStageCreate (0.00s)
=== RUN   TestStageRename
--- PASS: TestStageRename (0.00s)
=== RUN   TestStageChangeComment
--- PASS: TestStageChangeComment (0.00s)
=== RUN   TestStageChangeURL
--- PASS: TestStageChangeURL (0.00s)
=== RUN   TestStageChangeFileFormat
--- PASS: TestStageChangeFileFormat (0.00s)
=== RUN   TestStageChangeFileFormatToEmptyList
--- PASS: TestStageChangeFileFormatToEmptyList (0.00s)
=== RUN   TestStageChangeEncryption
--- PASS: TestStageChangeEncryption (0.00s)
=== RUN   TestStageChangeCredentials
--- PASS: TestStageChangeCredentials (0.00s)
=== RUN   TestStageChangeStorageIntegration
--- PASS: TestStageChangeStorageIntegration (0.00s)
=== RUN   TestStageChangeCopyOptions
--- PASS: TestStageChangeCopyOptions (0.00s)
=== RUN   TestStageDrop
--- PASS: TestStageDrop (0.00s)
=== RUN   TestStageUndrop
--- PASS: TestStageUndrop (0.00s)
=== RUN   TestStageDescribe
--- PASS: TestStageDescribe (0.00s)
=== RUN   TestStageShow
--- PASS: TestStageShow (0.00s)
=== RUN   TestStreamCreate
--- PASS: TestStreamCreate (0.00s)
=== RUN   TestStreamChangeComment
--- PASS: TestStreamChangeComment (0.00s)
=== RUN   TestStreamRemoveComment
--- PASS: TestStreamRemoveComment (0.00s)
=== RUN   TestStreamDrop
--- PASS: TestStreamDrop (0.00s)
=== RUN   TestStreamShow
--- PASS: TestStreamShow (0.00s)
=== RUN   TestSystemGenerateSCIMAccessToken
--- PASS: TestSystemGenerateSCIMAccessToken (0.00s)
=== RUN   TestSystemGetAWSSNSIAMPolicy
--- PASS: TestSystemGetAWSSNSIAMPolicy (0.00s)
=== RUN   TestSystemGetPrivateLinkConfigQuery
--- PASS: TestSystemGetPrivateLinkConfigQuery (0.00s)
=== RUN   TestSystemGetPrivateLinkGetStructuredConfigAws
--- PASS: TestSystemGetPrivateLinkGetStructuredConfigAws (0.00s)
=== RUN   TestSystemGetPrivateLinkGetStructuredConfigAwsAsPerDocumentation
--- PASS: TestSystemGetPrivateLinkGetStructuredConfigAwsAsPerDocumentation (0.00s)
=== RUN   TestSystemGetPrivateLinkGetStructuredConfigAzure
--- PASS: TestSystemGetPrivateLinkGetStructuredConfigAzure (0.00s)
=== RUN   TestSystemGetSnowflakePlatformInfoQuery
--- PASS: TestSystemGetSnowflakePlatformInfoQuery (0.00s)
=== RUN   TestSystemGetSnowflakePlatformInfoGetStructuredConfigAws
--- PASS: TestSystemGetSnowflakePlatformInfoGetStructuredConfigAws (0.00s)
=== RUN   TestSystemGetSnowflakePlatformInfoGetStructuredConfigAzure
--- PASS: TestSystemGetSnowflakePlatformInfoGetStructuredConfigAzure (0.00s)
=== RUN   TestTableCreate
{tag test_db test_schema value}
{tag2 test_db test_schema value2}
--- PASS: TestTableCreate (0.00s)
=== RUN   TestTableCreateIdentity
--- PASS: TestTableCreateIdentity (0.00s)
=== RUN   TestTableChangeComment
--- PASS: TestTableChangeComment (0.00s)
=== RUN   TestTableRemoveComment
--- PASS: TestTableRemoveComment (0.00s)
=== RUN   TestTableAddColumn
--- PASS: TestTableAddColumn (0.00s)
=== RUN   TestTableAddColumnWithComment
--- PASS: TestTableAddColumnWithComment (0.00s)
=== RUN   TestTableAddColumnWithDefault
--- PASS: TestTableAddColumnWithDefault (0.00s)
=== RUN   TestTableAddColumnWithIdentity
--- PASS: TestTableAddColumnWithIdentity (0.00s)
=== RUN   TestTableDropColumn
--- PASS: TestTableDropColumn (0.00s)
=== RUN   TestTableChangeColumnType
--- PASS: TestTableChangeColumnType (0.00s)
=== RUN   TestTableChangeColumnComment
--- PASS: TestTableChangeColumnComment (0.00s)
=== RUN   TestTableDropColumnDefault
--- PASS: TestTableDropColumnDefault (0.00s)
=== RUN   TestTableChangeClusterBy
--- PASS: TestTableChangeClusterBy (0.00s)
=== RUN   TestTableChangeDataRetention
--- PASS: TestTableChangeDataRetention (0.00s)
=== RUN   TestTableChangeChangeTracking
--- PASS: TestTableChangeChangeTracking (0.00s)
=== RUN   TestTableDropClusterBy
--- PASS: TestTableDropClusterBy (0.00s)
=== RUN   TestTableDrop
--- PASS: TestTableDrop (0.00s)
=== RUN   TestTableShow
--- PASS: TestTableShow (0.00s)
=== RUN   TestTableShowPrimaryKeys
--- PASS: TestTableShowPrimaryKeys (0.00s)
=== RUN   TestTableDropPrimaryKeys
--- PASS: TestTableDropPrimaryKeys (0.00s)
=== RUN   TestTableChangePrimaryKeysWithConstraintName
--- PASS: TestTableChangePrimaryKeysWithConstraintName (0.00s)
=== RUN   TestTableChangePrimaryKeysWithoutConstraintName
--- PASS: TestTableChangePrimaryKeysWithoutConstraintName (0.00s)
=== RUN   TestTableAddTag
--- PASS: TestTableAddTag (0.00s)
=== RUN   TestTableChangeTag
--- PASS: TestTableChangeTag (0.00s)
=== RUN   TestTableUnsetTag
--- PASS: TestTableUnsetTag (0.00s)
=== RUN   TestTableRename
--- PASS: TestTableRename (0.00s)
=== RUN   TestTagCreate
--- PASS: TestTagCreate (0.00s)
=== RUN   TestTagRename
--- PASS: TestTagRename (0.00s)
=== RUN   TestTagChangeComment
--- PASS: TestTagChangeComment (0.00s)
=== RUN   TestTagRemoveComment
--- PASS: TestTagRemoveComment (0.00s)
=== RUN   TestTagDrop
--- PASS: TestTagDrop (0.00s)
=== RUN   TestTagUndrop
--- PASS: TestTagUndrop (0.00s)
=== RUN   TestTagShow
--- PASS: TestTagShow (0.00s)
=== RUN   TestTaskCreate
--- PASS: TestTaskCreate (0.00s)
=== RUN   TestChangeWarehouse
--- PASS: TestChangeWarehouse (0.00s)
=== RUN   TestSwitchWarehouseToManaged
--- PASS: TestSwitchWarehouseToManaged (0.00s)
=== RUN   TestSwitchManagedWithInitialSize
--- PASS: TestSwitchManagedWithInitialSize (0.00s)
=== RUN   TestChangeSchedule
--- PASS: TestChangeSchedule (0.00s)
=== RUN   TestRemoveSchedule
--- PASS: TestRemoveSchedule (0.00s)
=== RUN   TestChangeTimeout
--- PASS: TestChangeTimeout (0.00s)
=== RUN   TestRemoveTimeout
--- PASS: TestRemoveTimeout (0.00s)
=== RUN   TestChangeComment
--- PASS: TestChangeComment (0.00s)
=== RUN   TestRemoveComment
--- PASS: TestRemoveComment (0.00s)
=== RUN   TestAddDependency
--- PASS: TestAddDependency (0.00s)
=== RUN   TestRemoveDependency
--- PASS: TestRemoveDependency (0.00s)
=== RUN   TestAddSessionParameters
--- PASS: TestAddSessionParameters (0.00s)
=== RUN   TestRemoveSessionParameters
--- PASS: TestRemoveSessionParameters (0.00s)
=== RUN   TestChangeCondition
--- PASS: TestChangeCondition (0.00s)
=== RUN   TestChangeSqlStatement
--- PASS: TestChangeSqlStatement (0.00s)
=== RUN   TestSuspend
--- PASS: TestSuspend (0.00s)
=== RUN   TestResume
--- PASS: TestResume (0.00s)
=== RUN   TestShowParameters
--- PASS: TestShowParameters (0.00s)
=== RUN   TestDrop
--- PASS: TestDrop (0.00s)
=== RUN   TestDescribe
--- PASS: TestDescribe (0.00s)
=== RUN   TestShow
--- PASS: TestShow (0.00s)
=== RUN   TestView
--- PASS: TestView (0.00s)
=== RUN   TestQualifiedName
--- PASS: TestQualifiedName (0.00s)
=== RUN   TestRename
--- PASS: TestRename (0.00s)
=== RUN   TestApiIntegration
--- PASS: TestApiIntegration (0.00s)
=== RUN   TestCurrentAccountSelect
--- PASS: TestCurrentAccountSelect (0.00s)
=== RUN   TestCurrentAccountRead
=== RUN   TestCurrentAccountRead/aws_oregon
2022/04/13 15:37:10 [DEBUG] query stmt SELECT CURRENT_ACCOUNT() AS "account", CURRENT_REGION() AS "region";
=== RUN   TestCurrentAccountRead/aws_n_virginia
2022/04/13 15:37:10 [DEBUG] query stmt SELECT CURRENT_ACCOUNT() AS "account", CURRENT_REGION() AS "region";
=== RUN   TestCurrentAccountRead/aws_canada_central
2022/04/13 15:37:10 [DEBUG] query stmt SELECT CURRENT_ACCOUNT() AS "account", CURRENT_REGION() AS "region";
=== RUN   TestCurrentAccountRead/gcp_canada_central
2022/04/13 15:37:10 [DEBUG] query stmt SELECT CURRENT_ACCOUNT() AS "account", CURRENT_REGION() AS "region";
=== RUN   TestCurrentAccountRead/azure_washington
2022/04/13 15:37:10 [DEBUG] query stmt SELECT CURRENT_ACCOUNT() AS "account", CURRENT_REGION() AS "region";
--- PASS: TestCurrentAccountRead (0.00s)
    --- PASS: TestCurrentAccountRead/aws_oregon (0.00s)
    --- PASS: TestCurrentAccountRead/aws_n_virginia (0.00s)
    --- PASS: TestCurrentAccountRead/aws_canada_central (0.00s)
    --- PASS: TestCurrentAccountRead/gcp_canada_central (0.00s)
    --- PASS: TestCurrentAccountRead/azure_washington (0.00s)
=== RUN   TestDatabase
--- PASS: TestDatabase (0.00s)
=== RUN   TestDatabaseCreateFromShare
--- PASS: TestDatabaseCreateFromShare (0.00s)
=== RUN   TestDatabaseCreateFromDatabase
--- PASS: TestDatabaseCreateFromDatabase (0.00s)
=== RUN   TestDatabaseCreateFromReplica
--- PASS: TestDatabaseCreateFromReplica (0.00s)
=== RUN   TestListDatabases
--- PASS: TestListDatabases (0.00s)
=== RUN   TestEscapeString
--- PASS: TestEscapeString (0.00s)
=== RUN   TestEscapeSnowflakeString
--- PASS: TestEscapeSnowflakeString (0.00s)
=== RUN   TestUnescapeSnowflakeString
--- PASS: TestUnescapeSnowflakeString (0.00s)
=== RUN   TestAddressEscape
=== RUN   TestAddressEscape/single_no_escape
=== RUN   TestAddressEscape/multiple_no_escape
=== RUN   TestAddressEscape/single_escape
=== RUN   TestAddressEscape/multiple_escape
=== RUN   TestAddressEscape/mixed_escape
--- PASS: TestAddressEscape (0.00s)
    --- PASS: TestAddressEscape/single_no_escape (0.00s)
    --- PASS: TestAddressEscape/multiple_no_escape (0.00s)
    --- PASS: TestAddressEscape/single_escape (0.00s)
    --- PASS: TestAddressEscape/multiple_escape (0.00s)
    --- PASS: TestAddressEscape/mixed_escape (0.00s)
=== RUN   TestExternalOauthIntegration
--- PASS: TestExternalOauthIntegration (0.00s)
=== RUN   TestFutureSchemaGrant
--- PASS: TestFutureSchemaGrant (0.00s)
=== RUN   TestFutureTableGrant
--- PASS: TestFutureTableGrant (0.00s)
=== RUN   TestFutureMaterializedViewGrant
--- PASS: TestFutureMaterializedViewGrant (0.00s)
=== RUN   TestFutureViewGrant
--- PASS: TestFutureViewGrant (0.00s)
=== RUN   TestFutureStageGrant
--- PASS: TestFutureStageGrant (0.00s)
=== RUN   TestShowFutureGrantsInSchema
--- PASS: TestShowFutureGrantsInSchema (0.00s)
=== RUN   TestFutureExternalTableGrant
--- PASS: TestFutureExternalTableGrant (0.00s)
=== RUN   TestFutureFileFormatGrant
--- PASS: TestFutureFileFormatGrant (0.00s)
=== RUN   TestDatabaseGrant
--- PASS: TestDatabaseGrant (0.00s)
=== RUN   TestSchemaGrant
--- PASS: TestSchemaGrant (0.00s)
=== RUN   TestViewGrant
--- PASS: TestViewGrant (0.00s)
=== RUN   TestMaterializedViewGrant
--- PASS: TestMaterializedViewGrant (0.00s)
=== RUN   TestExternalTableGrant
--- PASS: TestExternalTableGrant (0.00s)
=== RUN   TestFileFormatGrant
--- PASS: TestFileFormatGrant (0.00s)
=== RUN   TestFunctionGrant
--- PASS: TestFunctionGrant (0.00s)
=== RUN   TestProcedureGrant
--- PASS: TestProcedureGrant (0.00s)
=== RUN   TestWarehouseGrant
--- PASS: TestWarehouseGrant (0.00s)
=== RUN   TestAccountGrant
--- PASS: TestAccountGrant (0.00s)
=== RUN   TestIntegrationGrant
--- PASS: TestIntegrationGrant (0.00s)
=== RUN   TestResourceMonitorGrant
--- PASS: TestResourceMonitorGrant (0.00s)
=== RUN   TestMaskingPolicyGrant
--- PASS: TestMaskingPolicyGrant (0.00s)
=== RUN   TestShowGrantsOf
--- PASS: TestShowGrantsOf (0.00s)
=== RUN   TestManagedAccount
--- PASS: TestManagedAccount (0.00s)
=== RUN   TestMaskingPolicyCreate
--- PASS: TestMaskingPolicyCreate (0.00s)
=== RUN   TestMaskingPolicyDescribe
--- PASS: TestMaskingPolicyDescribe (0.00s)
=== RUN   TestMaskingPolicyDrop
--- PASS: TestMaskingPolicyDrop (0.00s)
=== RUN   TestMaskingPolicyChangeComment
--- PASS: TestMaskingPolicyChangeComment (0.00s)
=== RUN   TestMaskingPolicyRemoveComment
--- PASS: TestMaskingPolicyRemoveComment (0.00s)
=== RUN   TestMaskingChangeMaskingExpression
--- PASS: TestMaskingChangeMaskingExpression (0.00s)
=== RUN   TestNetworkPolicyCreate
--- PASS: TestNetworkPolicyCreate (0.00s)
=== RUN   TestNetworkPolicyCreateNoOptionals
--- PASS: TestNetworkPolicyCreateNoOptionals (0.00s)
=== RUN   TestNetworkPolicyDescribe
--- PASS: TestNetworkPolicyDescribe (0.00s)
=== RUN   TestNetworkPolicyDrop
--- PASS: TestNetworkPolicyDrop (0.00s)
=== RUN   TestNetworkPolicyChangeComment
--- PASS: TestNetworkPolicyChangeComment (0.00s)
=== RUN   TestNetworkPolicyRemoveComment
--- PASS: TestNetworkPolicyRemoveComment (0.00s)
=== RUN   TestNetworkPolicyChangeIpList
--- PASS: TestNetworkPolicyChangeIpList (0.00s)
=== RUN   TestNetworkPolicySetOnAccount
--- PASS: TestNetworkPolicySetOnAccount (0.00s)
=== RUN   TestNetworkPolicyUnsetOnAccount
--- PASS: TestNetworkPolicyUnsetOnAccount (0.00s)
=== RUN   TestNetworkPolicySetOnUser
--- PASS: TestNetworkPolicySetOnUser (0.00s)
=== RUN   TestNetworkPolicyUnsetOnUser
--- PASS: TestNetworkPolicyUnsetOnUser (0.00s)
=== RUN   TestNotificationIntegration_Azure
--- PASS: TestNotificationIntegration_Azure (0.00s)
=== RUN   TestNotificationIntegration_AWS
--- PASS: TestNotificationIntegration_AWS (0.00s)
=== RUN   TestNotificationIntegration_AWS_SNS
--- PASS: TestNotificationIntegration_AWS_SNS (0.00s)
=== RUN   TestOAuthIntegration
--- PASS: TestOAuthIntegration (0.00s)
=== RUN   TestResourceMonitor
--- PASS: TestResourceMonitor (0.00s)
=== RUN   TestResourceMonitorSetOnAccount
--- PASS: TestResourceMonitorSetOnAccount (0.00s)
=== RUN   TestResourceMonitorSetOnWarehouse
--- PASS: TestResourceMonitorSetOnWarehouse (0.00s)
=== RUN   TestRoleGrant
--- PASS: TestRoleGrant (0.00s)
=== RUN   TestRoleOwnershipGrantQuery
--- PASS: TestRoleOwnershipGrantQuery (0.00s)
=== RUN   TestRowAccessPolicyCreate
--- PASS: TestRowAccessPolicyCreate (0.00s)
=== RUN   TestRowAccessPolicyDescribe
--- PASS: TestRowAccessPolicyDescribe (0.00s)
=== RUN   TestRowAccessPolicyDrop
--- PASS: TestRowAccessPolicyDrop (0.00s)
=== RUN   TestRowAccessPolicyChangeComment
--- PASS: TestRowAccessPolicyChangeComment (0.00s)
=== RUN   TestRowAccessPolicyRemoveComment
--- PASS: TestRowAccessPolicyRemoveComment (0.00s)
=== RUN   TestRowAccessChangeRowAccessExpression
--- PASS: TestRowAccessChangeRowAccessExpression (0.00s)
=== RUN   TestSamlIntegration
--- PASS: TestSamlIntegration (0.00s)
=== RUN   TestScimIntegration
--- PASS: TestScimIntegration (0.00s)
=== RUN   TestShare
--- PASS: TestShare (0.00s)
=== RUN   TestStorageIntegration
--- PASS: TestStorageIntegration (0.00s)
=== RUN   TestUserOwnershipGrantQuery
--- PASS: TestUserOwnershipGrantQuery (0.00s)
=== RUN   TestUser
--- PASS: TestUser (0.00s)
=== RUN   TestValidateIdentifier
=== RUN   TestValidateIdentifier/word
=== RUN   TestValidateIdentifier/_1
=== RUN   TestValidateIdentifier/Aword
=== RUN   TestValidateIdentifier/azAZ09_$
=== RUN   TestValidateIdentifier/-30-Ab-
=== RUN   TestValidateIdentifier/invalidcharacter!
=== RUN   TestValidateIdentifier/1startwithnumber
=== RUN   TestValidateIdentifier/$startwithdollar
--- PASS: TestValidateIdentifier (0.00s)
    --- PASS: TestValidateIdentifier/word (0.00s)
    --- PASS: TestValidateIdentifier/_1 (0.00s)
    --- PASS: TestValidateIdentifier/Aword (0.00s)
    --- PASS: TestValidateIdentifier/azAZ09_$ (0.00s)
    --- PASS: TestValidateIdentifier/-30-Ab- (0.00s)
    --- PASS: TestValidateIdentifier/invalidcharacter! (0.00s)
    --- PASS: TestValidateIdentifier/1startwithnumber (0.00s)
    --- PASS: TestValidateIdentifier/$startwithdollar (0.00s)
PASS
coverage: 59.2% of statements
ok  	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake	0.189s	coverage: 59.2% of statements
?   	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers	[no test files]
=== RUN   TestValidatePassword
--- PASS: TestValidatePassword (0.00s)
=== RUN   TestValidatePrivilege
--- PASS: TestValidatePrivilege (0.00s)
PASS
coverage: 93.1% of statements
ok  	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/validation	0.311s	coverage: 93.1% of statements
?   	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/version	[no test files]
```

</details>

## References
<!-- issues documentation links, etc  -->

* [Snowflake documentation for Schema rename](https://docs.snowflake.com/en/sql-reference/sql/alter-schema.html#syntax)